### PR TITLE
Add Azure AD tenant ID for Microsoft SSO

### DIFF
--- a/app/src/components/layout/AuthButton.tsx
+++ b/app/src/components/layout/AuthButton.tsx
@@ -54,6 +54,9 @@ export default function AuthButton({
     try {
       const auth = getClientAuth();
       const provider = new OAuthProvider("microsoft.com");
+      provider.setCustomParameters({
+        tenant: "c8e16ff7-b48e-48dc-8e88-56ca27c5c21c",
+      });
       await signInWithPopup(auth, provider);
     } catch (err) {
       setError(


### PR DESCRIPTION
## Summary
- Add `tenant` custom parameter to the Microsoft OAuthProvider to support single-tenant Azure AD app registration
- Without this, Firebase sends auth requests to the common Microsoft endpoint which returns a 400 error

## Test plan
- [ ] Sign in with Microsoft account and verify popup completes successfully
- [ ] Verify admin panel access with owner role

🤖 Generated with [Claude Code](https://claude.com/claude-code)