### PR TITLE
Automate classification after sync

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -127,14 +127,108 @@ function getEffectivePermissions(
   };
 }
 
-// Scheduled sync every 6 hours in UTC - fetch reviews + compute summaries (no classification)
+const ACTIVE_CLASSIFICATION_STATUSES = new Set(["processing", "in_progress", "canceling"]);
+
+interface ClassificationAutomationResult {
+  processed: number;
+  polledStatus: string | null;
+  submittedBatchId: string | null;
+  submittedCount: number;
+  recomputedSummaries: boolean;
+  skippedReason: string | null;
+  error: string | null;
+}
+
+async function runClassificationAutomation(): Promise<ClassificationAutomationResult> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    return {
+      processed: 0,
+      polledStatus: null,
+      submittedBatchId: null,
+      submittedCount: 0,
+      recomputedSummaries: false,
+      skippedReason: "ANTHROPIC_API_KEY not set",
+      error: null,
+    };
+  }
+
+  try {
+    const db = getFirestore();
+    const batchMeta = (await db.collection("sync_meta").doc("batch_classify").get()).data();
+    const currentBatchId = typeof batchMeta?.batchId === "string" ? batchMeta.batchId : null;
+    const currentStatus = typeof batchMeta?.status === "string" ? batchMeta.status : null;
+
+    let processed = 0;
+    let polledStatus = currentStatus;
+    let recomputedSummaries = false;
+
+    if (
+      currentBatchId &&
+      (!currentStatus || ACTIVE_CLASSIFICATION_STATUSES.has(currentStatus))
+    ) {
+      const batchResult = await processBatchResults(currentBatchId);
+      processed = batchResult.processed;
+      polledStatus = batchResult.status;
+
+      if (batchResult.status === "complete" && batchResult.processed > 0) {
+        await computeSummaries("uniworld");
+        await computeSummaries("luxury-gold");
+        recomputedSummaries = true;
+      }
+
+      if (
+        batchResult.status !== "complete" &&
+        batchResult.status !== "ended_no_results" &&
+        batchResult.status !== "no_batch"
+      ) {
+        return {
+          processed,
+          polledStatus,
+          submittedBatchId: null,
+          submittedCount: 0,
+          recomputedSummaries,
+          skippedReason: "Existing classification batch still in progress",
+          error: null,
+        };
+      }
+    }
+
+    const submission = await submitClassificationBatch();
+    return {
+      processed,
+      polledStatus,
+      submittedBatchId: submission.batchId,
+      submittedCount: submission.totalUnclassified,
+      recomputedSummaries,
+      skippedReason: submission.totalUnclassified === 0 ? "No unclassified reviews found" : null,
+      error: submission.error,
+    };
+  } catch (error) {
+    console.error("Automatic classification cycle failed:", error);
+    return {
+      processed: 0,
+      polledStatus: null,
+      submittedBatchId: null,
+      submittedCount: 0,
+      recomputedSummaries: false,
+      skippedReason: null,
+      error: String(error),
+    };
+  }
+}
+
+// Scheduled sync every 2 hours in UTC - fetch reviews, recompute summaries, and advance theme classification.
 export const dailySync = onSchedule(
-  { schedule: "0 */6 * * *", timeZone: "UTC", timeoutSeconds: 540, memory: "1GiB" },
+  { schedule: "0 */2 * * *", timeZone: "UTC", timeoutSeconds: 540, memory: "1GiB" },
   async () => {
     const results = await syncAll(false);
     await computeSummaries("uniworld");
     await computeSummaries("luxury-gold");
-    console.log("Scheduled sync complete:", JSON.stringify(results));
+    const classification = await runClassificationAutomation();
+    console.log(
+      "Scheduled sync complete:",
+      JSON.stringify({ syncResults: results, classification })
+    );
   }
 );
 
@@ -157,8 +251,9 @@ export const manualSync = onRequest(
     const results = await syncAll(fullSync);
     await computeSummaries("uniworld");
     await computeSummaries("luxury-gold");
+    const classification = await runClassificationAutomation();
     console.log(`manualSync triggered by ${caller.source}:${caller.email ?? caller.uid}`);
-    res.json({ success: true, results });
+    res.json({ success: true, results, classification });
   }
 );
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -134,7 +134,7 @@ interface ClassificationAutomationResult {
   polledStatus: string | null;
   submittedBatchId: string | null;
   submittedCount: number;
-  recomputedSummaries: boolean;
+  themesUpdated: boolean;
   skippedReason: string | null;
   error: string | null;
 }
@@ -146,7 +146,7 @@ async function runClassificationAutomation(): Promise<ClassificationAutomationRe
       polledStatus: null,
       submittedBatchId: null,
       submittedCount: 0,
-      recomputedSummaries: false,
+      themesUpdated: false,
       skippedReason: "ANTHROPIC_API_KEY not set",
       error: null,
     };
@@ -160,7 +160,7 @@ async function runClassificationAutomation(): Promise<ClassificationAutomationRe
 
     let processed = 0;
     let polledStatus = currentStatus;
-    let recomputedSummaries = false;
+    let themesUpdated = false;
 
     if (
       currentBatchId &&
@@ -171,9 +171,7 @@ async function runClassificationAutomation(): Promise<ClassificationAutomationRe
       polledStatus = batchResult.status;
 
       if (batchResult.status === "complete" && batchResult.processed > 0) {
-        await computeSummaries("uniworld");
-        await computeSummaries("luxury-gold");
-        recomputedSummaries = true;
+        themesUpdated = true;
       }
 
       if (
@@ -186,7 +184,7 @@ async function runClassificationAutomation(): Promise<ClassificationAutomationRe
           polledStatus,
           submittedBatchId: null,
           submittedCount: 0,
-          recomputedSummaries,
+          themesUpdated,
           skippedReason: "Existing classification batch still in progress",
           error: null,
         };
@@ -199,7 +197,7 @@ async function runClassificationAutomation(): Promise<ClassificationAutomationRe
       polledStatus,
       submittedBatchId: submission.batchId,
       submittedCount: submission.totalUnclassified,
-      recomputedSummaries,
+      themesUpdated,
       skippedReason: submission.totalUnclassified === 0 ? "No unclassified reviews found" : null,
       error: submission.error,
     };
@@ -210,7 +208,7 @@ async function runClassificationAutomation(): Promise<ClassificationAutomationRe
       polledStatus: null,
       submittedBatchId: null,
       submittedCount: 0,
-      recomputedSummaries: false,
+      themesUpdated: false,
       skippedReason: null,
       error: String(error),
     };
@@ -222,9 +220,9 @@ export const dailySync = onSchedule(
   { schedule: "0 */2 * * *", timeZone: "UTC", timeoutSeconds: 540, memory: "1GiB" },
   async () => {
     const results = await syncAll(false);
+    const classification = await runClassificationAutomation();
     await computeSummaries("uniworld");
     await computeSummaries("luxury-gold");
-    const classification = await runClassificationAutomation();
     console.log(
       "Scheduled sync complete:",
       JSON.stringify({ syncResults: results, classification })
@@ -249,9 +247,9 @@ export const manualSync = onRequest(
 
     const fullSync = req.body?.fullSync === true;
     const results = await syncAll(fullSync);
+    const classification = await runClassificationAutomation();
     await computeSummaries("uniworld");
     await computeSummaries("luxury-gold");
-    const classification = await runClassificationAutomation();
     console.log(`manualSync triggered by ${caller.source}:${caller.email ?? caller.uid}`);
     res.json({ success: true, results, classification });
   }

--- a/functions/src/sync/batch-classify.ts
+++ b/functions/src/sync/batch-classify.ts
@@ -2,11 +2,14 @@ import { getFirestore } from "firebase-admin/firestore";
 import { POSITIVE_THEMES, NEGATIVE_THEMES, VALID_POSITIVE_NAMES, VALID_NEGATIVE_NAMES } from "@feefo/shared";
 
 const BATCH_SIZE = 10000; // Max requests per Anthropic batch
+const ACTIVE_BATCH_STATUSES = new Set(["processing", "in_progress", "canceling", "submitting"]);
+const SUBMISSION_LOCK_WINDOW_MS = 10 * 60 * 1000;
 
 interface BatchClassifyResult {
   totalUnclassified: number;
   batchId: string | null;
   error: string | null;
+  status: string;
 }
 
 /**
@@ -18,6 +21,53 @@ interface BatchClassifyResult {
  */
 export async function submitClassificationBatch(): Promise<BatchClassifyResult> {
   const db = getFirestore();
+  const batchMetaRef = db.collection("sync_meta").doc("batch_classify");
+  const lockToken = `lock-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  const lockExpiresAt = new Date(Date.now() + SUBMISSION_LOCK_WINDOW_MS).toISOString();
+
+  const reservation = await db.runTransaction(async (txn) => {
+    const meta = await txn.get(batchMetaRef);
+    const data = meta.data();
+    const currentStatus = typeof data?.status === "string" ? data.status : null;
+    const currentBatchId = typeof data?.batchId === "string" ? data.batchId : null;
+    const currentLockExpiresAt =
+      typeof data?.submissionLockExpiresAt === "string" ? data.submissionLockExpiresAt : null;
+    const activeSubmissionLock =
+      currentStatus === "submitting" &&
+      Boolean(currentLockExpiresAt && new Date(currentLockExpiresAt).getTime() > Date.now());
+    const activeBatch =
+      Boolean(currentBatchId) && Boolean(currentStatus && ACTIVE_BATCH_STATUSES.has(currentStatus));
+
+    if (activeSubmissionLock || activeBatch) {
+      return {
+        acquired: false,
+        batchId: currentBatchId,
+        status: currentStatus ?? (activeSubmissionLock ? "submitting" : "processing"),
+      };
+    }
+
+    txn.set(
+      batchMetaRef,
+      {
+        status: "submitting",
+        submissionLockToken: lockToken,
+        submissionLockExpiresAt: lockExpiresAt,
+        lastChecked: new Date().toISOString(),
+      },
+      { merge: true }
+    );
+
+    return { acquired: true, batchId: currentBatchId, status: "submitting" };
+  });
+
+  if (!reservation.acquired) {
+    return {
+      totalUnclassified: 0,
+      batchId: reservation.batchId ?? null,
+      error: null,
+      status: reservation.status,
+    };
+  }
 
   // 1. Find all reviews with comments that haven't been classified
   const unclassifiedQuery = db.collection("reviews")
@@ -28,7 +78,16 @@ export async function submitClassificationBatch(): Promise<BatchClassifyResult> 
   const snapshot = await unclassifiedQuery.get();
 
   if (snapshot.empty) {
-    return { totalUnclassified: 0, batchId: null, error: null };
+    await batchMetaRef.set(
+      {
+        status: "idle",
+        submissionLockToken: null,
+        submissionLockExpiresAt: null,
+        lastChecked: new Date().toISOString(),
+      },
+      { merge: true }
+    );
+    return { totalUnclassified: 0, batchId: null, error: null, status: "idle" };
   }
 
   console.log(`Found ${snapshot.size} unclassified reviews`);
@@ -91,18 +150,38 @@ Return empty arrays if no themes match. Only use themes from the lists above.`,
     console.log(`Batch submitted: ${batch.id} (${batch.processing_status}), ${requests.length} requests`);
 
     // Store batch ID in Firestore for polling
-    await db.collection("sync_meta").doc("batch_classify").set({
-      batchId: batch.id,
-      submittedAt: new Date().toISOString(),
-      totalRequests: requests.length,
-      status: "processing",
-    });
+    await batchMetaRef.set(
+      {
+        batchId: batch.id,
+        submittedAt: new Date().toISOString(),
+        totalRequests: requests.length,
+        status: batch.processing_status,
+        submissionLockToken: null,
+        submissionLockExpiresAt: null,
+      },
+      { merge: true }
+    );
 
-    return { totalUnclassified: snapshot.size, batchId: batch.id, error: null };
+    return {
+      totalUnclassified: snapshot.size,
+      batchId: batch.id,
+      error: null,
+      status: batch.processing_status,
+    };
   } catch (err) {
     const errorMsg = String(err);
     console.error(`Batch submission failed: ${errorMsg}`);
-    return { totalUnclassified: snapshot.size, batchId: null, error: errorMsg };
+    await batchMetaRef.set(
+      {
+        status: "error",
+        errorMessage: errorMsg.slice(0, 5000),
+        submissionLockToken: null,
+        submissionLockExpiresAt: null,
+        lastChecked: new Date().toISOString(),
+      },
+      { merge: true }
+    );
+    return { totalUnclassified: snapshot.size, batchId: null, error: errorMsg, status: "error" };
   }
 }
 


### PR DESCRIPTION
## Summary
- automate Anthropic batch classification after scheduled and manual syncs
- poll any in-flight batch before submitting a new one to avoid duplicate work
- recompute summaries after classification completes and align the function cron with the live 2-hour schedule

## Testing
- npm run build (functions)