### PR TITLE
Restore spinner animation

### DIFF
--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -220,3 +220,18 @@ body {
 .animate-slide-in-right {
   animation: slide-in-right 0.25s ease-out;
 }
+
+@keyframes app-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.animate-spin {
+  animation: app-spin 0.8s linear infinite;
+  transform-origin: center;
+  will-change: transform;
+}


### PR DESCRIPTION
## Summary
- add a global fallback spin keyframe so loader rings animate consistently again
- keep the fix centralized in globals so existing loaders and refresh icons keep working without per-component changes

## Testing
- npm run build (app)