### PR TITLE
Fix TypeScript error in ThemeContext server snapshot

### DIFF
--- a/app/src/contexts/ThemeContext.tsx
+++ b/app/src/contexts/ThemeContext.tsx
@@ -63,7 +63,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const theme = useSyncExternalStore(
     subscribeToTheme,
     readThemeSnapshot,
-    () => "light"
+    (): Theme => "light"
   );
 
   // Apply class to document


### PR DESCRIPTION
## Summary
- Add explicit `Theme` return type to the `useSyncExternalStore` server snapshot function
- Fixes deploy failure caused by TypeScript inferring `string` instead of `Theme` from `() => "light"`

## Context
PR #30 deploy failed with: `Type 'string' is not assignable to type 'Theme'`

## Test plan
- [ ] Verify deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)