### PR TITLE
Share view mode toggle between itineraries and ships pages

### DIFF
--- a/app/src/app/itineraries/page.tsx
+++ b/app/src/app/itineraries/page.tsx
@@ -45,7 +45,7 @@ function ItineraryList() {
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [sortBy, setSortBy] = usePersistedState<SortOption>("pref:itineraries:sort", "reviewCount");
-  const [viewMode, setViewMode] = usePersistedState<ViewMode>("pref:itineraries:viewMode", "cards");
+  const [viewMode, setViewMode] = usePersistedState<ViewMode>("pref:listViewMode", "cards");
 
   useEffect(() => {
     setLoading(true);

--- a/app/src/app/ships/page.tsx
+++ b/app/src/app/ships/page.tsx
@@ -45,7 +45,7 @@ function ShipList() {
   const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [sortBy, setSortBy] = usePersistedState<SortOption>("pref:ships:sort", "reviewCount");
-  const [viewMode, setViewMode] = usePersistedState<ViewMode>("pref:ships:viewMode", "cards");
+  const [viewMode, setViewMode] = usePersistedState<ViewMode>("pref:listViewMode", "cards");
 
   useEffect(() => {
     setLoading(true);


### PR DESCRIPTION
## Summary

- Both itineraries and ships pages now use the same localStorage key (`pref:listViewMode`) for the card/table toggle
- Switching to table view on one page automatically applies to the other
- Sort order remains per-page (different preferences make sense for ships vs itineraries)

**Note:** The previous PR was merged before this fix was pushed to the branch, so this is a follow-up.

## Test plan

- [ ] Switch to table view on itineraries → navigate to ships → should also be table view
- [ ] Switch back to cards on ships → navigate to itineraries → should also be cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)