### PR TITLE
Persist user preferences in localStorage

### DIFF
--- a/app/src/app/itineraries/page.tsx
+++ b/app/src/app/itineraries/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useMemo, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useDashboard } from "@/contexts/DashboardContext";
+import { usePersistedState } from "@/hooks/usePersistedState";
 import SearchFilter from "@/components/dashboard/SearchFilter";
 import HealthBadge from "@/components/dashboard/HealthBadge";
 import ItineraryDetail from "@/components/itineraries/ItineraryDetail";
@@ -43,8 +44,8 @@ function ItineraryList() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
-  const [sortBy, setSortBy] = useState<SortOption>("reviewCount");
-  const [viewMode, setViewMode] = useState<ViewMode>("cards");
+  const [sortBy, setSortBy] = usePersistedState<SortOption>("pref:itineraries:sort", "reviewCount");
+  const [viewMode, setViewMode] = usePersistedState<ViewMode>("pref:itineraries:viewMode", "cards");
 
   useEffect(() => {
     setLoading(true);

--- a/app/src/app/ships/page.tsx
+++ b/app/src/app/ships/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useMemo, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useDashboard } from "@/contexts/DashboardContext";
+import { usePersistedState } from "@/hooks/usePersistedState";
 import SearchFilter from "@/components/dashboard/SearchFilter";
 import HealthBadge from "@/components/dashboard/HealthBadge";
 import ShipDetail from "@/components/ships/ShipDetail";
@@ -43,8 +44,8 @@ function ShipList() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
-  const [sortBy, setSortBy] = useState<SortOption>("reviewCount");
-  const [viewMode, setViewMode] = useState<ViewMode>("cards");
+  const [sortBy, setSortBy] = usePersistedState<SortOption>("pref:ships:sort", "reviewCount");
+  const [viewMode, setViewMode] = usePersistedState<ViewMode>("pref:ships:viewMode", "cards");
 
   useEffect(() => {
     setLoading(true);

--- a/app/src/contexts/DashboardContext.tsx
+++ b/app/src/contexts/DashboardContext.tsx
@@ -110,7 +110,12 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   const handleSetDateRange = useCallback((range: DateRange) => {
     setDateRangeState(range);
     try {
-      localStorage.setItem("pref:datePreset", JSON.stringify(range.preset));
+      if (range.preset === "Custom Range") {
+        // Can't reconstruct custom dates on hydration, so clear the key
+        localStorage.removeItem("pref:datePreset");
+      } else {
+        localStorage.setItem("pref:datePreset", JSON.stringify(range.preset));
+      }
     } catch {
       // Ignore
     }

--- a/app/src/contexts/DashboardContext.tsx
+++ b/app/src/contexts/DashboardContext.tsx
@@ -4,10 +4,12 @@ import {
   createContext,
   useContext,
   useState,
+  useEffect,
   useCallback,
   type ReactNode,
 } from "react";
 import { subMonths, subYears, startOfMonth, startOfYear, startOfWeek } from "date-fns";
+import { usePersistedState } from "@/hooks/usePersistedState";
 
 export type Brand = "uniworld" | "luxury-gold" | "combined";
 
@@ -43,6 +45,8 @@ interface DashboardContextValue {
 
 const DashboardContext = createContext<DashboardContextValue | null>(null);
 
+const DEFAULT_PRESET: DatePreset = "Last 12 Months";
+
 export function getDateRangeForPreset(preset: DatePreset): { start: Date; end: Date } {
   const now = new Date();
   const end = now;
@@ -76,23 +80,40 @@ export function getDateRangeForPreset(preset: DatePreset): { start: Date; end: D
 }
 
 function getDefaultDateRange(): DateRange {
-  const preset: DatePreset = "Last 12 Months";
-  const { start, end } = getDateRangeForPreset(preset);
-  return { start, end, preset };
+  const { start, end } = getDateRangeForPreset(DEFAULT_PRESET);
+  return { start, end, preset: DEFAULT_PRESET };
 }
 
 export function DashboardProvider({ children }: { children: ReactNode }) {
-  const [brand, setBrand] = useState<Brand>("uniworld");
-  const [dateRange, setDateRange] = useState<DateRange>(getDefaultDateRange);
+  const [brand, setBrand] = usePersistedState<Brand>("pref:brand", "uniworld");
+  const [dateRange, setDateRangeState] = useState<DateRange>(getDefaultDateRange);
   const [lastSynced, setLastSynced] = useState<string | null>(null);
   const [dataVersion, setDataVersion] = useState(0);
 
-  const handleSetDateRange = useCallback((range: DateRange) => {
-    setDateRange(range);
+  // Hydrate date range from persisted preset on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem("pref:datePreset");
+      if (stored) {
+        const preset = JSON.parse(stored) as DatePreset;
+        // For Custom Range, we can't reconstruct the dates, so skip
+        if (preset !== "Custom Range") {
+          const { start, end } = getDateRangeForPreset(preset);
+          setDateRangeState({ start, end, preset });
+        }
+      }
+    } catch {
+      // Ignore
+    }
   }, []);
 
-  const handleSetBrand = useCallback((b: Brand) => {
-    setBrand(b);
+  const handleSetDateRange = useCallback((range: DateRange) => {
+    setDateRangeState(range);
+    try {
+      localStorage.setItem("pref:datePreset", JSON.stringify(range.preset));
+    } catch {
+      // Ignore
+    }
   }, []);
 
   const handleSetLastSynced = useCallback((value: string | null) => {
@@ -107,7 +128,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     <DashboardContext.Provider
       value={{
         brand,
-        setBrand: handleSetBrand,
+        setBrand,
         dateRange,
         setDateRange: handleSetDateRange,
         lastSynced,

--- a/app/src/hooks/usePersistedState.ts
+++ b/app/src/hooks/usePersistedState.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+/**
+ * Like useState, but persists the value to localStorage.
+ * SSR-safe: renders with `defaultValue` on the server / first client paint,
+ * then hydrates from localStorage in a useEffect.
+ */
+export function usePersistedState<T>(
+  key: string,
+  defaultValue: T
+): [T, (value: T) => void] {
+  const [state, setState] = useState<T>(defaultValue);
+
+  // Hydrate from localStorage on mount
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(key);
+      if (stored !== null) {
+        setState(JSON.parse(stored) as T);
+      }
+    } catch {
+      // Ignore parse errors or disabled localStorage
+    }
+  }, [key]);
+
+  const setPersistedState = useCallback(
+    (value: T) => {
+      setState(value);
+      try {
+        localStorage.setItem(key, JSON.stringify(value));
+      } catch {
+        // Ignore quota errors
+      }
+    },
+    [key]
+  );
+
+  return [state, setPersistedState];
+}

--- a/app/src/hooks/usePersistedState.ts
+++ b/app/src/hooks/usePersistedState.ts
@@ -1,38 +1,50 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, type SetStateAction, type Dispatch } from "react";
 
 /**
  * Like useState, but persists the value to localStorage.
  * SSR-safe: renders with `defaultValue` on the server / first client paint,
  * then hydrates from localStorage in a useEffect.
+ *
+ * Supports functional updates like React's useState:
+ *   setPersistedState(prev => next)
  */
 export function usePersistedState<T>(
   key: string,
   defaultValue: T
-): [T, (value: T) => void] {
+): [T, Dispatch<SetStateAction<T>>] {
   const [state, setState] = useState<T>(defaultValue);
 
-  // Hydrate from localStorage on mount
+  // Hydrate from localStorage on mount (or when key changes)
   useEffect(() => {
     try {
       const stored = localStorage.getItem(key);
       if (stored !== null) {
         setState(JSON.parse(stored) as T);
+      } else {
+        // Reset to default when key changes and nothing is stored
+        setState(defaultValue);
       }
     } catch {
-      // Ignore parse errors or disabled localStorage
+      setState(defaultValue);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key]);
 
-  const setPersistedState = useCallback(
-    (value: T) => {
-      setState(value);
-      try {
-        localStorage.setItem(key, JSON.stringify(value));
-      } catch {
-        // Ignore quota errors
-      }
+  const setPersistedState: Dispatch<SetStateAction<T>> = useCallback(
+    (action: SetStateAction<T>) => {
+      setState((prev) => {
+        const next = typeof action === "function"
+          ? (action as (prev: T) => T)(prev)
+          : action;
+        try {
+          localStorage.setItem(key, JSON.stringify(next));
+        } catch {
+          // Ignore quota errors
+        }
+        return next;
+      });
     },
     [key]
   );


### PR DESCRIPTION
## Summary

- New `usePersistedState` hook — drop-in replacement for `useState` that reads/writes localStorage (SSR-safe)
- **Brand selection** persists across page refreshes
- **Date range preset** persists (stores the preset name, recomputes dates on load so relative ranges stay current)
- **View mode** (cards/table) on itineraries and ships pages persists
- **Sort order** on itineraries and ships pages persists

## Test plan

- [ ] Change brand → refresh → brand retained
- [ ] Change date range to "Last 6 Months" → refresh → still "Last 6 Months"
- [ ] Switch to table view on itineraries → navigate to ships → come back → still table view
- [ ] Change sort to "Name" on ships → refresh → still sorted by name
- [ ] Open in incognito — all defaults apply (no stale prefs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)