### PR TITLE
Fix brand switcher stretching full width on mobile

### DIFF
--- a/app/src/components/layout/BrandSwitcher.tsx
+++ b/app/src/components/layout/BrandSwitcher.tsx
@@ -12,7 +12,7 @@ export default function BrandSwitcher() {
   const { brand, setBrand } = useDashboard();
 
   return (
-    <div className="flex items-center rounded-full bg-white/10 p-0.5">
+    <div className="inline-flex items-center rounded-full bg-white/10 p-0.5">
       {brands.map(({ value, label }) => (
         <button
           key={value}


### PR DESCRIPTION
## Summary

- Changed brand switcher container from `flex` to `inline-flex` so it hugs the pill buttons instead of stretching the full width of the header, eliminating the awkward empty space on the right side on mobile

## Test plan

- [ ] Verify brand switcher pills are snug against each other without trailing empty space
- [ ] Verify all three brand options are still tappable and highlight correctly
- [ ] Verify no regression on larger screens

https://claude.ai/code/session_01DFammupVAX4mb9DRzfhFJb