### PR TITLE
Add operational logs to admin tooling

### DIFF
--- a/app/src/app/admin/logs/page.tsx
+++ b/app/src/app/admin/logs/page.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { onAuthStateChanged, type User } from "firebase/auth";
+import { useRouter } from "next/navigation";
+import { getClientAuth } from "@/lib/firebase";
+import {
+  getCurrentAdminAccess,
+  listOperationalLogs,
+  type CurrentAdminAccess,
+  type OperationLogEntry,
+  type OperationLogType,
+} from "@/lib/firestore/admin-queries";
+import OperationLogsTable from "@/components/admin/OperationLogsTable";
+
+type RangeFilter = "24h" | "7d" | "30d" | "all";
+type TypeFilter = "all" | OperationLogType;
+
+const RANGE_TO_HOURS: Record<Exclude<RangeFilter, "all">, number> = {
+  "24h": 24,
+  "7d": 24 * 7,
+  "30d": 24 * 30,
+};
+
+export default function AdminLogsPage() {
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [authResolved, setAuthResolved] = useState(false);
+  const [currentAccess, setCurrentAccess] = useState<CurrentAdminAccess | null>(null);
+  const [checkingAccess, setCheckingAccess] = useState(true);
+  const [logs, setLogs] = useState<OperationLogEntry[]>([]);
+  const [loadingLogs, setLoadingLogs] = useState(true);
+  const [range, setRange] = useState<RangeFilter>("all");
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>("all");
+  const [toast, setToast] = useState<string | null>(null);
+
+  const canViewLogs = Boolean(currentAccess?.permissions.sync);
+
+  const loadLogs = useCallback(async (nextRange: RangeFilter) => {
+    setLoadingLogs(true);
+    try {
+      const hours = nextRange === "all" ? null : RANGE_TO_HOURS[nextRange];
+      const data = await listOperationalLogs(hours);
+      setLogs(data);
+    } catch (error) {
+      setToast(error instanceof Error ? error.message : "Failed to load logs");
+    }
+    setLoadingLogs(false);
+  }, []);
+
+  useEffect(() => {
+    try {
+      const auth = getClientAuth();
+      return onAuthStateChanged(auth, (nextUser) => {
+        setUser(nextUser);
+        setAuthResolved(true);
+      });
+    } catch {
+      setAuthResolved(true);
+      router.replace("/");
+      return;
+    }
+  }, [router]);
+
+  useEffect(() => {
+    if (!authResolved) {
+      return;
+    }
+
+    if (!user) {
+      setCurrentAccess(null);
+      setCheckingAccess(false);
+      router.replace("/");
+      return;
+    }
+
+    let cancelled = false;
+    setCheckingAccess(true);
+
+    getCurrentAdminAccess()
+      .then((access) => {
+        if (cancelled) return;
+        setCurrentAccess(access);
+        if (!access.permissions.sync) {
+          router.replace("/");
+        }
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setCurrentAccess(null);
+        router.replace("/");
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setCheckingAccess(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authResolved, router, user]);
+
+  useEffect(() => {
+    if (checkingAccess || !canViewLogs) {
+      return;
+    }
+    loadLogs(range);
+  }, [canViewLogs, checkingAccess, loadLogs, range]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const timeout = setTimeout(() => setToast(null), 4000);
+    return () => clearTimeout(timeout);
+  }, [toast]);
+
+  const filteredLogs = useMemo(() => {
+    if (typeFilter === "all") {
+      return logs;
+    }
+    return logs.filter((log) => log.type === typeFilter);
+  }, [logs, typeFilter]);
+
+  if (!authResolved || checkingAccess) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-[#1B3A5C]" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="mb-2 text-sm font-medium text-gray-500">
+            <Link href="/admin" className="hover:text-[#1B3A5C] hover:underline">
+              Admin
+            </Link>
+            <span className="mx-2 text-gray-300">/</span>
+            Logs
+          </div>
+          <h1 className="text-2xl font-semibold text-[#1B3A5C]">Operational Logs</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Review sync, classification, and summary activity.
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <select
+            value={range}
+            onChange={(event) => setRange(event.target.value as RangeFilter)}
+            className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm"
+          >
+            <option value="24h">Last 24 hours</option>
+            <option value="7d">Last 7 days</option>
+            <option value="30d">Last 30 days</option>
+            <option value="all">All logs</option>
+          </select>
+          <select
+            value={typeFilter}
+            onChange={(event) => setTypeFilter(event.target.value as TypeFilter)}
+            className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm"
+          >
+            <option value="all">All types</option>
+            <option value="sync">Sync</option>
+            <option value="classification">Classification</option>
+            <option value="summary">Summary</option>
+          </select>
+          <button
+            onClick={() => loadLogs(range)}
+            className="inline-flex items-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+          >
+            Refresh Logs
+          </button>
+        </div>
+      </div>
+
+      <OperationLogsTable
+        logs={filteredLogs}
+        loading={loadingLogs}
+        emptyMessage="No operational logs matched the current filter."
+      />
+
+      {toast ? (
+        <div className="fixed bottom-4 right-4 z-50 rounded-lg bg-gray-900 px-4 py-3 text-sm text-white shadow-lg">
+          {toast}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useCallback } from "react";
+import Link from "next/link";
 import { onAuthStateChanged, type User } from "firebase/auth";
 import { useRouter } from "next/navigation";
 import { useDashboard } from "@/contexts/DashboardContext";
@@ -10,6 +11,7 @@ import {
   getCurrentAdminAccess,
   listAdminUsers,
   listKnownUsers,
+  listOperationalLogs,
   removeAdminUser,
   getItineraryMappings,
   upsertAdminUser,
@@ -21,7 +23,9 @@ import {
   type AdminUserAccess,
   type ItineraryMapping,
   type KnownUser,
+  type OperationLogEntry,
 } from "@/lib/firestore/admin-queries";
+import OperationLogsTable from "@/components/admin/OperationLogsTable";
 
 type StatusFilter = "all" | "auto" | "manual" | "unchanged";
 type SortKey = "rawName" | "effectiveParentName" | "reviewCount" | "status";
@@ -76,6 +80,9 @@ export default function AdminPage() {
   const [accessEmail, setAccessEmail] = useState("");
   const [accessRole, setAccessRole] = useState<AdminRole>("sync");
   const [savingAccess, setSavingAccess] = useState(false);
+  const [operationLogs, setOperationLogs] = useState<OperationLogEntry[]>([]);
+  const [logsLoading, setLogsLoading] = useState(true);
+  const [logsExpanded, setLogsExpanded] = useState(true);
   const [mappings, setMappings] = useState<ItineraryMapping[]>([]);
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
@@ -94,6 +101,8 @@ export default function AdminPage() {
   const dateStart = dateRange.start.toISOString();
   const dateEnd = dateRange.end.toISOString();
   const canManageUsers = Boolean(currentAccess?.permissions.manageUsers);
+  const canManageMappings = Boolean(currentAccess?.permissions.manageMappings);
+  const canViewLogs = Boolean(currentAccess?.permissions.sync);
 
   const loadAdminAccess = useCallback(async () => {
     setAdminUsersLoading(true);
@@ -115,6 +124,17 @@ export default function AdminPage() {
       setToast(err instanceof Error ? err.message : "Failed to load signed-in users");
     }
     setKnownUsersLoading(false);
+  }, []);
+
+  const loadOperationLogs = useCallback(async () => {
+    setLogsLoading(true);
+    try {
+      const logs = await listOperationalLogs(24, 100);
+      setOperationLogs(logs);
+    } catch (err) {
+      setToast(err instanceof Error ? err.message : "Failed to load operational logs");
+    }
+    setLogsLoading(false);
   }, []);
 
   const loadMappings = useCallback(async () => {
@@ -189,7 +209,9 @@ export default function AdminPage() {
         if (cancelled) return;
         setCurrentAccess(access);
         const canUseAdminPage =
-          access.permissions.manageMappings || access.permissions.manageUsers;
+          access.permissions.sync ||
+          access.permissions.manageMappings ||
+          access.permissions.manageUsers;
         if (!canUseAdminPage) {
           router.replace("/");
         }
@@ -208,6 +230,20 @@ export default function AdminPage() {
       cancelled = true;
     };
   }, [authResolved, router, user]);
+
+  useEffect(() => {
+    if (checkingPageAccess || !currentAccess) {
+      return;
+    }
+
+    if (currentAccess.permissions.sync) {
+      loadOperationLogs();
+      return;
+    }
+
+    setOperationLogs([]);
+    setLogsLoading(false);
+  }, [checkingPageAccess, currentAccess, loadOperationLogs]);
 
   useEffect(() => {
     if (checkingPageAccess || !currentAccess) {
@@ -667,6 +703,50 @@ export default function AdminPage() {
       </div>
       ) : null}
 
+      {canViewLogs ? (
+        <div className="mb-8 rounded-xl border border-gray-200 bg-white shadow-sm">
+          <div className="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 px-6 py-5">
+            <div>
+              <h2 className="text-xl font-semibold text-[#1B3A5C]">Operational Logs</h2>
+              <p className="mt-1 text-sm text-gray-500">
+                Last 24 hours of sync, classification, and summary activity.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                onClick={() => loadOperationLogs()}
+                className="inline-flex items-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+              >
+                Refresh Logs
+              </button>
+              <Link
+                href="/admin/logs"
+                className="inline-flex items-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+              >
+                View All Logs
+              </Link>
+              <button
+                onClick={() => setLogsExpanded((value) => !value)}
+                className="inline-flex items-center rounded-lg bg-[#1B3A5C] px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-[#1B3A5C]/90"
+              >
+                {logsExpanded ? "Hide Logs" : "Show Logs"}
+              </button>
+            </div>
+          </div>
+          {logsExpanded ? (
+            <div className="px-6 py-5">
+              <OperationLogsTable
+                logs={operationLogs}
+                loading={logsLoading}
+                emptyMessage="No operational logs were recorded in the last 24 hours."
+              />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {canManageMappings ? (
+      <>
       {/* Header */}
       <div className="mb-6">
         <h1 className="text-2xl font-semibold text-[#1B3A5C]">Itinerary Grouping</h1>
@@ -901,6 +981,14 @@ export default function AdminPage() {
           {toast}
         </div>
       )}
+      </>
+      ) : null}
+
+      {!canManageMappings && toast ? (
+        <div className="fixed bottom-4 right-4 z-50 rounded-lg bg-gray-900 px-4 py-3 text-sm text-white shadow-lg">
+          {toast}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/app/src/components/admin/OperationLogsTable.tsx
+++ b/app/src/components/admin/OperationLogsTable.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { format } from "date-fns";
+import type { OperationLogEntry, OperationLogLevel } from "@/lib/firestore/admin-queries";
+
+function LevelBadge({ level }: { level: OperationLogLevel }) {
+  const className =
+    level === "success"
+      ? "bg-emerald-100 text-emerald-700"
+      : level === "warning"
+        ? "bg-amber-100 text-amber-700"
+        : level === "error"
+          ? "bg-red-100 text-red-700"
+          : "bg-slate-100 text-slate-600";
+
+  return (
+    <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${className}`}>
+      {level}
+    </span>
+  );
+}
+
+function renderDetails(details: Record<string, unknown> | null | undefined): string {
+  if (!details) return "";
+
+  const parts = Object.entries(details)
+    .filter(([, value]) => value !== null && value !== undefined && value !== "")
+    .slice(0, 3)
+    .map(([key, value]) => {
+      if (typeof value === "object") {
+        return `${key}: ${JSON.stringify(value)}`;
+      }
+      return `${key}: ${String(value)}`;
+    });
+
+  return parts.join(" | ");
+}
+
+export default function OperationLogsTable({
+  logs,
+  loading,
+  emptyMessage,
+}: {
+  logs: OperationLogEntry[];
+  loading: boolean;
+  emptyMessage: string;
+}) {
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="h-6 w-6 animate-spin rounded-full border-4 border-gray-200 border-t-[#1B3A5C]" />
+      </div>
+    );
+  }
+
+  if (logs.length === 0) {
+    return <div className="px-4 py-6 text-sm text-gray-500">{emptyMessage}</div>;
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white shadow-sm">
+      <table className="w-full min-w-[860px] text-sm">
+        <thead>
+          <tr className="bg-gray-50 text-left text-gray-500">
+            <th className="px-4 py-3 font-medium">Time</th>
+            <th className="px-4 py-3 font-medium">Type</th>
+            <th className="px-4 py-3 font-medium">Status</th>
+            <th className="px-4 py-3 font-medium">Message</th>
+            <th className="px-4 py-3 font-medium">Context</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((log) => {
+            const context = [
+              log.brand ? `brand: ${log.brand}` : null,
+              log.source ? `source: ${log.source}` : null,
+              log.actorEmail ? `actor: ${log.actorEmail}` : null,
+              renderDetails(log.details),
+            ]
+              .filter(Boolean)
+              .join(" | ");
+
+            return (
+              <tr key={log.id} className="border-t border-gray-100 align-top">
+                <td className="px-4 py-3 whitespace-nowrap text-gray-600">
+                  {log.createdAt ? format(new Date(log.createdAt), "M/d/yyyy h:mm:ss a") : "-"}
+                </td>
+                <td className="px-4 py-3">
+                  <span className="inline-flex rounded-full bg-[#1B3A5C]/10 px-2 py-0.5 text-xs font-medium capitalize text-[#1B3A5C]">
+                    {log.type}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <LevelBadge level={log.level} />
+                </td>
+                <td className="px-4 py-3 text-gray-900">
+                  <div className="font-medium">{log.message}</div>
+                  <div className="mt-1 text-xs text-gray-500">{log.action}</div>
+                </td>
+                <td className="px-4 py-3 text-xs leading-5 text-gray-500">
+                  {context || "-"}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/src/components/layout/Navigation.tsx
+++ b/app/src/components/layout/Navigation.tsx
@@ -64,7 +64,11 @@ export default function Navigation() {
       .then((access) => {
         if (cancelled) return;
         setShowAdminTab(
-          Boolean(access.permissions.manageMappings || access.permissions.manageUsers)
+          Boolean(
+            access.permissions.sync ||
+              access.permissions.manageMappings ||
+              access.permissions.manageUsers
+          )
         );
       })
       .catch(() => {

--- a/app/src/lib/firestore/admin-queries.ts
+++ b/app/src/lib/firestore/admin-queries.ts
@@ -51,6 +51,24 @@ export interface KnownUser {
   active: boolean | null;
 }
 
+export type OperationLogType = "sync" | "classification" | "summary";
+export type OperationLogLevel = "info" | "success" | "warning" | "error";
+export type OperationLogSource = "scheduled" | "manual" | "system";
+
+export interface OperationLogEntry {
+  id: string;
+  type: OperationLogType;
+  level: OperationLogLevel;
+  action: string;
+  message: string;
+  createdAt: string;
+  brand?: string | null;
+  source?: OperationLogSource;
+  actorEmail?: string | null;
+  actorUid?: string | null;
+  details?: Record<string, unknown> | null;
+}
+
 export async function getItineraryMappings(brand: string): Promise<ItineraryMapping[]> {
   const db = getClientDb();
   const ref = collection(db, "itinerary_mappings");
@@ -131,4 +149,15 @@ export async function removeAdminUser(email: string): Promise<void> {
     action: "remove",
     email,
   });
+}
+
+export async function listOperationalLogs(
+  hours?: number | null,
+  limit?: number
+): Promise<OperationLogEntry[]> {
+  const response = await postFunction<{ logs?: OperationLogEntry[] }>("adminLogs", {
+    hours: typeof hours === "number" ? hours : null,
+    limit,
+  });
+  return response.logs ?? [];
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -23,6 +23,10 @@ import {
   rebuildMappings as rebuildItineraryMappings,
   updateMapping as updateItineraryMapping,
 } from "./sync/itinerary-mappings";
+import {
+  listOperationLogs,
+  writeOperationLog,
+} from "./ops/operation-logs";
 
 initializeApp();
 
@@ -203,6 +207,16 @@ async function runClassificationAutomation(): Promise<ClassificationAutomationRe
     };
   } catch (error) {
     console.error("Automatic classification cycle failed:", error);
+    await writeOperationLog({
+      type: "classification",
+      level: "error",
+      action: "automation_failed",
+      message: "Automatic classification cycle failed",
+      source: "system",
+      details: {
+        error: String(error),
+      },
+    });
     return {
       processed: 0,
       polledStatus: null,
@@ -219,14 +233,51 @@ async function runClassificationAutomation(): Promise<ClassificationAutomationRe
 export const dailySync = onSchedule(
   { schedule: "0 */2 * * *", timeZone: "UTC", timeoutSeconds: 540, memory: "1GiB" },
   async () => {
-    const results = await syncAll(false);
-    const classification = await runClassificationAutomation();
-    await computeSummaries("uniworld");
-    await computeSummaries("luxury-gold");
-    console.log(
-      "Scheduled sync complete:",
-      JSON.stringify({ syncResults: results, classification })
-    );
+    await writeOperationLog({
+      type: "sync",
+      level: "info",
+      action: "cycle_started",
+      message: "Scheduled sync cycle started",
+      source: "scheduled",
+    });
+
+    try {
+      const results = await syncAll(false);
+      const classification = await runClassificationAutomation();
+      await computeSummaries("uniworld");
+      await computeSummaries("luxury-gold");
+      await writeOperationLog({
+        type: "sync",
+        level: "success",
+        action: "cycle_complete",
+        message: "Scheduled sync cycle completed",
+        source: "scheduled",
+        details: {
+          brands: results.map((result) => ({
+            brand: result.brand,
+            totalProcessed: result.totalProcessed,
+            errorCount: result.errors.length,
+          })),
+          classification,
+        },
+      });
+      console.log(
+        "Scheduled sync complete:",
+        JSON.stringify({ syncResults: results, classification })
+      );
+    } catch (error) {
+      await writeOperationLog({
+        type: "sync",
+        level: "error",
+        action: "cycle_failed",
+        message: "Scheduled sync cycle failed",
+        source: "scheduled",
+        details: {
+          error: String(error),
+        },
+      });
+      throw error;
+    }
   }
 );
 
@@ -246,12 +297,59 @@ export const manualSync = onRequest(
     }
 
     const fullSync = req.body?.fullSync === true;
-    const results = await syncAll(fullSync);
-    const classification = await runClassificationAutomation();
-    await computeSummaries("uniworld");
-    await computeSummaries("luxury-gold");
-    console.log(`manualSync triggered by ${caller.source}:${caller.email ?? caller.uid}`);
-    res.json({ success: true, results, classification });
+    await writeOperationLog({
+      type: "sync",
+      level: "info",
+      action: "cycle_started",
+      message: "Manual sync cycle started",
+      source: "manual",
+      actorEmail: caller.email,
+      actorUid: caller.uid,
+      details: {
+        fullSync,
+      },
+    });
+
+    try {
+      const results = await syncAll(fullSync);
+      const classification = await runClassificationAutomation();
+      await computeSummaries("uniworld");
+      await computeSummaries("luxury-gold");
+      await writeOperationLog({
+        type: "sync",
+        level: "success",
+        action: "cycle_complete",
+        message: "Manual sync cycle completed",
+        source: "manual",
+        actorEmail: caller.email,
+        actorUid: caller.uid,
+        details: {
+          brands: results.map((result) => ({
+            brand: result.brand,
+            totalProcessed: result.totalProcessed,
+            errorCount: result.errors.length,
+          })),
+          classification,
+        },
+      });
+      console.log(`manualSync triggered by ${caller.source}:${caller.email ?? caller.uid}`);
+      res.json({ success: true, results, classification });
+    } catch (error) {
+      await writeOperationLog({
+        type: "sync",
+        level: "error",
+        action: "cycle_failed",
+        message: "Manual sync cycle failed",
+        source: "manual",
+        actorEmail: caller.email,
+        actorUid: caller.uid,
+        details: {
+          error: String(error),
+          fullSync,
+        },
+      });
+      throw error;
+    }
   }
 );
 
@@ -327,12 +425,39 @@ export const itineraryMappings = onRequest(
     if (action === "recompute") {
       if (!brand || brand === "uniworld") await computeSummaries("uniworld");
       if (!brand || brand === "luxury-gold") await computeSummaries("luxury-gold");
+      await writeOperationLog({
+        type: "summary",
+        level: "info",
+        action: "manual_recompute_requested",
+        message: "Manual summary recompute completed",
+        brand: brand ?? "combined",
+        source: "manual",
+        actorEmail: caller.email,
+        actorUid: caller.uid,
+      });
       console.log(`itineraryMappings recompute by ${caller.source}:${caller.email ?? caller.uid}`);
       res.json({ success: true });
       return;
     }
 
     res.status(400).json({ error: "Invalid action. Use 'rebuild', 'update', or 'recompute'." });
+  }
+);
+
+export const adminLogs = onRequest(
+  { timeoutSeconds: 120, memory: "512MiB", invoker: "public", cors: true },
+  async (req, res) => {
+    if (!ensurePost(req, res)) return;
+    const caller = await authorizeRequest(req, res, "sync");
+    if (!caller) return;
+
+    const hours =
+      typeof req.body?.hours === "number" && req.body.hours > 0 ? req.body.hours : null;
+    const limit =
+      typeof req.body?.limit === "number" && req.body.limit > 0 ? req.body.limit : undefined;
+
+    const logs = await listOperationLogs({ hours, limit });
+    res.json({ logs });
   }
 );
 

--- a/functions/src/ops/operation-logs.ts
+++ b/functions/src/ops/operation-logs.ts
@@ -1,0 +1,105 @@
+import { getFirestore, type Query } from "firebase-admin/firestore";
+
+export type OperationLogType = "sync" | "classification" | "summary";
+export type OperationLogLevel = "info" | "success" | "warning" | "error";
+export type OperationLogSource = "scheduled" | "manual" | "system";
+
+export interface OperationLogRecord {
+  id: string;
+  type: OperationLogType;
+  level: OperationLogLevel;
+  action: string;
+  message: string;
+  createdAt: string;
+  brand?: string | null;
+  source?: OperationLogSource;
+  actorEmail?: string | null;
+  actorUid?: string | null;
+  details?: Record<string, unknown> | null;
+}
+
+const OPERATION_LOGS_COLLECTION = "operation_logs";
+
+export async function writeOperationLog(input: {
+  type: OperationLogType;
+  level: OperationLogLevel;
+  action: string;
+  message: string;
+  brand?: string | null;
+  source?: OperationLogSource;
+  actorEmail?: string | null;
+  actorUid?: string | null;
+  details?: Record<string, unknown> | null;
+}): Promise<void> {
+  const db = getFirestore();
+
+  try {
+    const createdAt = new Date().toISOString();
+    await db.collection(OPERATION_LOGS_COLLECTION).add({
+      type: input.type,
+      level: input.level,
+      action: input.action,
+      message: input.message,
+      createdAt,
+      brand: input.brand ?? null,
+      source: input.source ?? "system",
+      actorEmail: input.actorEmail ?? null,
+      actorUid: input.actorUid ?? null,
+      details: input.details ?? null,
+    } satisfies Omit<OperationLogRecord, "id">);
+  } catch (error) {
+    console.error("Failed to write operation log:", error);
+  }
+}
+
+export async function listOperationLogs(options?: {
+  hours?: number | null;
+  limit?: number;
+}): Promise<OperationLogRecord[]> {
+  const db = getFirestore();
+  let query: Query = db.collection(OPERATION_LOGS_COLLECTION);
+
+  if (typeof options?.hours === "number" && options.hours > 0) {
+    const since = new Date(Date.now() - options.hours * 60 * 60 * 1000).toISOString();
+    query = query.where("createdAt", ">=", since);
+  }
+
+  query = query.orderBy("createdAt", "desc");
+
+  if (typeof options?.limit === "number" && options.limit > 0) {
+    query = query.limit(options.limit);
+  }
+
+  const snapshot = await query.get();
+  return snapshot.docs.map((doc) => {
+    const data = doc.data() ?? {};
+    return {
+      id: doc.id,
+      type: data.type === "classification" || data.type === "summary" ? data.type : "sync",
+      level:
+        data.level === "success" ||
+        data.level === "warning" ||
+        data.level === "error"
+          ? data.level
+          : "info",
+      action: typeof data.action === "string" ? data.action : "unknown",
+      message: typeof data.message === "string" ? data.message : "No message",
+      createdAt: typeof data.createdAt === "string" ? data.createdAt : "",
+      brand: typeof data.brand === "string" || data.brand === null ? data.brand : null,
+      source:
+        data.source === "scheduled" || data.source === "manual" || data.source === "system"
+          ? data.source
+          : "system",
+      actorEmail:
+        typeof data.actorEmail === "string" || data.actorEmail === null
+          ? data.actorEmail
+          : null,
+      actorUid:
+        typeof data.actorUid === "string" || data.actorUid === null ? data.actorUid : null,
+      details:
+        typeof data.details === "object" && data.details !== null
+          ? (data.details as Record<string, unknown>)
+          : null,
+    } satisfies OperationLogRecord;
+  });
+}

--- a/functions/src/sync/batch-classify.ts
+++ b/functions/src/sync/batch-classify.ts
@@ -1,5 +1,6 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { POSITIVE_THEMES, NEGATIVE_THEMES, VALID_POSITIVE_NAMES, VALID_NEGATIVE_NAMES } from "@feefo/shared";
+import { writeOperationLog } from "../ops/operation-logs";
 
 const BATCH_SIZE = 10000; // Max requests per Anthropic batch
 const ACTIVE_BATCH_STATUSES = new Set(["processing", "in_progress", "canceling", "submitting"]);
@@ -61,6 +62,17 @@ export async function submitClassificationBatch(): Promise<BatchClassifyResult> 
   });
 
   if (!reservation.acquired) {
+    await writeOperationLog({
+      type: "classification",
+      level: "info",
+      action: "batch_submit_skipped",
+      message: "Skipped classification batch submission because another batch is already active",
+      source: "system",
+      details: {
+        batchId: reservation.batchId ?? null,
+        status: reservation.status,
+      },
+    });
     return {
       totalUnclassified: 0,
       batchId: reservation.batchId ?? null,
@@ -87,6 +99,13 @@ export async function submitClassificationBatch(): Promise<BatchClassifyResult> 
       },
       { merge: true }
     );
+    await writeOperationLog({
+      type: "classification",
+      level: "info",
+      action: "batch_submit_skipped",
+      message: "No unclassified reviews were found for classification",
+      source: "system",
+    });
     return { totalUnclassified: 0, batchId: null, error: null, status: "idle" };
   }
 
@@ -161,6 +180,17 @@ Return empty arrays if no themes match. Only use themes from the lists above.`,
       },
       { merge: true }
     );
+    await writeOperationLog({
+      type: "classification",
+      level: "success",
+      action: "batch_submitted",
+      message: `Submitted classification batch ${batch.id}`,
+      source: "system",
+      details: {
+        totalRequests: requests.length,
+        status: batch.processing_status,
+      },
+    });
 
     return {
       totalUnclassified: snapshot.size,
@@ -181,6 +211,17 @@ Return empty arrays if no themes match. Only use themes from the lists above.`,
       },
       { merge: true }
     );
+    await writeOperationLog({
+      type: "classification",
+      level: "error",
+      action: "batch_submit_failed",
+      message: "Failed to submit classification batch",
+      source: "system",
+      details: {
+        error: errorMsg,
+        attemptedCount: snapshot.size,
+      },
+    });
     return { totalUnclassified: snapshot.size, batchId: null, error: errorMsg, status: "error" };
   }
 }
@@ -229,6 +270,17 @@ export async function processBatchResults(batchId?: string): Promise<{ processed
       { status: batchStatus.processing_status, lastChecked: new Date().toISOString() },
       { merge: true }
     );
+    await writeOperationLog({
+      type: "classification",
+      level: "info",
+      action: "batch_poll_in_progress",
+      message: `Classification batch ${batchId} is still ${batchStatus.processing_status}`,
+      source: "system",
+      details: {
+        batchId,
+        requestCounts: batchStatus.request_counts as unknown as Record<string, unknown>,
+      },
+    });
     return { processed: 0, status: batchStatus.processing_status };
   }
 
@@ -297,6 +349,18 @@ export async function processBatchResults(batchId?: string): Promise<{ processed
     completedAt: new Date().toISOString(),
     processed,
     total: lines.length,
+  });
+  await writeOperationLog({
+    type: "classification",
+    level: "success",
+    action: "batch_complete",
+    message: `Completed classification batch ${batchId}`,
+    source: "system",
+    details: {
+      batchId,
+      processed,
+      total: lines.length,
+    },
   });
 
   console.log(`Batch ${batchId}: wrote ${processed}/${lines.length} classifications to Firestore`);

--- a/functions/src/sync/compute-summaries.ts
+++ b/functions/src/sync/compute-summaries.ts
@@ -1,6 +1,7 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { ReviewDocument, Brand, normalizeItineraryName } from "@feefo/shared";
 import { getMappingLookup } from "./itinerary-mappings";
+import { writeOperationLog } from "../ops/operation-logs";
 
 interface Summary {
   id: string;
@@ -29,54 +30,87 @@ interface MonthlySummary {
 }
 
 export async function computeSummaries(brand: Brand): Promise<void> {
-  const db = getFirestore();
-  const snapshot = await db
-    .collection("reviews")
-    .where("brand", "==", brand)
-    .get();
+  try {
+    const db = getFirestore();
+    const snapshot = await db
+      .collection("reviews")
+      .where("brand", "==", brand)
+      .get();
 
-  const reviews = snapshot.docs.map((doc) => doc.data() as ReviewDocument);
+    const reviews = snapshot.docs.map((doc) => doc.data() as ReviewDocument);
 
-  // Fleet-level summary
-  const fleetSummary = buildSummary(brand, "fleet", null, reviews);
-  await db.collection("summaries").doc(brand).set(fleetSummary);
+    // Fleet-level summary
+    const fleetSummary = buildSummary(brand, "fleet", null, reviews);
+    await db.collection("summaries").doc(brand).set(fleetSummary);
 
-  // Per-ship summaries
-  const byShip = groupBy(reviews, (r) => r.tags.ship);
-  for (const [ship, shipReviews] of Object.entries(byShip)) {
-    if (!ship) continue;
-    const summary = buildSummary(brand, "ship", ship, shipReviews);
-    summary.itineraries = [...new Set(shipReviews.map((r) => r.tags.tour).filter(Boolean) as string[])];
-    const docId = `${brand}_ship_${slugify(ship)}`;
-    await db.collection("summaries").doc(docId).set(summary);
+    // Per-ship summaries
+    const byShip = groupBy(reviews, (r) => r.tags.ship);
+    for (const [ship, shipReviews] of Object.entries(byShip)) {
+      if (!ship) continue;
+      const summary = buildSummary(brand, "ship", ship, shipReviews);
+      summary.itineraries = [
+        ...new Set(shipReviews.map((r) => r.tags.tour).filter(Boolean) as string[]),
+      ];
+      const docId = `${brand}_ship_${slugify(ship)}`;
+      await db.collection("summaries").doc(docId).set(summary);
+    }
+
+    // Per-itinerary summaries - group by effective parent name via mappings
+    const mappingLookup = await getMappingLookup(brand);
+    const resolveParent = (rawTour: string): string =>
+      mappingLookup.get(rawTour) ?? normalizeItineraryName(rawTour);
+
+    const byItinerary = groupBy(reviews, (r) => {
+      const raw = r.tags.tour ?? r.product.title;
+      return raw ? resolveParent(raw) : null;
+    });
+
+    for (const [itinerary, itinReviews] of Object.entries(byItinerary)) {
+      if (!itinerary) continue;
+      const summary = buildSummary(brand, "itinerary", itinerary, itinReviews);
+      summary.ships = [
+        ...new Set(itinReviews.map((r) => r.tags.ship).filter(Boolean) as string[]),
+      ];
+      // Track which raw itinerary names rolled up into this parent.
+      summary.childItineraries = [
+        ...new Set(
+          itinReviews.map((r) => r.tags.tour ?? r.product.title).filter(Boolean) as string[]
+        ),
+      ];
+      const docId = `${brand}_itinerary_${slugify(itinerary)}`;
+      await db.collection("summaries").doc(docId).set(summary);
+    }
+
+    await computeMonthlySummaries(brand, reviews);
+    await cleanStaleSummaries(brand, byShip, byItinerary);
+
+    await writeOperationLog({
+      type: "summary",
+      level: "success",
+      action: "recompute",
+      message: `Recomputed summaries for ${brand}`,
+      brand,
+      source: "system",
+      details: {
+        reviewCount: reviews.length,
+        shipCount: Object.keys(byShip).length,
+        itineraryCount: Object.keys(byItinerary).length,
+      },
+    });
+  } catch (error) {
+    await writeOperationLog({
+      type: "summary",
+      level: "error",
+      action: "recompute",
+      message: `Failed to recompute summaries for ${brand}`,
+      brand,
+      source: "system",
+      details: {
+        error: String(error),
+      },
+    });
+    throw error;
   }
-
-  // Per-itinerary summaries — group by effective parent name via mappings
-  const mappingLookup = await getMappingLookup(brand);
-  const resolveParent = (rawTour: string): string =>
-    mappingLookup.get(rawTour) ?? normalizeItineraryName(rawTour);
-
-  const byItinerary = groupBy(reviews, (r) => {
-    const raw = r.tags.tour ?? r.product.title;
-    return raw ? resolveParent(raw) : null;
-  });
-  for (const [itinerary, itinReviews] of Object.entries(byItinerary)) {
-    if (!itinerary) continue;
-    const summary = buildSummary(brand, "itinerary", itinerary, itinReviews);
-    summary.ships = [...new Set(itinReviews.map((r) => r.tags.ship).filter(Boolean) as string[])];
-    // Track which raw itinerary names rolled up into this parent
-    summary.childItineraries = [...new Set(
-      itinReviews.map((r) => r.tags.tour ?? r.product.title).filter(Boolean) as string[]
-    )];
-    const docId = `${brand}_itinerary_${slugify(itinerary)}`;
-    await db.collection("summaries").doc(docId).set(summary);
-  }
-
-  // Monthly summaries for trend charts
-  await computeMonthlySummaries(brand, reviews);
-
-  // Clean stale summaries
-  await cleanStaleSummaries(brand, byShip, byItinerary);
 }
 
 async function computeMonthlySummaries(brand: Brand, reviews: ReviewDocument[]): Promise<void> {
@@ -90,7 +124,9 @@ async function computeMonthlySummaries(brand: Brand, reviews: ReviewDocument[]):
 
   for (const [month, monthReviews] of Object.entries(byMonth)) {
     if (!month) continue;
-    const ratings = monthReviews.map((r) => r.ratings.product).filter((r): r is number => r !== null);
+    const ratings = monthReviews
+      .map((r) => r.ratings.product)
+      .filter((r): r is number => r !== null);
     const starDist: Record<string, number> = { "1": 0, "2": 0, "3": 0, "4": 0, "5": 0 };
     for (const r of ratings) {
       starDist[String(Math.round(r))] = (starDist[String(Math.round(r))] || 0) + 1;
@@ -101,7 +137,12 @@ async function computeMonthlySummaries(brand: Brand, reviews: ReviewDocument[]):
       brand,
       month,
       totalReviews: monthReviews.length,
-      avgRating: ratings.length > 0 ? Math.round((ratings.reduce((a, b) => a + b, 0) / ratings.length) * 100) / 100 : 0,
+      avgRating:
+        ratings.length > 0
+          ? Math.round(
+              (ratings.reduce((a, b) => a + b, 0) / ratings.length) * 100
+            ) / 100
+          : 0,
       starDistribution: starDist,
     };
 
@@ -117,9 +158,7 @@ async function cleanStaleSummaries(
   byItinerary: Record<string, ReviewDocument[]>
 ): Promise<void> {
   const db = getFirestore();
-  const existing = await db.collection("summaries")
-    .where("brand", "==", brand)
-    .get();
+  const existing = await db.collection("summaries").where("brand", "==", brand).get();
 
   const writer = db.bulkWriter();
 

--- a/functions/src/sync/sync-reviews.ts
+++ b/functions/src/sync/sync-reviews.ts
@@ -1,5 +1,6 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { fetchReviews, transformReview, Brand, ReviewDocument } from "@feefo/shared";
+import { writeOperationLog } from "../ops/operation-logs";
 
 interface SyncResult {
   brand: Brand;
@@ -30,6 +31,14 @@ export async function syncBrand(brand: Brand, fullSync: boolean = false): Promis
 
   if (!lockAcquired) {
     result.errors.push(`Sync already in progress for ${brand}`);
+    await writeOperationLog({
+      type: "sync",
+      level: "warning",
+      action: "brand_skipped_locked",
+      message: `Skipped ${brand} sync because another run is already in progress`,
+      brand,
+      source: "system",
+    });
     return result;
   }
 
@@ -90,12 +99,36 @@ export async function syncBrand(brand: Brand, fullSync: boolean = false): Promis
       status: "success",
       errorMessage: result.errors.length > 0 ? result.errors.join("; ").slice(0, 5000) : null,
     });
+    await writeOperationLog({
+      type: "sync",
+      level: result.errors.length > 0 ? "warning" : "success",
+      action: "brand_sync_complete",
+      message: `Completed ${brand} sync`,
+      brand,
+      source: "system",
+      details: {
+        totalProcessed: result.totalProcessed,
+        errorCount: result.errors.length,
+        maxSourceUpdatedAt: result.maxSourceUpdatedAt,
+      },
+    });
   } catch (err) {
     result.errors.push(`Sync failed for ${brand}: ${err}`);
     await syncMetaRef.set(
       { status: "error", errorMessage: String(err).slice(0, 5000) },
       { merge: true }
     );
+    await writeOperationLog({
+      type: "sync",
+      level: "error",
+      action: "brand_sync_failed",
+      message: `Failed ${brand} sync`,
+      brand,
+      source: "system",
+      details: {
+        error: String(err),
+      },
+    });
   }
 
   return result;


### PR DESCRIPTION
## Summary
- record sync, classification, and summary events into Firestore-backed operational logs
- expose the last 24 hours of logs on the Admin page for owners and sync-capable users
- add a dedicated admin logs page for deeper review

## Testing
- npm run build (functions)
- npm run build (app)