### PR TITLE
Tighten admin navigation visibility

### DIFF
--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -360,8 +360,8 @@ export default function AdminPage() {
         <div className="border-b border-gray-200 px-6 py-5">
           <h2 className="text-xl font-semibold text-[#1B3A5C]">Access Control</h2>
           <p className="mt-1 text-sm text-gray-500">
-            Admin access now lives in Firestore, not GitHub. Owners can add or remove
-            who is allowed to sync data and use protected admin actions.
+            Owners can add or remove who is allowed to sync data and use protected admin
+            actions.
           </p>
         </div>
         <div className="grid gap-6 px-6 py-5 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">

--- a/app/src/components/layout/Navigation.tsx
+++ b/app/src/components/layout/Navigation.tsx
@@ -1,22 +1,90 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { onAuthStateChanged, type User } from "firebase/auth";
 import AuthButton from "./AuthButton";
 import RefreshButton from "./RefreshButton";
-import { hasFirebaseWebConfig } from "@/lib/firebase";
+import { getClientAuth, hasFirebaseWebConfig } from "@/lib/firebase";
+import { getCurrentAdminAccess } from "@/lib/firestore/admin-queries";
 
-const tabs = [
+const baseTabs = [
   { href: "/", label: "Overview" },
   { href: "/itineraries", label: "Itineraries" },
   { href: "/ships", label: "Ships" },
   { href: "/reviews", label: "Reviews" },
-  { href: "/admin", label: "Admin" },
 ];
 
 export default function Navigation() {
   const pathname = usePathname();
   const showAuthControls = hasFirebaseWebConfig();
+  const [user, setUser] = useState<User | null>(null);
+  const [showAdminTab, setShowAdminTab] = useState(false);
+  const [checkingAdminAccess, setCheckingAdminAccess] = useState(showAuthControls);
+
+  useEffect(() => {
+    if (!showAuthControls) {
+      setUser(null);
+      setShowAdminTab(false);
+      setCheckingAdminAccess(false);
+      return;
+    }
+
+    try {
+      const auth = getClientAuth();
+      return onAuthStateChanged(auth, (nextUser) => {
+        setUser(nextUser);
+        if (!nextUser) {
+          setShowAdminTab(false);
+          setCheckingAdminAccess(false);
+        } else {
+          setCheckingAdminAccess(true);
+        }
+      });
+    } catch {
+      setUser(null);
+      setShowAdminTab(false);
+      setCheckingAdminAccess(false);
+      return;
+    }
+  }, [showAuthControls]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!showAuthControls || !user) {
+      setShowAdminTab(false);
+      return;
+    }
+
+    setCheckingAdminAccess(true);
+
+    getCurrentAdminAccess()
+      .then((access) => {
+        if (cancelled) return;
+        setShowAdminTab(
+          Boolean(access.permissions.manageMappings || access.permissions.manageUsers)
+        );
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setShowAdminTab(false);
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setCheckingAdminAccess(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [showAuthControls, user]);
+
+  const tabs = [...baseTabs];
+  if (showAdminTab || (pathname.startsWith("/admin") && checkingAdminAccess)) {
+    tabs.push({ href: "/admin", label: "Admin" });
+  }
 
   return (
     <nav className="border-b border-gray-200 bg-white shadow-sm dark:bg-[#111927] dark:border-[#1e2d44]">

--- a/app/src/lib/firestore/admin-queries.ts
+++ b/app/src/lib/firestore/admin-queries.ts
@@ -16,6 +16,12 @@ export interface ItineraryMapping {
 
 export type AdminRole = "owner" | "admin" | "sync";
 
+export type AdminAccessPermission =
+  | "sync"
+  | "batchClassify"
+  | "manageMappings"
+  | "manageUsers";
+
 export interface AdminUserAccess {
   email: string;
   role: AdminRole;
@@ -24,6 +30,14 @@ export interface AdminUserAccess {
   updatedAt?: string;
   createdBy?: string | null;
   updatedBy?: string | null;
+}
+
+export interface CurrentAdminAccess {
+  email: string | null;
+  role: AdminRole | null;
+  active: boolean;
+  allowed: boolean;
+  permissions: Record<AdminAccessPermission, boolean>;
 }
 
 export async function getItineraryMappings(brand: string): Promise<ItineraryMapping[]> {
@@ -71,6 +85,13 @@ export async function listAdminUsers(): Promise<AdminUserAccess[]> {
     action: "list",
   });
   return response.users ?? [];
+}
+
+export async function getCurrentAdminAccess(): Promise<CurrentAdminAccess> {
+  const response = await postFunction<{ access: CurrentAdminAccess }>("adminUsers", {
+    action: "current",
+  });
+  return response.access;
 }
 
 export async function upsertAdminUser(

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -110,6 +110,21 @@ function ensurePost(req: any, res: any): boolean {
   return true;
 }
 
+function getEffectivePermissions(
+  allowedByLegacyEmailList: boolean,
+  adminUser: Awaited<ReturnType<typeof getAdminUserByEmail>>
+) {
+  return {
+    sync: allowedByLegacyEmailList || hasPermission(adminUser, "sync"),
+    batchClassify:
+      allowedByLegacyEmailList || hasPermission(adminUser, "batchClassify"),
+    manageMappings:
+      allowedByLegacyEmailList || hasPermission(adminUser, "manageMappings"),
+    manageUsers:
+      allowedByLegacyEmailList || hasPermission(adminUser, "manageUsers"),
+  };
+}
+
 // Scheduled sync every 6 hours in UTC - fetch reviews + compute summaries (no classification)
 export const dailySync = onSchedule(
   { schedule: "0 */6 * * *", timeZone: "UTC", timeoutSeconds: 540, memory: "1GiB" },
@@ -231,10 +246,46 @@ export const adminUsers = onRequest(
   { timeoutSeconds: 120, memory: "512MiB", invoker: "public", cors: true },
   async (req, res) => {
     if (!ensurePost(req, res)) return;
+    const action = req.body?.action ?? "list";
+
+    if (action === "current") {
+      const authHeader = req.headers.authorization;
+      if (!authHeader || !authHeader.startsWith("Bearer ")) {
+        res.status(401).json({ error: "Missing bearer token." });
+        return;
+      }
+
+      const token = authHeader.slice("Bearer ".length).trim();
+
+      try {
+        const decoded = await getAuth().verifyIdToken(token);
+        const email = decoded.email?.toLowerCase() ?? null;
+        const allowedEmails = parseAllowedEmails();
+        const adminUser = await getAdminUserByEmail(email);
+        const allowedByLegacyEmailList =
+          allowedEmails.size > 0 && Boolean(email && allowedEmails.has(email));
+        const permissions = getEffectivePermissions(
+          allowedByLegacyEmailList,
+          adminUser
+        );
+
+        res.json({
+          access: {
+            email,
+            role: adminUser?.role ?? (allowedByLegacyEmailList ? "admin" : null),
+            active: adminUser?.active ?? allowedByLegacyEmailList,
+            allowed: Object.values(permissions).some(Boolean),
+            permissions,
+          },
+        });
+      } catch {
+        res.status(401).json({ error: "Invalid bearer token." });
+      }
+      return;
+    }
+
     const caller = await authorizeRequest(req, res, "manageUsers");
     if (!caller) return;
-
-    const action = req.body?.action ?? "list";
 
     if (action === "list") {
       const users = await listAdminUsers();
@@ -297,6 +348,8 @@ export const adminUsers = onRequest(
       return;
     }
 
-    res.status(400).json({ error: "Invalid action. Use 'list', 'upsert', or 'remove'." });
+    res
+      .status(400)
+      .json({ error: "Invalid action. Use 'current', 'list', 'upsert', or 'remove'." });
   }
 );


### PR DESCRIPTION
## Summary
- remove the old Firestore/GitHub bootstrap sentence from the admin access header
- hide the Admin tab unless the signed-in user has admin-page access
- add a lightweight current-access function so the nav can check permissions safely

## Testing
- npm run build (functions)
- npm run build (app)