### PR TITLE
Respect date range on ships and itineraries

### DIFF
--- a/app/src/app/itineraries/page.tsx
+++ b/app/src/app/itineraries/page.tsx
@@ -38,7 +38,7 @@ function ItinerariesContent() {
 }
 
 function ItineraryList() {
-  const { brand, dataVersion } = useDashboard();
+  const { brand, dateRange, dataVersion } = useDashboard();
   const [itineraries, setItineraries] = useState<ItinerarySummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -49,7 +49,7 @@ function ItineraryList() {
   useEffect(() => {
     setLoading(true);
     setError(null);
-    getItineraries(brand).then((data) => {
+    getItineraries(brand, dateRange).then((data) => {
       setItineraries(data);
       setLoading(false);
     }).catch((err) => {
@@ -57,7 +57,7 @@ function ItineraryList() {
       setError(err instanceof Error ? err.message : "Unable to load itineraries right now.");
       setLoading(false);
     });
-  }, [brand, dataVersion]);
+  }, [brand, dateRange, dataVersion]);
 
   const filtered = useMemo(() => {
     const result = itineraries.filter((it) =>

--- a/app/src/app/ships/page.tsx
+++ b/app/src/app/ships/page.tsx
@@ -38,7 +38,7 @@ function ShipsContent() {
 }
 
 function ShipList() {
-  const { brand, dataVersion } = useDashboard();
+  const { brand, dateRange, dataVersion } = useDashboard();
   const [ships, setShips] = useState<ShipSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -49,7 +49,7 @@ function ShipList() {
   useEffect(() => {
     setLoading(true);
     setError(null);
-    getShips(brand).then((data) => {
+    getShips(brand, dateRange).then((data) => {
       setShips(data);
       setLoading(false);
     }).catch((err) => {
@@ -57,7 +57,7 @@ function ShipList() {
       setError(err instanceof Error ? err.message : "Unable to load ships right now.");
       setLoading(false);
     });
-  }, [brand, dataVersion]);
+  }, [brand, dateRange, dataVersion]);
 
   const filtered = useMemo(() => {
     const result = ships.filter((s) =>

--- a/app/src/components/itineraries/ItineraryDetail.tsx
+++ b/app/src/components/itineraries/ItineraryDetail.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/lib/firestore/itinerary-queries";
 
 export default function ItineraryDetail({ slug }: { slug: string }) {
-  const { brand, dataVersion } = useDashboard();
+  const { brand, dateRange, dataVersion } = useDashboard();
   const [itinerary, setItinerary] = useState<ItinerarySummary | null>(null);
   const [quotes, setQuotes] = useState<{ positive: Quote[]; negative: Quote[] }>({
     positive: [],
@@ -36,11 +36,17 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    getItineraryBySlug(slug, brand).then(async (data) => {
+    getItineraryBySlug(slug, brand, dateRange).then(async (data) => {
       if (cancelled) return;
       setItinerary(data);
       if (data) {
-        const q = await getItineraryQuotes(data.name, data.childItineraries, data.ships[0], brand);
+        const q = await getItineraryQuotes(
+          data.name,
+          data.childItineraries,
+          data.ships[0],
+          brand,
+          dateRange
+        );
         if (!cancelled) setQuotes(q);
       }
       setLoading(false);
@@ -51,7 +57,7 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
       setLoading(false);
     });
     return () => { cancelled = true; };
-  }, [slug, brand, dataVersion]);
+  }, [slug, brand, dateRange, dataVersion]);
 
   const openPanel = useCallback(async (theme: string, type: "positive" | "negative") => {
     setPanelTheme(theme);
@@ -59,7 +65,7 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
     setPanelOpen(true);
     setPanelLoading(true);
     try {
-      const reviews = await getReviewsByTheme(brand, theme, type);
+      const reviews = await getReviewsByTheme(brand, theme, type, dateRange.start, dateRange.end);
       setPanelReviews(reviews);
     } catch (err) {
       console.error("Failed to load theme reviews", err);
@@ -67,7 +73,7 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
     } finally {
       setPanelLoading(false);
     }
-  }, [brand]);
+  }, [brand, dateRange]);
 
   const closePanel = useCallback(() => {
     setPanelOpen(false);

--- a/app/src/components/ships/ShipDetail.tsx
+++ b/app/src/components/ships/ShipDetail.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/lib/firestore/ship-queries";
 
 export default function ShipDetail({ slug }: { slug: string }) {
-  const { brand, dataVersion } = useDashboard();
+  const { brand, dateRange, dataVersion } = useDashboard();
   const [ship, setShip] = useState<ShipSummary | null>(null);
   const [quotes, setQuotes] = useState<{ positive: Quote[]; negative: Quote[] }>({
     positive: [],
@@ -37,11 +37,11 @@ export default function ShipDetail({ slug }: { slug: string }) {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    getShipBySlug(slug, brand).then(async (data) => {
+    getShipBySlug(slug, brand, dateRange).then(async (data) => {
       if (cancelled) return;
       setShip(data);
       if (data) {
-        const q = await getShipQuotes(data.name, brand);
+        const q = await getShipQuotes(data.name, brand, dateRange);
         if (!cancelled) setQuotes(q);
       }
       setLoading(false);
@@ -52,7 +52,7 @@ export default function ShipDetail({ slug }: { slug: string }) {
       setLoading(false);
     });
     return () => { cancelled = true; };
-  }, [slug, brand, dataVersion]);
+  }, [slug, brand, dateRange, dataVersion]);
 
   const openPanel = useCallback(async (theme: string, type: "positive" | "negative") => {
     setPanelTheme(theme);
@@ -60,7 +60,7 @@ export default function ShipDetail({ slug }: { slug: string }) {
     setPanelOpen(true);
     setPanelLoading(true);
     try {
-      const reviews = await getReviewsByTheme(brand, theme, type);
+      const reviews = await getReviewsByTheme(brand, theme, type, dateRange.start, dateRange.end);
       setPanelReviews(reviews);
     } catch (err) {
       console.error("Failed to load theme reviews", err);
@@ -68,7 +68,7 @@ export default function ShipDetail({ slug }: { slug: string }) {
     } finally {
       setPanelLoading(false);
     }
-  }, [brand]);
+  }, [brand, dateRange]);
 
   const closePanel = useCallback(() => {
     setPanelOpen(false);

--- a/app/src/lib/firestore/itinerary-queries.ts
+++ b/app/src/lib/firestore/itinerary-queries.ts
@@ -1,6 +1,8 @@
 "use client";
 
 import { getClientDb } from "@/lib/firebase";
+import type { DateRange } from "@/contexts/DashboardContext";
+import { getFleetSummaryByDateRange } from "@/lib/firestore/queries";
 import {
   collection,
   query,
@@ -29,6 +31,8 @@ export interface ItinerarySummary {
   fleetAvgFiveStar: number;
 }
 
+type SummaryDateRange = Pick<DateRange, "start" | "end" | "preset">;
+
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function slugify(text: string): string {
@@ -37,6 +41,151 @@ function slugify(text: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "")
     .slice(0, 100);
+}
+
+function usesAllTimeSummaries(dateRange?: SummaryDateRange): boolean {
+  return !dateRange || dateRange.preset === "All Time";
+}
+
+function getReviewRating(data: Record<string, unknown>): number {
+  const ratings = data.ratings as { product?: number; service?: number } | undefined;
+  const fallback = typeof data.rating === "number" ? data.rating : 0;
+  return ratings?.product ?? ratings?.service ?? fallback;
+}
+
+function buildDateRangeConstraints(
+  brand: string,
+  startDate: Date,
+  endDate: Date
+) {
+  const constraints = [
+    where("dates.created", ">=", startDate.toISOString()),
+    where("dates.created", "<=", endDate.toISOString()),
+    orderBy("dates.created", "desc"),
+  ];
+
+  if (brand !== "combined") {
+    constraints.unshift(where("brand", "==", brand));
+  }
+
+  return constraints;
+}
+
+async function getParentNameLookup(brand: string): Promise<Map<string, string>> {
+  const db = getClientDb();
+  const ref = collection(db, "itinerary_mappings");
+  const constraints = brand === "combined" ? [] : [where("brand", "==", brand)];
+  const snap = await getDocs(query(ref, ...constraints));
+  const lookup = new Map<string, string>();
+
+  for (const d of snap.docs) {
+    const mapping = d.data();
+    if (mapping.rawName && mapping.effectiveParentName) {
+      lookup.set(mapping.rawName, mapping.effectiveParentName);
+    }
+  }
+
+  return lookup;
+}
+
+async function getItinerariesByDateRange(
+  brand: string,
+  dateRange: SummaryDateRange
+): Promise<ItinerarySummary[]> {
+  const db = getClientDb();
+  const ref = collection(db, "reviews");
+  const [snap, parentLookup, fleet] = await Promise.all([
+    getDocs(query(ref, ...buildDateRangeConstraints(brand, dateRange.start, dateRange.end))),
+    getParentNameLookup(brand),
+    getFleetSummaryByDateRange(brand, dateRange.start, dateRange.end),
+  ]);
+
+  if (snap.empty) return [];
+
+  const byName: Record<string, {
+    totalReviews: number;
+    ratingSum: number;
+    starDist: Record<string, number>;
+    positiveCounts: Record<string, number>;
+    negativeCounts: Record<string, number>;
+    ships: Set<string>;
+    childItineraries: Set<string>;
+  }> = {};
+
+  for (const d of snap.docs) {
+    const data = d.data();
+    const rawName = data.tags?.tour || data.product?.title || "";
+    if (!rawName) continue;
+
+    const name = parentLookup.get(rawName) ?? rawName;
+
+    if (!byName[name]) {
+      byName[name] = {
+        totalReviews: 0,
+        ratingSum: 0,
+        starDist: { "1": 0, "2": 0, "3": 0, "4": 0, "5": 0 },
+        positiveCounts: {},
+        negativeCounts: {},
+        ships: new Set(),
+        childItineraries: new Set(),
+      };
+    }
+
+    const agg = byName[name];
+    const rating = getReviewRating(data);
+    const roundedRating = Math.min(5, Math.max(1, Math.round(rating)));
+
+    agg.totalReviews += 1;
+    agg.ratingSum += rating;
+    agg.starDist[String(roundedRating)] = (agg.starDist[String(roundedRating)] || 0) + 1;
+
+    for (const theme of data.themes?.positive || []) {
+      agg.positiveCounts[theme] = (agg.positiveCounts[theme] || 0) + 1;
+    }
+
+    for (const theme of data.themes?.negative || []) {
+      agg.negativeCounts[theme] = (agg.negativeCounts[theme] || 0) + 1;
+    }
+
+    if (data.tags?.ship) {
+      agg.ships.add(data.tags.ship);
+    }
+
+    agg.childItineraries.add(rawName);
+  }
+
+  return Object.entries(byName)
+    .map(([name, agg]) => {
+      const total = agg.totalReviews;
+      const fiveStar = agg.starDist["5"] || 0;
+      const fourPlus = (agg.starDist["5"] || 0) + (agg.starDist["4"] || 0);
+
+      return {
+        slug: slugify(name),
+        name,
+        ships: [...agg.ships],
+        childItineraries: [...agg.childItineraries],
+        averageRating: total > 0 ? Math.round((agg.ratingSum / total) * 100) / 100 : 0,
+        reviewCount: total,
+        fiveStarPercent: total > 0 ? Math.round((fiveStar / total) * 1000) / 10 : 0,
+        fourPlusPercent: total > 0 ? Math.round((fourPlus / total) * 1000) / 10 : 0,
+        ratingDistribution: [5, 4, 3, 2, 1].map((star) => ({
+          star,
+          count: agg.starDist[String(star)] || 0,
+        })),
+        positiveThemes: Object.entries(agg.positiveCounts)
+          .map(([theme, count]) => ({ theme, count }))
+          .sort((a, b) => b.count - a.count)
+          .slice(0, 10),
+        negativeThemes: Object.entries(agg.negativeCounts)
+          .map(([theme, count]) => ({ theme, count }))
+          .sort((a, b) => b.count - a.count)
+          .slice(0, 10),
+        fleetAvgRating: fleet.averageRating,
+        fleetAvgFiveStar: fleet.fiveStarPercent,
+      };
+    })
+    .sort((a, b) => b.averageRating - a.averageRating);
 }
 
 async function getFleetAverages(brand: string): Promise<{ avgRating: number; avgFiveStar: number }> {
@@ -69,7 +218,14 @@ async function getFleetAverages(brand: string): Promise<{ avgRating: number; avg
 
 // ── Query functions ─────────────────────────────────────────────────────────
 
-export async function getItineraries(brand: string = "combined"): Promise<ItinerarySummary[]> {
+export async function getItineraries(
+  brand: string = "combined",
+  dateRange?: SummaryDateRange
+): Promise<ItinerarySummary[]> {
+  if (dateRange && !usesAllTimeSummaries(dateRange)) {
+    return getItinerariesByDateRange(brand, dateRange);
+  }
+
   const db = getClientDb();
   const ref = collection(db, "summaries");
   const constraints = brand === "combined"
@@ -156,8 +312,12 @@ export async function getItineraries(brand: string = "combined"): Promise<Itiner
     .sort((a, b) => b.averageRating - a.averageRating);
 }
 
-export async function getItineraryBySlug(slug: string, brand: string = "combined"): Promise<ItinerarySummary | null> {
-  const itineraries = await getItineraries(brand);
+export async function getItineraryBySlug(
+  slug: string,
+  brand: string = "combined",
+  dateRange?: SummaryDateRange
+): Promise<ItinerarySummary | null> {
+  const itineraries = await getItineraries(brand, dateRange);
   return itineraries.find((it) => it.slug === slug) ?? null;
 }
 
@@ -165,16 +325,18 @@ export async function getItineraryQuotes(
   itineraryName: string,
   childItineraries: string[],
   _ship: string,
-  brand: string = "combined"
+  brand: string = "combined",
+  dateRange?: SummaryDateRange
 ): Promise<{ positive: Quote[]; negative: Quote[] }> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
   // Use childItineraries to match all variant tour names; Firestore "in" supports up to 30
   const tourNames = childItineraries.length > 0 ? childItineraries.slice(0, 30) : [itineraryName];
+  const reviewLimit = dateRange && !usesAllTimeSummaries(dateRange) ? 100 : 20;
   const baseConstraints = [
     where("tags.tour", "in", tourNames),
     orderBy("dates.created", "desc"),
-    limit(20),
+    limit(reviewLimit),
   ];
   if (brand !== "combined") {
     baseConstraints.unshift(where("brand", "==", brand));
@@ -184,9 +346,20 @@ export async function getItineraryQuotes(
 
   const positive: Quote[] = [];
   const negative: Quote[] = [];
+  const startIso = dateRange?.start.toISOString();
+  const endIso = dateRange?.end.toISOString();
 
   for (const d of snap.docs) {
     const data = d.data();
+    const created = data.dates?.created;
+    if (
+      startIso &&
+      endIso &&
+      (typeof created !== "string" || created < startIso || created > endIso)
+    ) {
+      continue;
+    }
+
     const rating = data.ratings?.product ?? data.ratings?.service ?? 0;
     const text = data.reviews?.productText || data.reviews?.serviceText || "";
     if (!text) continue;

--- a/app/src/lib/firestore/queries.ts
+++ b/app/src/lib/firestore/queries.ts
@@ -526,14 +526,17 @@ export async function getFilterOptions(
 export async function getReviewsByTheme(
   brand: string,
   theme: string,
-  type: "positive" | "negative"
+  type: "positive" | "negative",
+  startDate?: Date,
+  endDate?: Date
 ): Promise<ThemeReview[]> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
+  const fetchLimit = startDate && endDate ? 100 : 20;
   const constraints = [
     where(`themes.${type}`, "array-contains", theme),
     orderBy("dates.created", "desc"),
-    limit(20),
+    limit(fetchLimit),
   ];
   if (brand !== "combined") {
     constraints.unshift(where("brand", "==", brand));
@@ -543,7 +546,19 @@ export async function getReviewsByTheme(
 
   if (snap.empty) return [];
 
-  return snap.docs.map((docSnap) =>
+  const filteredDocs =
+    startDate && endDate
+      ? snap.docs.filter((docSnap) => {
+          const created = docSnap.data().dates?.created;
+          return (
+            typeof created === "string" &&
+            created >= startDate.toISOString() &&
+            created <= endDate.toISOString()
+          );
+        })
+      : snap.docs;
+
+  return filteredDocs.slice(0, 20).map((docSnap) =>
     mapReviewDoc({ id: docSnap.id, data: docSnap.data() })
   );
 }

--- a/app/src/lib/firestore/ship-queries.ts
+++ b/app/src/lib/firestore/ship-queries.ts
@@ -1,6 +1,8 @@
 "use client";
 
 import { getClientDb } from "@/lib/firebase";
+import type { DateRange } from "@/contexts/DashboardContext";
+import { getFleetSummaryByDateRange } from "@/lib/firestore/queries";
 import {
   collection,
   query,
@@ -37,6 +39,8 @@ export interface ShipSummary {
   fleetAvgFiveStar: number;
 }
 
+type SummaryDateRange = Pick<DateRange, "start" | "end" | "preset">;
+
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
 function slugify(text: string): string {
@@ -45,6 +49,170 @@ function slugify(text: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "")
     .slice(0, 100);
+}
+
+function usesAllTimeSummaries(dateRange?: SummaryDateRange): boolean {
+  return !dateRange || dateRange.preset === "All Time";
+}
+
+function getReviewRating(data: Record<string, unknown>): number {
+  const ratings = data.ratings as { product?: number; service?: number } | undefined;
+  const fallback = typeof data.rating === "number" ? data.rating : 0;
+  return ratings?.product ?? ratings?.service ?? fallback;
+}
+
+function buildDateRangeConstraints(
+  brand: string,
+  startDate: Date,
+  endDate: Date
+) {
+  const constraints = [
+    where("dates.created", ">=", startDate.toISOString()),
+    where("dates.created", "<=", endDate.toISOString()),
+    orderBy("dates.created", "desc"),
+  ];
+
+  if (brand !== "combined") {
+    constraints.unshift(where("brand", "==", brand));
+  }
+
+  return constraints;
+}
+
+async function getParentNameLookup(brand: string): Promise<Map<string, string>> {
+  const db = getClientDb();
+  const ref = collection(db, "itinerary_mappings");
+  const constraints = brand === "combined" ? [] : [where("brand", "==", brand)];
+  const snap = await getDocs(query(ref, ...constraints));
+  const lookup = new Map<string, string>();
+
+  for (const d of snap.docs) {
+    const mapping = d.data();
+    if (mapping.rawName && mapping.effectiveParentName) {
+      lookup.set(mapping.rawName, mapping.effectiveParentName);
+    }
+  }
+
+  return lookup;
+}
+
+async function getShipsByDateRange(
+  brand: string,
+  dateRange: SummaryDateRange
+): Promise<ShipSummary[]> {
+  const db = getClientDb();
+  const ref = collection(db, "reviews");
+  const [snap, parentLookup, fleet] = await Promise.all([
+    getDocs(query(ref, ...buildDateRangeConstraints(brand, dateRange.start, dateRange.end))),
+    getParentNameLookup(brand),
+    getFleetSummaryByDateRange(brand, dateRange.start, dateRange.end),
+  ]);
+
+  if (snap.empty) return [];
+
+  const byShip: Record<string, {
+    totalReviews: number;
+    ratingSum: number;
+    starDist: Record<string, number>;
+    positiveCounts: Record<string, number>;
+    negativeCounts: Record<string, number>;
+    itineraries: Record<string, { totalReviews: number; ratingSum: number; fiveStar: number }>;
+  }> = {};
+
+  for (const d of snap.docs) {
+    const data = d.data();
+    const shipName = data.tags?.ship || "";
+    if (!shipName) continue;
+
+    if (!byShip[shipName]) {
+      byShip[shipName] = {
+        totalReviews: 0,
+        ratingSum: 0,
+        starDist: { "1": 0, "2": 0, "3": 0, "4": 0, "5": 0 },
+        positiveCounts: {},
+        negativeCounts: {},
+        itineraries: {},
+      };
+    }
+
+    const agg = byShip[shipName];
+    const rating = getReviewRating(data);
+    const roundedRating = Math.min(5, Math.max(1, Math.round(rating)));
+
+    agg.totalReviews += 1;
+    agg.ratingSum += rating;
+    agg.starDist[String(roundedRating)] = (agg.starDist[String(roundedRating)] || 0) + 1;
+
+    for (const theme of data.themes?.positive || []) {
+      agg.positiveCounts[theme] = (agg.positiveCounts[theme] || 0) + 1;
+    }
+
+    for (const theme of data.themes?.negative || []) {
+      agg.negativeCounts[theme] = (agg.negativeCounts[theme] || 0) + 1;
+    }
+
+    const rawItinerary = data.tags?.tour || data.product?.title || "";
+    if (rawItinerary) {
+      const itineraryName = parentLookup.get(rawItinerary) ?? rawItinerary;
+      if (!agg.itineraries[itineraryName]) {
+        agg.itineraries[itineraryName] = { totalReviews: 0, ratingSum: 0, fiveStar: 0 };
+      }
+
+      agg.itineraries[itineraryName].totalReviews += 1;
+      agg.itineraries[itineraryName].ratingSum += rating;
+      if (roundedRating === 5) {
+        agg.itineraries[itineraryName].fiveStar += 1;
+      }
+    }
+  }
+
+  return Object.entries(byShip)
+    .map(([name, agg]) => {
+      const total = agg.totalReviews;
+      const fiveStar = agg.starDist["5"] || 0;
+      const fourPlus = (agg.starDist["5"] || 0) + (agg.starDist["4"] || 0);
+      const itineraries = Object.entries(agg.itineraries)
+        .map(([itineraryName, itineraryAgg]) => ({
+          slug: slugify(itineraryName),
+          name: itineraryName,
+          averageRating:
+            itineraryAgg.totalReviews > 0
+              ? Math.round((itineraryAgg.ratingSum / itineraryAgg.totalReviews) * 100) / 100
+              : 0,
+          reviewCount: itineraryAgg.totalReviews,
+          fiveStarPercent:
+            itineraryAgg.totalReviews > 0
+              ? Math.round((itineraryAgg.fiveStar / itineraryAgg.totalReviews) * 1000) / 10
+              : 0,
+        }))
+        .sort((a, b) => b.reviewCount - a.reviewCount);
+
+      return {
+        slug: slugify(name),
+        name,
+        averageRating: total > 0 ? Math.round((agg.ratingSum / total) * 100) / 100 : 0,
+        reviewCount: total,
+        fiveStarPercent: total > 0 ? Math.round((fiveStar / total) * 1000) / 10 : 0,
+        fourPlusPercent: total > 0 ? Math.round((fourPlus / total) * 1000) / 10 : 0,
+        itineraryCount: itineraries.length,
+        itineraries,
+        ratingDistribution: [5, 4, 3, 2, 1].map((star) => ({
+          star,
+          count: agg.starDist[String(star)] || 0,
+        })),
+        positiveThemes: Object.entries(agg.positiveCounts)
+          .map(([theme, count]) => ({ theme, count }))
+          .sort((a, b) => b.count - a.count)
+          .slice(0, 10),
+        negativeThemes: Object.entries(agg.negativeCounts)
+          .map(([theme, count]) => ({ theme, count }))
+          .sort((a, b) => b.count - a.count)
+          .slice(0, 10),
+        fleetAvgRating: fleet.averageRating,
+        fleetAvgFiveStar: fleet.fiveStarPercent,
+      };
+    })
+    .sort((a, b) => b.averageRating - a.averageRating);
 }
 
 function buildShipSummaryFromDocs(
@@ -154,7 +322,14 @@ async function getFleetAverages(brand: string): Promise<{ avgRating: number; avg
 
 // ── Query functions ─────────────────────────────────────────────────────────
 
-export async function getShips(brand: string = "combined"): Promise<ShipSummary[]> {
+export async function getShips(
+  brand: string = "combined",
+  dateRange?: SummaryDateRange
+): Promise<ShipSummary[]> {
+  if (dateRange && !usesAllTimeSummaries(dateRange)) {
+    return getShipsByDateRange(brand, dateRange);
+  }
+
   const db = getClientDb();
   const ref = collection(db, "summaries");
   const constraints = brand === "combined"
@@ -174,17 +349,23 @@ export async function getShips(brand: string = "combined"): Promise<ShipSummary[
     .sort((a, b) => b.averageRating - a.averageRating);
 }
 
-export async function getShipBySlug(slug: string, brand: string = "combined"): Promise<ShipSummary | null> {
-  const ships = await getShips(brand);
+export async function getShipBySlug(
+  slug: string,
+  brand: string = "combined",
+  dateRange?: SummaryDateRange
+): Promise<ShipSummary | null> {
+  const ships = await getShips(brand, dateRange);
   return ships.find((s) => s.slug === slug) ?? null;
 }
 
 export async function getShipQuotes(
   shipName: string,
-  brand: string = "combined"
+  brand: string = "combined",
+  dateRange?: SummaryDateRange
 ): Promise<{ positive: Quote[]; negative: Quote[] }> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
+  const reviewLimit = dateRange && !usesAllTimeSummaries(dateRange) ? 100 : 20;
   const baseConstraints = [
     where("tags.ship", "==", shipName),
     orderBy("dates.created", "desc"),
@@ -195,14 +376,25 @@ export async function getShipQuotes(
 
   // Firestore doesn't allow multiple inequality filters on different fields,
   // so we fetch recent reviews and split them by rating
-  const allQ = query(ref, ...baseConstraints, limit(20));
+  const allQ = query(ref, ...baseConstraints, limit(reviewLimit));
   const snap = await getDocs(allQ);
 
   const positive: Quote[] = [];
   const negative: Quote[] = [];
+  const startIso = dateRange?.start.toISOString();
+  const endIso = dateRange?.end.toISOString();
 
   for (const d of snap.docs) {
     const data = d.data();
+    const created = data.dates?.created;
+    if (
+      startIso &&
+      endIso &&
+      (typeof created !== "string" || created < startIso || created > endIso)
+    ) {
+      continue;
+    }
+
     const rating = data.ratings?.product ?? data.ratings?.service ?? 0;
     const text = data.reviews?.productText || data.reviews?.serviceText || "";
     if (!text) continue;


### PR DESCRIPTION
## Summary
- make the selected date range drive the ships and itineraries list pages instead of always reading all-time summaries
- apply the same selected range to ship and itinerary detail metrics and quotes
- keep theme review drilldowns aligned with the selected time window

## Testing
- npm run build
