### PR TITLE
Align nav dark mode with app theme

### DIFF
--- a/app/public/theme-init.js
+++ b/app/public/theme-init.js
@@ -4,11 +4,10 @@
     var prefersDark =
       window.matchMedia &&
       window.matchMedia("(prefers-color-scheme: dark)").matches;
+    var shouldUseDark = theme === "dark" || (!theme && prefersDark);
 
-    if (theme === "dark" || (!theme && prefersDark)) {
-      document.documentElement.classList.add("dark");
-      document.documentElement.style.colorScheme = "dark";
-    }
+    document.documentElement.classList.toggle("dark", shouldUseDark);
+    document.documentElement.style.colorScheme = shouldUseDark ? "dark" : "light";
   } catch (error) {
     // Ignore client-side storage/theme bootstrap failures.
   }

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@custom-variant dark (&:where(.dark, .dark *));
 
 :root {
   --background: #f8f9fa;

--- a/app/src/contexts/ThemeContext.tsx
+++ b/app/src/contexts/ThemeContext.tsx
@@ -39,8 +39,10 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     const root = document.documentElement;
     if (theme === "dark") {
       root.classList.add("dark");
+      root.style.colorScheme = "dark";
     } else {
       root.classList.remove("dark");
+      root.style.colorScheme = "light";
     }
     localStorage.setItem("theme", theme);
   }, [theme, mounted]);


### PR DESCRIPTION
## Summary
- make Tailwind dark: utilities follow the app's .dark class instead of browser preference
- keep color-scheme synced with the selected app theme
- ensure the nav and header controls respect the same light/dark toggle as the rest of the dashboard

## Testing
- npm run build (app)