### PR TITLE
Adapt overview trends to selected range

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -11,22 +11,24 @@ import FleetComparisonTable from "@/components/dashboard/FleetComparisonTable";
 import {
   getFleetSummary,
   getFleetSummaryByDateRange,
-  getMonthlySummaries,
+  getTrendSeries,
   getEntitySummaries,
   getEntitySummariesByDateRange,
   getReviewsForOverviewSelection,
   type OverviewSelectionFilter,
   type FleetSummary,
-  type MonthlySummary,
   type EntitySummary,
   type ThemeReview,
+  type TrendPoint,
+  type TrendGranularity,
 } from "@/lib/firestore/queries";
 
 export default function OverviewPage() {
   const { brand, dateRange, dataVersion } = useDashboard();
 
   const [fleet, setFleet] = useState<FleetSummary | null>(null);
-  const [monthly, setMonthly] = useState<MonthlySummary[]>([]);
+  const [trendPoints, setTrendPoints] = useState<TrendPoint[]>([]);
+  const [trendGranularity, setTrendGranularity] = useState<TrendGranularity>("month");
   const [entities, setEntities] = useState<EntitySummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -56,18 +58,14 @@ export default function OverviewPage() {
 
     Promise.all([
       fleetPromise,
-      getMonthlySummaries(brand),
+      getTrendSeries(brand, dateRange.start, dateRange.end),
       entityPromise,
-    ]).then(([f, m, e]) => {
+    ]).then(([f, trend, e]) => {
       if (cancelled) return;
 
-      // Filter monthly summaries by date range
-      const startMonth = `${dateRange.start.getFullYear()}-${String(dateRange.start.getMonth() + 1).padStart(2, "0")}`;
-      const endMonth = `${dateRange.end.getFullYear()}-${String(dateRange.end.getMonth() + 1).padStart(2, "0")}`;
-      const filteredMonthly = m.filter((ms) => ms.month >= startMonth && ms.month <= endMonth);
-
       setFleet(f);
-      setMonthly(filteredMonthly);
+      setTrendPoints(trend.points);
+      setTrendGranularity(trend.granularity);
       setEntities(e);
       setLoading(false);
     }).catch((err) => {
@@ -217,13 +215,19 @@ export default function OverviewPage() {
 
       {/* Trend Charts (rating + volume side by side) */}
       <TrendChart
-        data={monthly}
-        onSelectMonth={(month) =>
+        data={trendPoints}
+        granularity={trendGranularity}
+        onSelectPeriod={(period) =>
           openPanel({
-            title: `Reviews from ${month}`,
-            subtitle: "Reviews included in the selected month",
+            title: `Reviews from ${period.fullLabel}`,
+            subtitle: `Reviews included in the selected ${trendGranularity} range`,
             accent: "neutral",
-            filter: { kind: "month", month },
+            filter: {
+              kind: "period",
+              start: period.periodStart,
+              end: period.periodEnd,
+              label: period.fullLabel,
+            },
           })
         }
       />

--- a/app/src/components/dashboard/TrendChart.tsx
+++ b/app/src/components/dashboard/TrendChart.tsx
@@ -12,11 +12,12 @@ import {
   ResponsiveContainer,
   CartesianGrid,
 } from "recharts";
-import { format, parseISO } from "date-fns";
+import type { TrendGranularity, TrendPoint } from "@/lib/firestore/queries";
 
 interface TrendChartProps {
-  data: { month: string; averageRating: number; reviewCount: number }[];
-  onSelectMonth?: (month: string) => void;
+  data: TrendPoint[];
+  granularity: TrendGranularity;
+  onSelectPeriod?: (period: TrendPoint) => void;
 }
 
 const TOOLTIP_STYLE = {
@@ -36,14 +37,6 @@ const TOOLTIP_ITEM_STYLE = {
   color: "#cbd5e1",
 };
 
-function formatMonth(month: string): string {
-  try {
-    return format(parseISO(`${month}-01`), "MMM yy");
-  } catch {
-    return month;
-  }
-}
-
 function useIsMobile(breakpoint = 640) {
   const [isMobile, setIsMobile] = useState(false);
   useEffect(() => {
@@ -56,53 +49,80 @@ function useIsMobile(breakpoint = 640) {
   return isMobile;
 }
 
-export default function TrendChart({ data, onSelectMonth }: TrendChartProps) {
+function granularityLabel(granularity: TrendGranularity): string {
+  if (granularity === "day") return "Daily";
+  if (granularity === "week") return "Weekly";
+  return "Monthly";
+}
+
+export default function TrendChart({
+  data,
+  granularity,
+  onSelectPeriod,
+}: TrendChartProps) {
   const isMobile = useIsMobile();
   const chartHeight = isMobile ? 200 : 260;
-  const chartData = data.map((d) => ({
-    ...d,
-    label: formatMonth(d.month),
-  }));
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-      {/* Rating Trend */}
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
       <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6">
-        <h3 className="text-lg font-semibold text-[#1B3A5C] mb-4">
-          Rating Trend Over Time
-        </h3>
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <h3 className="text-lg font-semibold text-[#1B3A5C]">
+            Rating Trend Over Time
+          </h3>
+          <span className="rounded-full bg-[#1B3A5C]/10 px-2.5 py-1 text-xs font-medium text-[#1B3A5C]">
+            {granularityLabel(granularity)}
+          </span>
+        </div>
         <ResponsiveContainer width="100%" height={chartHeight}>
-          <LineChart data={chartData} margin={{ left: 0, right: 10, top: 5, bottom: 0 }}>
+          <LineChart data={data} margin={{ left: 0, right: 10, top: 5, bottom: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-            <XAxis dataKey="label" tick={{ fontSize: isMobile ? 9 : 11 }} />
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: isMobile ? 9 : 11 }}
+              minTickGap={isMobile ? 18 : 24}
+            />
             <YAxis domain={[4.0, 5.0]} tick={{ fontSize: 11 }} />
             <Tooltip
               cursor={{ stroke: "#36506f", strokeWidth: 1, strokeDasharray: "3 3" }}
               contentStyle={TOOLTIP_STYLE}
               labelStyle={TOOLTIP_LABEL_STYLE}
               itemStyle={TOOLTIP_ITEM_STYLE}
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              formatter={(value: any) => [Number(value).toFixed(2), "Avg Rating"]}
+              labelFormatter={(_, payload) =>
+                payload?.[0]?.payload?.fullLabel ?? ""
+              }
+              formatter={(value) => [
+                value == null ? "No ratings" : Number(value).toFixed(2),
+                "Avg Rating",
+              ]}
             />
             <Line
               type="monotone"
               dataKey="averageRating"
               stroke="#1B3A5C"
               strokeWidth={2}
-              dot={(dotProps) => (
-                <circle
-                  cx={dotProps.cx}
-                  cy={dotProps.cy}
-                  r={isMobile ? 3 : 4}
-                  fill="#1B3A5C"
-                  className={onSelectMonth ? "cursor-pointer" : undefined}
-                  onClick={() => {
-                    if (onSelectMonth && typeof dotProps.payload?.month === "string") {
-                      onSelectMonth(dotProps.payload.month);
-                    }
-                  }}
-                />
-              )}
+              connectNulls={false}
+              dot={(dotProps) => {
+                const payload = dotProps.payload as TrendPoint | undefined;
+                if (!payload || payload.averageRating === null) {
+                  return null;
+                }
+
+                return (
+                  <circle
+                    cx={dotProps.cx}
+                    cy={dotProps.cy}
+                    r={isMobile ? 3 : 4}
+                    fill="#1B3A5C"
+                    className={onSelectPeriod ? "cursor-pointer" : undefined}
+                    onClick={() => {
+                      if (onSelectPeriod) {
+                        onSelectPeriod(payload);
+                      }
+                    }}
+                  />
+                );
+              }}
               activeDot={{
                 r: isMobile ? 4 : 6,
                 fill: "#7CC0FF",
@@ -114,33 +134,43 @@ export default function TrendChart({ data, onSelectMonth }: TrendChartProps) {
         </ResponsiveContainer>
       </div>
 
-      {/* Volume Trend */}
       <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6">
-        <h3 className="text-lg font-semibold text-[#1B3A5C] mb-4">
-          Review Volume Over Time
-        </h3>
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <h3 className="text-lg font-semibold text-[#1B3A5C]">
+            Review Volume Over Time
+          </h3>
+          <span className="rounded-full bg-[#C5A258]/15 px-2.5 py-1 text-xs font-medium text-[#8B6C29]">
+            {granularityLabel(granularity)}
+          </span>
+        </div>
         <ResponsiveContainer width="100%" height={chartHeight}>
-          <BarChart data={chartData} margin={{ left: 0, right: 10, top: 5, bottom: 0 }}>
+          <BarChart data={data} margin={{ left: 0, right: 10, top: 5, bottom: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
-            <XAxis dataKey="label" tick={{ fontSize: isMobile ? 9 : 11 }} />
+            <XAxis
+              dataKey="label"
+              tick={{ fontSize: isMobile ? 9 : 11 }}
+              minTickGap={isMobile ? 18 : 24}
+            />
             <YAxis tick={{ fontSize: 11 }} />
             <Tooltip
               cursor={false}
               contentStyle={TOOLTIP_STYLE}
               labelStyle={TOOLTIP_LABEL_STYLE}
               itemStyle={TOOLTIP_ITEM_STYLE}
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              formatter={(value: any) => [Number(value).toLocaleString(), "Reviews"]}
+              labelFormatter={(_, payload) =>
+                payload?.[0]?.payload?.fullLabel ?? ""
+              }
+              formatter={(value) => [Number(value ?? 0).toLocaleString(), "Reviews"]}
             />
             <Bar
               dataKey="reviewCount"
               fill="#C5A258"
               radius={[4, 4, 0, 0]}
-              cursor={onSelectMonth ? "pointer" : "default"}
+              cursor={onSelectPeriod ? "pointer" : "default"}
               activeBar={false}
               onClick={(_, index) => {
-                if (onSelectMonth && index >= 0 && chartData[index]) {
-                  onSelectMonth(chartData[index].month);
+                if (onSelectPeriod && index >= 0 && data[index]) {
+                  onSelectPeriod(data[index]);
                 }
               }}
             />

--- a/app/src/lib/firestore/queries.ts
+++ b/app/src/lib/firestore/queries.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { format } from "date-fns";
 import { getClientDb } from "@/lib/firebase";
 import {
   collection,
@@ -38,6 +39,18 @@ export interface MonthlySummary {
   reviewCount: number;
 }
 
+export type TrendGranularity = "day" | "week" | "month";
+
+export interface TrendPoint {
+  key: string;
+  label: string;
+  fullLabel: string;
+  averageRating: number | null;
+  reviewCount: number;
+  periodStart: string;
+  periodEnd: string;
+}
+
 export interface EntitySummary {
   id: string;
   name: string;
@@ -60,7 +73,8 @@ export interface ThemeReview {
 export type OverviewSelectionFilter =
   | { kind: "theme"; theme: string; sentiment: "positive" | "negative" }
   | { kind: "rating"; star: number }
-  | { kind: "month"; month: string };
+  | { kind: "month"; month: string }
+  | { kind: "period"; start: string; end: string; label: string };
 
 const PANEL_REVIEW_LIMIT = 100;
 const PANEL_REVIEW_BATCH_SIZE = 200;
@@ -236,6 +250,36 @@ export async function getMonthlySummaries(brand: string): Promise<MonthlySummary
       reviewCount: data.totalReviews || 0,
     };
   });
+}
+
+export async function getTrendSeries(
+  brand: string,
+  startDate: Date,
+  endDate: Date
+): Promise<{ granularity: TrendGranularity; points: TrendPoint[] }> {
+  const rangeDays = getRangeLengthInDays(startDate, endDate);
+  const granularity: TrendGranularity =
+    rangeDays <= 45 ? "day" : rangeDays <= 366 ? "week" : "month";
+
+  if (granularity === "month") {
+    const monthly = await getMonthlySummaries(brand);
+    return {
+      granularity,
+      points: buildMonthlyTrendPoints(monthly, startDate, endDate),
+    };
+  }
+
+  const db = getClientDb();
+  const ref = collection(db, "reviews");
+  const constraints = [
+    ...buildDateRangeConstraints(brand, startDate.toISOString(), endDate.toISOString()),
+  ];
+  const snap = await getDocs(query(ref, ...constraints));
+
+  return {
+    granularity,
+    points: buildAdaptiveTrendPoints(snap.docs.map((docSnap) => docSnap.data()), startDate, endDate, granularity),
+  };
 }
 
 export async function getEntitySummaries(
@@ -573,6 +617,10 @@ export async function getReviewsForOverviewSelection(
     return getThemeSelectionReviews(brand, startDate, endDate, filter);
   }
 
+  if (filter.kind === "period") {
+    return getPeriodSelectionReviews(brand, filter.start, filter.end);
+  }
+
   if (filter.kind === "month") {
     return getMonthSelectionReviews(brand, filter.month);
   }
@@ -607,6 +655,9 @@ function matchesOverviewSelection(data: DocumentData, filter: OverviewSelectionF
   }
 
   const created = typeof data.dates?.created === "string" ? data.dates.created : "";
+  if (filter.kind === "period") {
+    return created >= filter.start && created < filter.end;
+  }
   return created.startsWith(filter.month);
 }
 
@@ -619,6 +670,192 @@ function getMonthBounds(month: string): { start: string; end: string } {
     start: start.toISOString(),
     end: end.toISOString(),
   };
+}
+
+function getRangeLengthInDays(startDate: Date, endDate: Date): number {
+  const start = Date.UTC(
+    startDate.getUTCFullYear(),
+    startDate.getUTCMonth(),
+    startDate.getUTCDate()
+  );
+  const end = Date.UTC(
+    endDate.getUTCFullYear(),
+    endDate.getUTCMonth(),
+    endDate.getUTCDate()
+  );
+
+  return Math.max(1, Math.floor((end - start) / 86400000) + 1);
+}
+
+function toUtcDayKey(value: Date | string): string {
+  const date = typeof value === "string" ? new Date(value) : value;
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(
+    date.getUTCDate()
+  ).padStart(2, "0")}`;
+}
+
+function parseUtcDayKey(dayKey: string): Date {
+  return new Date(`${dayKey}T00:00:00.000Z`);
+}
+
+function addUtcDays(dayKey: string, amount: number): string {
+  const date = parseUtcDayKey(dayKey);
+  date.setUTCDate(date.getUTCDate() + amount);
+  return toUtcDayKey(date);
+}
+
+function getUtcWeekStartKey(value: Date | string): string {
+  const date = typeof value === "string" ? new Date(value) : value;
+  const utcDate = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate())
+  );
+  const day = utcDate.getUTCDay();
+  const offset = day === 0 ? -6 : 1 - day;
+  utcDate.setUTCDate(utcDate.getUTCDate() + offset);
+  return toUtcDayKey(utcDate);
+}
+
+function addUtcWeeks(dayKey: string, amount: number): string {
+  return addUtcDays(dayKey, amount * 7);
+}
+
+function toUtcMonthKey(value: Date | string): string {
+  const date = typeof value === "string" ? new Date(value) : value;
+  return `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function parseUtcMonthKey(monthKey: string): Date {
+  return new Date(`${monthKey}-01T00:00:00.000Z`);
+}
+
+function addUtcMonths(monthKey: string, amount: number): string {
+  const date = parseUtcMonthKey(monthKey);
+  date.setUTCMonth(date.getUTCMonth() + amount);
+  return toUtcMonthKey(date);
+}
+
+function formatPeriodLabel(
+  granularity: TrendGranularity,
+  periodStart: string,
+  periodEnd: string
+): { label: string; fullLabel: string } {
+  if (granularity === "day") {
+    const start = parseUtcDayKey(periodStart);
+    return {
+      label: format(start, "MMM d"),
+      fullLabel: format(start, "MMM d, yyyy"),
+    };
+  }
+
+  if (granularity === "week") {
+    const start = parseUtcDayKey(periodStart);
+    const exclusiveEnd = parseUtcDayKey(periodEnd);
+    const inclusiveEnd = new Date(exclusiveEnd);
+    inclusiveEnd.setUTCDate(inclusiveEnd.getUTCDate() - 1);
+    return {
+      label: format(start, "MMM d"),
+      fullLabel: `${format(start, "MMM d")} - ${format(inclusiveEnd, "MMM d, yyyy")}`,
+    };
+  }
+
+  const start = parseUtcMonthKey(periodStart);
+  return {
+    label: format(start, "MMM yy"),
+    fullLabel: format(start, "MMMM yyyy"),
+  };
+}
+
+function buildAdaptiveTrendPoints(
+  docs: DocumentData[],
+  startDate: Date,
+  endDate: Date,
+  granularity: Extract<TrendGranularity, "day" | "week">
+): TrendPoint[] {
+  const bucketStats = new Map<string, { ratingSum: number; ratingCount: number; reviewCount: number }>();
+  const rangeStartKey = granularity === "day" ? toUtcDayKey(startDate) : getUtcWeekStartKey(startDate);
+  const rangeEndKey = granularity === "day" ? toUtcDayKey(endDate) : getUtcWeekStartKey(endDate);
+  const selectedStartIso = startDate.toISOString();
+  const selectedEndExclusiveIso = `${addUtcDays(toUtcDayKey(endDate), 1)}T00:00:00.000Z`;
+
+  for (const data of docs) {
+    const created = typeof data.dates?.created === "string" ? data.dates.created : null;
+    if (!created) continue;
+
+    const bucketKey = granularity === "day" ? toUtcDayKey(created) : getUtcWeekStartKey(created);
+    const current = bucketStats.get(bucketKey) ?? { ratingSum: 0, ratingCount: 0, reviewCount: 0 };
+    const rating = data.ratings?.product ?? data.ratings?.service ?? null;
+
+    current.reviewCount += 1;
+    if (typeof rating === "number" && Number.isFinite(rating)) {
+      current.ratingSum += rating;
+      current.ratingCount += 1;
+    }
+    bucketStats.set(bucketKey, current);
+  }
+
+  const points: TrendPoint[] = [];
+  let bucketKey = rangeStartKey;
+  while (bucketKey <= rangeEndKey) {
+    const stats = bucketStats.get(bucketKey) ?? { ratingSum: 0, ratingCount: 0, reviewCount: 0 };
+    const nextBucketKey = granularity === "day" ? addUtcDays(bucketKey, 1) : addUtcWeeks(bucketKey, 1);
+    const rawPeriodStart = `${bucketKey}T00:00:00.000Z`;
+    const rawPeriodEnd = `${nextBucketKey}T00:00:00.000Z`;
+    const periodStart = rawPeriodStart < selectedStartIso ? selectedStartIso : rawPeriodStart;
+    const periodEnd = rawPeriodEnd > selectedEndExclusiveIso ? selectedEndExclusiveIso : rawPeriodEnd;
+    const labels = formatPeriodLabel(
+      granularity,
+      toUtcDayKey(periodStart),
+      toUtcDayKey(periodEnd)
+    );
+
+    points.push({
+      key: bucketKey,
+      label: labels.label,
+      fullLabel: labels.fullLabel,
+      averageRating:
+        stats.ratingCount > 0
+          ? Math.round((stats.ratingSum / stats.ratingCount) * 100) / 100
+          : null,
+      reviewCount: stats.reviewCount,
+      periodStart,
+      periodEnd,
+    });
+
+    bucketKey = nextBucketKey;
+  }
+
+  return points;
+}
+
+function buildMonthlyTrendPoints(
+  monthly: MonthlySummary[],
+  startDate: Date,
+  endDate: Date
+): TrendPoint[] {
+  const statsByMonth = new Map(monthly.map((entry) => [entry.month, entry]));
+  const points: TrendPoint[] = [];
+  let monthKey = toUtcMonthKey(startDate);
+  const endMonthKey = toUtcMonthKey(endDate);
+
+  while (monthKey <= endMonthKey) {
+    const stats = statsByMonth.get(monthKey);
+    const nextMonthKey = addUtcMonths(monthKey, 1);
+    const labels = formatPeriodLabel("month", monthKey, nextMonthKey);
+
+    points.push({
+      key: monthKey,
+      label: labels.label,
+      fullLabel: labels.fullLabel,
+      averageRating: stats ? stats.averageRating : null,
+      reviewCount: stats?.reviewCount ?? 0,
+      periodStart: `${monthKey}-01T00:00:00.000Z`,
+      periodEnd: `${nextMonthKey}-01T00:00:00.000Z`,
+    });
+
+    monthKey = nextMonthKey;
+  }
+
+  return points;
 }
 
 function buildDateRangeConstraints(
@@ -666,11 +903,19 @@ async function getThemeSelectionReviews(
 }
 
 async function getMonthSelectionReviews(brand: string, month: string): Promise<ThemeReview[]> {
+  const bounds = getMonthBounds(month);
+  return getPeriodSelectionReviews(brand, bounds.start, bounds.end);
+}
+
+async function getPeriodSelectionReviews(
+  brand: string,
+  periodStart: string,
+  periodEnd: string
+): Promise<ThemeReview[]> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
-  const bounds = getMonthBounds(month);
   const constraints = [
-    ...buildDateRangeConstraints(brand, bounds.start, bounds.end, "<"),
+    ...buildDateRangeConstraints(brand, periodStart, periodEnd, "<"),
     limit(PANEL_REVIEW_LIMIT),
   ];
   const snap = await getDocs(query(ref, ...constraints));


### PR DESCRIPTION
## Summary
- make overview trend charts adapt their granularity to the selected time range
- use daily buckets for short ranges, weekly buckets for medium ranges, and monthly buckets for longer ranges
- preserve click-through review drilldowns for each visible chart period

## Testing
- npm run build (app)