### PR TITLE
Condense mobile navigation for better mobile UX

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -29,7 +29,7 @@
         "typescript": "^5"
       },
       "engines": {
-        "node": "20.x"
+        "node": "20"
       }
     },
     "node_modules/@algolia/abtesting": {

--- a/app/src/components/layout/AuthButton.tsx
+++ b/app/src/components/layout/AuthButton.tsx
@@ -136,7 +136,23 @@ export default function AuthButton({
             : "border border-white/20 bg-white/10 text-white hover:bg-white/20"
         }`}
       >
-        {busy ? "Working..." : user ? "Sign Out" : "Sign In"}
+        <span className="hidden sm:inline">{busy ? "Working..." : user ? "Sign Out" : "Sign In"}</span>
+        <svg
+          className="h-4 w-4 sm:hidden"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d={user
+              ? "M15.75 9V5.25A2.25 2.25 0 0013.5 3h-6a2.25 2.25 0 00-2.25 2.25v13.5A2.25 2.25 0 007.5 21h6a2.25 2.25 0 002.25-2.25V15m3 0l3-3m0 0l-3-3m3 3H9"
+              : "M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z"
+            }
+          />
+        </svg>
       </button>
       {error ? (
         <span

--- a/app/src/components/layout/Header.tsx
+++ b/app/src/components/layout/Header.tsx
@@ -7,20 +7,18 @@ import ThemeToggle from "./ThemeToggle";
 export default function Header() {
   return (
     <header className="bg-[#1B3A5C] text-white shadow-md">
-      <div className="mx-auto max-w-7xl px-4 py-3 sm:px-6 lg:px-8">
-        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:gap-4">
-            <div className="flex items-center gap-3">
-              <h1 className="whitespace-nowrap text-lg font-semibold tracking-wide text-white">
-                Feefo Reviews
-              </h1>
-            </div>
-            <BrandSwitcher />
-          </div>
-          <div className="flex items-center justify-end gap-2">
+      <div className="mx-auto max-w-7xl px-4 py-2 sm:px-6 sm:py-3 lg:px-8">
+        <div className="flex items-center justify-between gap-3 md:gap-4">
+          <h1 className="whitespace-nowrap text-base font-semibold tracking-wide text-white sm:text-lg">
+            Feefo Reviews
+          </h1>
+          <div className="flex items-center gap-2">
             <DateRangePicker />
             <ThemeToggle />
           </div>
+        </div>
+        <div className="mt-2">
+          <BrandSwitcher />
         </div>
       </div>
     </header>

--- a/app/src/components/layout/Navigation.tsx
+++ b/app/src/components/layout/Navigation.tsx
@@ -105,9 +105,9 @@ export default function Navigation() {
   return (
     <nav className="border-b border-gray-200 bg-white shadow-sm dark:bg-[#111927] dark:border-[#1e2d44]">
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="flex flex-col gap-3 py-2.5 lg:flex-row lg:items-center lg:justify-between">
+        <div className="flex items-center justify-between gap-2 py-1.5 sm:py-2.5">
           <div className="min-w-0">
-            <div className="flex flex-wrap items-center gap-1">
+            <div className="flex items-center gap-0.5 sm:gap-1">
               {tabs.map(({ href, label }) => {
                 const isActive =
                   href === "/" ? pathname === "/" : pathname.startsWith(href);
@@ -116,7 +116,7 @@ export default function Navigation() {
                   <Link
                     key={href}
                     href={href}
-                    className={`relative whitespace-nowrap rounded-md px-4 py-2.5 text-sm font-medium transition-colors sm:px-5 ${
+                    className={`relative whitespace-nowrap rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors sm:px-4 sm:py-2.5 sm:text-sm ${
                       isActive
                         ? "font-semibold text-[#1B3A5C] dark:text-white"
                         : "text-gray-500 hover:text-[#1B3A5C] dark:text-white/60 dark:hover:text-white"
@@ -132,7 +132,7 @@ export default function Navigation() {
             </div>
           </div>
 
-          <div className="flex flex-wrap items-center gap-2 lg:justify-end">
+          <div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
             {showAuthControls ? <RefreshButton tone="neutral" showSyncLabel /> : null}
             {showAuthControls ? (
               <AuthButton tone="neutral" showEmail={false} showStatus={false} />

--- a/app/src/components/layout/RefreshButton.tsx
+++ b/app/src/components/layout/RefreshButton.tsx
@@ -183,7 +183,7 @@ export default function RefreshButton({
             d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.992 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182M20.015 4.356v4.992"
           />
         </svg>
-        {syncing ? "Syncing..." : "Refresh"}
+        <span className="hidden sm:inline">{syncing ? "Syncing..." : "Refresh"}</span>
       </button>
       {message ? (
         <span


### PR DESCRIPTION
## Summary

- **Header**: Restructured to put title + date picker + theme toggle on one row, with brand switcher on a compact second row (previously stacked across 3 rows on mobile)
- **Navigation**: Tabs and action buttons (Refresh, Sign In) now sit in a single horizontal row instead of stacking vertically on mobile
- **Compact sizing**: Reduced padding, font sizes, and gaps on mobile (scales back up at `sm` breakpoint)
- **Icon-only buttons on mobile**: Refresh and Sign In buttons show only icons on small screens, with full text labels appearing at `sm+`

These changes reduce the sticky header/nav from ~5 visual rows to ~3 on iPhone 16 Pro, giving significantly more content area without losing any functionality.

## Test plan

- [ ] Verify on iPhone 16 Pro (393pt width) that all nav elements are visible and tappable
- [ ] Verify brand switcher pills are accessible and highlight correctly
- [ ] Verify date picker dropdown opens correctly and doesn't clip off-screen
- [ ] Verify tab navigation underline indicator works on all tabs
- [ ] Verify Refresh and Sign In icon buttons are recognizable on mobile
- [ ] Verify layout scales correctly at `sm` (640px) and `md` (768px) breakpoints
- [ ] Verify dark mode styling is preserved
- [ ] Verify desktop layout is not regressed

https://claude.ai/code/session_01DFammupVAX4mb9DRzfhFJb