### PR TITLE
Stabilize brand navigation state

### DIFF
--- a/app/src/components/layout/Navigation.tsx
+++ b/app/src/components/layout/Navigation.tsx
@@ -2,26 +2,29 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { onAuthStateChanged, type User } from "firebase/auth";
 import AuthButton from "./AuthButton";
 import RefreshButton from "./RefreshButton";
 import { getClientAuth, hasFirebaseWebConfig } from "@/lib/firebase";
 import { getCurrentAdminAccess } from "@/lib/firestore/admin-queries";
+import { brandHasShips, useDashboard } from "@/contexts/DashboardContext";
 
 const baseTabs = [
   { href: "/", label: "Overview" },
   { href: "/itineraries", label: "Itineraries" },
-  { href: "/ships", label: "Ships" },
   { href: "/reviews", label: "Reviews" },
 ];
 
 export default function Navigation() {
+  const router = useRouter();
   const pathname = usePathname();
+  const { brand } = useDashboard();
   const showAuthControls = hasFirebaseWebConfig();
   const [user, setUser] = useState<User | null>(null);
   const [showAdminTab, setShowAdminTab] = useState(false);
   const [checkingAdminAccess, setCheckingAdminAccess] = useState(showAuthControls);
+  const showShipsTab = brandHasShips(brand);
 
   useEffect(() => {
     if (!showAuthControls) {
@@ -86,9 +89,18 @@ export default function Navigation() {
   }, [showAuthControls, user]);
 
   const tabs = [...baseTabs];
+  if (showShipsTab) {
+    tabs.splice(2, 0, { href: "/ships", label: "Ships" });
+  }
   if (showAdminTab || (pathname.startsWith("/admin") && checkingAdminAccess)) {
     tabs.push({ href: "/admin", label: "Admin" });
   }
+
+  useEffect(() => {
+    if (!showShipsTab && pathname.startsWith("/ships")) {
+      router.replace("/itineraries");
+    }
+  }, [pathname, router, showShipsTab]);
 
   return (
     <nav className="border-b border-gray-200 bg-white shadow-sm dark:bg-[#111927] dark:border-[#1e2d44]">

--- a/app/src/contexts/DashboardContext.tsx
+++ b/app/src/contexts/DashboardContext.tsx
@@ -4,7 +4,6 @@ import {
   createContext,
   useContext,
   useState,
-  useEffect,
   useCallback,
   type ReactNode,
 } from "react";
@@ -12,6 +11,10 @@ import { subMonths, subYears, startOfMonth, startOfYear, startOfWeek } from "dat
 import { usePersistedState } from "@/hooks/usePersistedState";
 
 export type Brand = "uniworld" | "luxury-gold" | "combined";
+
+export function brandHasShips(brand: Brand): boolean {
+  return brand !== "luxury-gold";
+}
 
 export type DatePreset =
   | "This Week"
@@ -84,28 +87,34 @@ function getDefaultDateRange(): DateRange {
   return { start, end, preset: DEFAULT_PRESET };
 }
 
+function getInitialDateRange(): DateRange {
+  if (typeof window === "undefined") {
+    return getDefaultDateRange();
+  }
+
+  try {
+    const stored = localStorage.getItem("pref:datePreset");
+    if (!stored) {
+      return getDefaultDateRange();
+    }
+
+    const preset = JSON.parse(stored) as DatePreset;
+    if (preset === "Custom Range") {
+      return getDefaultDateRange();
+    }
+
+    const { start, end } = getDateRangeForPreset(preset);
+    return { start, end, preset };
+  } catch {
+    return getDefaultDateRange();
+  }
+}
+
 export function DashboardProvider({ children }: { children: ReactNode }) {
   const [brand, setBrand] = usePersistedState<Brand>("pref:brand", "uniworld");
-  const [dateRange, setDateRangeState] = useState<DateRange>(getDefaultDateRange);
+  const [dateRange, setDateRangeState] = useState<DateRange>(getInitialDateRange);
   const [lastSynced, setLastSynced] = useState<string | null>(null);
   const [dataVersion, setDataVersion] = useState(0);
-
-  // Hydrate date range from persisted preset on mount
-  useEffect(() => {
-    try {
-      const stored = localStorage.getItem("pref:datePreset");
-      if (stored) {
-        const preset = JSON.parse(stored) as DatePreset;
-        // For Custom Range, we can't reconstruct the dates, so skip
-        if (preset !== "Custom Range") {
-          const { start, end } = getDateRangeForPreset(preset);
-          setDateRangeState({ start, end, preset });
-        }
-      }
-    } catch {
-      // Ignore
-    }
-  }, []);
 
   const handleSetDateRange = useCallback((range: DateRange) => {
     setDateRangeState(range);

--- a/app/src/hooks/usePersistedState.ts
+++ b/app/src/hooks/usePersistedState.ts
@@ -14,23 +14,25 @@ export function usePersistedState<T>(
   key: string,
   defaultValue: T
 ): [T, Dispatch<SetStateAction<T>>] {
-  const [state, setState] = useState<T>(defaultValue);
+  const readStoredValue = useCallback((): T => {
+    if (typeof window === "undefined") {
+      return defaultValue;
+    }
+
+    try {
+      const stored = localStorage.getItem(key);
+      return stored !== null ? (JSON.parse(stored) as T) : defaultValue;
+    } catch {
+      return defaultValue;
+    }
+  }, [defaultValue, key]);
+
+  const [state, setState] = useState<T>(readStoredValue);
 
   // Hydrate from localStorage on mount (or when key changes)
   useEffect(() => {
-    try {
-      const stored = localStorage.getItem(key);
-      if (stored !== null) {
-        setState(JSON.parse(stored) as T);
-      } else {
-        // Reset to default when key changes and nothing is stored
-        setState(defaultValue);
-      }
-    } catch {
-      setState(defaultValue);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key]);
+    setState(readStoredValue());
+  }, [readStoredValue]);
 
   const setPersistedState: Dispatch<SetStateAction<T>> = useCallback(
     (action: SetStateAction<T>) => {


### PR DESCRIPTION
## Summary
- initialize persisted dashboard brand and date preset before the first client paint so route changes do not flash back to the default brand
- hide the Ships tab whenever Luxury Gold is selected
- redirect away from /ships to /itineraries if the active brand does not support ships

## Testing
- npm run build
