### PR TITLE
Fix tooltip text color on chart tooltips

### DIFF
--- a/app/src/components/dashboard/RatingDistributionChart.tsx
+++ b/app/src/components/dashboard/RatingDistributionChart.tsx
@@ -36,6 +36,10 @@ const TOOLTIP_LABEL_STYLE = {
   fontWeight: 600,
 };
 
+const TOOLTIP_ITEM_STYLE = {
+  color: "#cbd5e1",
+};
+
 export default function RatingDistributionChart({
   data,
   onBarClick,
@@ -57,6 +61,7 @@ export default function RatingDistributionChart({
             cursor={false}
             contentStyle={TOOLTIP_STYLE}
             labelStyle={TOOLTIP_LABEL_STYLE}
+            itemStyle={TOOLTIP_ITEM_STYLE}
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             formatter={(value: any) => [Number(value).toLocaleString(), "Reviews"]}
           />

--- a/app/src/components/dashboard/ThemeChart.tsx
+++ b/app/src/components/dashboard/ThemeChart.tsx
@@ -31,6 +31,10 @@ const TOOLTIP_LABEL_STYLE = {
   fontWeight: 600,
 };
 
+const TOOLTIP_ITEM_STYLE = {
+  color: "#cbd5e1",
+};
+
 const POSITIVE_COLORS = [
   "#1B3A5C", "#1e4a73", "#22578a", "#2d6aa0", "#3b82f6",
   "#4a8ed9", "#5c9be0", "#71a9e6", "#8ab8ec", "#a3c7f2",
@@ -77,6 +81,7 @@ export default function ThemeChart({ title, data, type, onBarClick }: ThemeChart
             cursor={false}
             contentStyle={TOOLTIP_STYLE}
             labelStyle={TOOLTIP_LABEL_STYLE}
+            itemStyle={TOOLTIP_ITEM_STYLE}
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             formatter={(value: any) => [Number(value).toLocaleString(), "Reviews"]}
           />

--- a/app/src/components/dashboard/TrendChart.tsx
+++ b/app/src/components/dashboard/TrendChart.tsx
@@ -32,6 +32,10 @@ const TOOLTIP_LABEL_STYLE = {
   fontWeight: 600,
 };
 
+const TOOLTIP_ITEM_STYLE = {
+  color: "#cbd5e1",
+};
+
 function formatMonth(month: string): string {
   try {
     return format(parseISO(`${month}-01`), "MMM yy");
@@ -76,6 +80,7 @@ export default function TrendChart({ data, onSelectMonth }: TrendChartProps) {
               cursor={{ stroke: "#36506f", strokeWidth: 1, strokeDasharray: "3 3" }}
               contentStyle={TOOLTIP_STYLE}
               labelStyle={TOOLTIP_LABEL_STYLE}
+              itemStyle={TOOLTIP_ITEM_STYLE}
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               formatter={(value: any) => [Number(value).toFixed(2), "Avg Rating"]}
             />
@@ -123,6 +128,7 @@ export default function TrendChart({ data, onSelectMonth }: TrendChartProps) {
               cursor={false}
               contentStyle={TOOLTIP_STYLE}
               labelStyle={TOOLTIP_LABEL_STYLE}
+              itemStyle={TOOLTIP_ITEM_STYLE}
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               formatter={(value: any) => [Number(value).toLocaleString(), "Reviews"]}
             />


### PR DESCRIPTION
## Summary

- Add `itemStyle` with light text color (`#cbd5e1`) to all three chart tooltips
- Fixes unreadable "Reviews : 64" text on the dark tooltip background
- Applied consistently to RatingDistributionChart, TrendChart, and ThemeChart

## Files changed

- `app/src/components/dashboard/RatingDistributionChart.tsx`
- `app/src/components/dashboard/TrendChart.tsx`
- `app/src/components/dashboard/ThemeChart.tsx`

## Test plan

- [ ] Hover over rating distribution bars — tooltip text is readable
- [ ] Hover over trend chart data points — tooltip text is readable
- [ ] Hover over theme chart bars — tooltip text is readable
- [ ] Verify in both light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)