### PR TITLE
Phase 1: Theme engine, Uniworld Journeys reskin & responsive header

### DIFF
--- a/app/public/theme-init.js
+++ b/app/public/theme-init.js
@@ -1,14 +1,114 @@
+/**
+ * theme-init.js — runs beforeInteractive to prevent flash of unstyled content.
+ *
+ * Responsibilities:
+ *  1. Read the user's saved theme preference (or system preference).
+ *  2. Apply the correct CSS custom property set for the active brand + mode
+ *     BEFORE React mounts, so there is no visual flash.
+ *  3. Set the .dark class and color-scheme so Tailwind dark: variants fire
+ *     correctly on first paint.
+ *
+ * Phase 1: token values are baked in for Uniworld Journeys (the only tenant).
+ * Phase 2: replace the hardcoded LIGHT/DARK maps with a small async fetch
+ *   from /api/brand-tokens?brand=<brandId> and re-run applyVars() on resolve.
+ *
+ * ⚠️  This file cannot import ES modules. All logic must be plain ES5-compatible JS.
+ */
 (function () {
+  // ---------------------------------------------------------------------------
+  // Uniworld Journeys — derived CSS variable sets (computed from 6 brand tokens)
+  //
+  // Tokens:
+  //   primary:     #373535   primaryDark: #1e1c1c
+  //   accent:      #c2ab82   accentLight: #e7d39c
+  //   neutral:     #655e51   surfaceWarm: #f1eeea
+  // ---------------------------------------------------------------------------
+
+  var LIGHT = {
+    "--background":           "#f1eeea",
+    "--foreground":           "#373535",
+    "--surface":              "#ffffff",
+    "--surface-hover":        "#f7f5f2",
+    "--surface-alt":          "#f4f1ee",
+    "--border":               "rgba(101,94,81,0.2)",
+    "--border-light":         "rgba(101,94,81,0.1)",
+    "--text-primary":         "#1e1c1c",
+    "--text-secondary":       "#655e51",
+    "--text-tertiary":        "#9d988e",
+    "--header-bg":            "#373535",
+    "--header-text":          "#ffffff",
+    "--nav-active-text":      "#373535",
+    "--nav-active-indicator": "#c2ab82",
+    "--nav-inactive-text":    "#655e51",
+    "--brand-accent":         "#c2ab82",
+    "--brand-accent-light":   "#e7d39c",
+    "--brand-accent-hover":   "rgba(194,171,130,0.1)",
+    "--brand-primary-hover":  "rgba(55,53,53,0.05)",
+    "--brand-primary-light":  "rgba(55,53,53,0.1)",
+    "--input-bg":             "#ffffff",
+    "--input-border":         "#c7c3bc",
+    "--badge-gray-bg":        "#c7c3bc",
+    "--badge-gray-text":      "#655e51",
+    "--spinner-track":        "#9d988e",
+    "--spinner-accent":       "#c2ab82",
+    "--nav-bg":               "#ffffff",
+    "--nav-border":           "rgba(101,94,81,0.2)",
+    "--shadow-sm":            "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+    "--shadow":               "0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)"
+  };
+
+  var DARK = {
+    "--background":           "#1e1c1c",
+    "--foreground":           "#f1eeea",
+    "--surface":              "#2f2d2c",
+    "--surface-hover":        "#3e3c3b",
+    "--surface-alt":          "#292726",
+    "--border":               "#302d29",
+    "--border-light":         "#292624",
+    "--text-primary":         "#f1eeea",
+    "--text-secondary":       "#b9b4ad",
+    "--text-tertiary":        "#655e51",
+    "--header-bg":            "#1e1c1c",
+    "--header-text":          "#f1eeea",
+    "--nav-active-text":      "#f1eeea",
+    "--nav-active-indicator": "#c2ab82",
+    "--nav-inactive-text":    "#9d9a98",
+    "--brand-accent":         "#e7d39c",
+    "--brand-accent-light":   "#e7d39c",
+    "--brand-accent-hover":   "rgba(231,211,156,0.1)",
+    "--brand-primary-hover":  "rgba(231,211,156,0.08)",
+    "--brand-primary-light":  "rgba(231,211,156,0.15)",
+    "--input-bg":             "#2f2d2c",
+    "--input-border":         "#37332f",
+    "--badge-gray-bg":        "#2c2927",
+    "--badge-gray-text":      "#b9b4ad",
+    "--spinner-track":        "#2c2927",
+    "--spinner-accent":       "#e7d39c",
+    "--nav-bg":               "#292726",
+    "--nav-border":           "#302d29",
+    "--shadow-sm":            "0 1px 2px 0 rgb(0 0 0 / 0.3)",
+    "--shadow":               "0 1px 3px 0 rgb(0 0 0 / 0.4), 0 1px 2px -1px rgb(0 0 0 / 0.3)"
+  };
+
+  function applyVars(vars) {
+    var root = document.documentElement;
+    var keys = Object.keys(vars);
+    for (var i = 0; i < keys.length; i++) {
+      root.style.setProperty(keys[i], vars[keys[i]]);
+    }
+  }
+
   try {
     var theme = localStorage.getItem("theme");
     var prefersDark =
-      window.matchMedia &&
-      window.matchMedia("(prefers-color-scheme: dark)").matches;
+      window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
     var shouldUseDark = theme === "dark" || (!theme && prefersDark);
 
     document.documentElement.classList.toggle("dark", shouldUseDark);
     document.documentElement.style.colorScheme = shouldUseDark ? "dark" : "light";
-  } catch {
-    // Ignore client-side storage/theme bootstrap failures.
+
+    applyVars(shouldUseDark ? DARK : LIGHT);
+  } catch (e) {
+    // Ignore storage/matchMedia failures (e.g. SSR, restrictive CSP).
   }
 })();

--- a/app/src/app/admin/logs/page.tsx
+++ b/app/src/app/admin/logs/page.tsx
@@ -126,7 +126,7 @@ export default function AdminLogsPage() {
   if (!authResolved || checkingAccess) {
     return (
       <div className="flex items-center justify-center py-24">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-[#1B3A5C]" />
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent" />
       </div>
     );
   }
@@ -135,15 +135,15 @@ export default function AdminLogsPage() {
     <div>
       <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <div className="mb-2 text-sm font-medium text-gray-500">
-            <Link href="/admin" className="hover:text-[#1B3A5C] hover:underline">
+          <div className="mb-2 text-sm font-medium text-text-secondary">
+            <Link href="/admin" className="hover:text-text-primary hover:underline">
               Admin
             </Link>
-            <span className="mx-2 text-gray-300">/</span>
+            <span className="mx-2 text-text-tertiary">/</span>
             Logs
           </div>
-          <h1 className="text-2xl font-semibold text-[#1B3A5C]">Operational Logs</h1>
-          <p className="mt-1 text-sm text-gray-500">
+          <h1 className="text-2xl font-semibold text-text-primary">Operational Logs</h1>
+          <p className="mt-1 text-sm text-text-secondary">
             Review sync, classification, and summary activity.
           </p>
         </div>
@@ -152,7 +152,7 @@ export default function AdminLogsPage() {
           <select
             value={range}
             onChange={(event) => setRange(event.target.value as RangeFilter)}
-            className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm"
+            className="rounded-lg border border-input-border bg-surface px-3 py-2 text-sm"
           >
             <option value="24h">Last 24 hours</option>
             <option value="7d">Last 7 days</option>
@@ -162,7 +162,7 @@ export default function AdminLogsPage() {
           <select
             value={typeFilter}
             onChange={(event) => setTypeFilter(event.target.value as TypeFilter)}
-            className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm"
+            className="rounded-lg border border-input-border bg-surface px-3 py-2 text-sm"
           >
             <option value="all">All types</option>
             <option value="sync">Sync</option>
@@ -171,7 +171,7 @@ export default function AdminLogsPage() {
           </select>
           <button
             onClick={() => loadLogs(range)}
-            className="inline-flex items-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+            className="inline-flex items-center rounded-lg border border-input-border bg-surface px-4 py-2 text-sm font-medium text-text-primary shadow-sm hover:bg-surface-hover"
           >
             Refresh Logs
           </button>

--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { onAuthStateChanged, type User } from "firebase/auth";
 import { useRouter } from "next/navigation";
 import { useDashboard } from "@/contexts/DashboardContext";
+import { useBrand } from "@/contexts/BrandContext";
 import { getClientAuth, getClientDb } from "@/lib/firebase";
 import { collection, query, where, getDocs, orderBy, QueryConstraint } from "firebase/firestore";
 import {
@@ -63,7 +64,7 @@ function StatusBadge({ mapping }: { mapping: ItineraryMapping }) {
     );
   }
   return (
-    <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">
+    <span className="inline-flex items-center rounded-full bg-surface-alt px-2 py-0.5 text-xs font-medium text-text-secondary">
       Unchanged
     </span>
   );
@@ -78,13 +79,14 @@ function getStatus(m: ItineraryMapping): "auto" | "manual" | "unchanged" {
 const STATUS_ORDER = { manual: 0, auto: 1, unchanged: 2 };
 
 function SortIndicator({ active, dir }: { active: boolean; dir: SortDir }) {
-  if (!active) return <span className="ml-1 text-gray-300">{"\u2195"}</span>;
+  if (!active) return <span className="ml-1 text-text-tertiary">{"\u2195"}</span>;
   return <span className="ml-1">{dir === "asc" ? "\u2191" : "\u2193"}</span>;
 }
 
 export default function AdminPage() {
   const router = useRouter();
-  const { brand, dateRange, dataVersion } = useDashboard();
+  const { merchantQueryId: brand } = useBrand();
+  const { dateRange, dataVersion } = useDashboard();
   const [user, setUser] = useState<User | null>(null);
   const [authResolved, setAuthResolved] = useState(false);
   const [currentAccess, setCurrentAccess] = useState<CurrentAdminAccess | null>(null);
@@ -515,7 +517,7 @@ export default function AdminPage() {
   if (!authResolved || checkingPageAccess) {
     return (
       <div className="flex items-center justify-center py-24">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-[#1B3A5C]" />
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent" />
       </div>
     );
   }
@@ -523,33 +525,33 @@ export default function AdminPage() {
   return (
     <div>
       {canManageUsers ? (
-      <div className="mb-8 rounded-xl border border-gray-200 bg-white shadow-sm">
-        <div className="border-b border-gray-200 px-6 py-5">
-          <h2 className="text-xl font-semibold text-[#1B3A5C]">Access Control</h2>
-          <p className="mt-1 text-sm text-gray-500">
+      <div className="mb-8 rounded-xl border border-border bg-surface shadow-sm">
+        <div className="border-b border-border px-6 py-5">
+          <h2 className="text-xl font-semibold text-text-primary">Access Control</h2>
+          <p className="mt-1 text-sm text-text-secondary">
             Owners can promote people who have signed in and manage who is allowed to sync
             data and use protected admin actions.
           </p>
         </div>
         <div className="grid gap-6 px-6 py-5 lg:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
           <div>
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-text-secondary">
               Current Access
             </h3>
-            <div className="mt-4 overflow-x-auto rounded-lg border border-gray-200">
+            <div className="mt-4 overflow-x-auto rounded-lg border border-border">
               {adminUsersLoading ? (
                 <div className="flex items-center justify-center py-12">
-                  <div className="h-6 w-6 animate-spin rounded-full border-4 border-gray-200 border-t-[#1B3A5C]" />
+                  <div className="h-6 w-6 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent" />
                 </div>
               ) : adminUsers.length === 0 ? (
-                <div className="px-4 py-6 text-sm text-gray-500">
+                <div className="px-4 py-6 text-sm text-text-secondary">
                   No admin users are configured yet. Add your first owner in Firestore or
                   after bootstrap use the form on the right.
                 </div>
               ) : (
                 <table className="w-full text-sm">
                   <thead>
-                    <tr className="bg-gray-50 text-left text-gray-500">
+                    <tr className="bg-surface-alt text-left text-text-secondary">
                       <th className="px-4 py-3 font-medium">Email</th>
                       <th className="px-4 py-3 font-medium">Role</th>
                       <th className="px-4 py-3 font-medium">Status</th>
@@ -559,10 +561,10 @@ export default function AdminPage() {
                   </thead>
                   <tbody>
                     {adminUsers.map((user) => (
-                      <tr key={user.email} className="border-t border-gray-100">
-                        <td className="px-4 py-3 text-gray-900">{user.email}</td>
+                      <tr key={user.email} className="border-t border-border">
+                        <td className="px-4 py-3 text-text-primary">{user.email}</td>
                         <td className="px-4 py-3">
-                          <span className="inline-flex rounded-full bg-[#1B3A5C]/10 px-2 py-0.5 text-xs font-medium capitalize text-[#1B3A5C]">
+                          <span className="inline-flex rounded-full bg-brand-primary-light px-2 py-0.5 text-xs font-medium capitalize text-text-primary">
                             {user.role}
                           </span>
                         </td>
@@ -571,13 +573,13 @@ export default function AdminPage() {
                             className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
                               user.active
                                 ? "bg-emerald-100 text-emerald-700"
-                                : "bg-gray-100 text-gray-500"
+                                : "bg-surface-alt text-text-secondary"
                             }`}
                           >
                             {user.active ? "Active" : "Inactive"}
                           </span>
                         </td>
-                        <td className="px-4 py-3 text-gray-500">
+                        <td className="px-4 py-3 text-text-secondary">
                           {user.updatedAt
                             ? new Date(user.updatedAt).toLocaleString()
                             : "—"}
@@ -600,13 +602,13 @@ export default function AdminPage() {
           </div>
 
           <div>
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-text-secondary">
               Grant Or Update Access
             </h3>
-            <div className="mt-4 rounded-lg border border-gray-200 bg-gray-50 p-4">
+            <div className="mt-4 rounded-lg border border-border bg-surface-alt p-4">
               <div className="space-y-4">
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-gray-700">
+                  <label className="mb-1 block text-sm font-medium text-text-primary">
                     Signed-in users
                   </label>
                   <select
@@ -619,7 +621,7 @@ export default function AdminPage() {
                       setAccessRole(selected?.role ?? "sync");
                       e.target.value = "";
                     }}
-                    className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#1B3A5C]/30"
+                    className="w-full rounded-lg border border-input-border bg-surface px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-accent/30"
                   >
                     <option value="">Choose a user who has already signed in</option>
                     {knownUsers.map((knownUser) => {
@@ -633,7 +635,7 @@ export default function AdminPage() {
                       );
                     })}
                   </select>
-                  <p className="mt-2 text-xs text-gray-500">
+                  <p className="mt-2 text-xs text-text-secondary">
                     {knownUsersLoading
                       ? "Loading signed-in users..."
                       : knownUsers.length > 0
@@ -642,7 +644,7 @@ export default function AdminPage() {
                   </p>
                 </div>
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-gray-700">
+                  <label className="mb-1 block text-sm font-medium text-text-primary">
                     Email
                   </label>
                   <input
@@ -650,12 +652,12 @@ export default function AdminPage() {
                     value={accessEmail}
                     onChange={(e) => setAccessEmail(e.target.value)}
                     placeholder="name@company.com"
-                    className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#1B3A5C]/30"
+                    className="w-full rounded-lg border border-input-border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-accent/30"
                   />
                 </div>
                 {knownUsers.length > 0 ? (
-                  <div className="rounded-lg bg-white p-3">
-                    <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">
+                  <div className="rounded-lg bg-surface p-3">
+                    <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-secondary">
                       Recent Sign-Ins
                     </div>
                     <div className="flex flex-wrap gap-2">
@@ -667,7 +669,7 @@ export default function AdminPage() {
                             setAccessEmail(knownUser.email);
                             setAccessRole(knownUser.role ?? "sync");
                           }}
-                          className="rounded-full border border-gray-200 bg-gray-50 px-3 py-1.5 text-xs text-gray-700 hover:bg-gray-100"
+                          className="rounded-full border border-border bg-surface-alt px-3 py-1.5 text-xs text-text-primary hover:bg-surface-alt"
                           title={
                             knownUser.lastSeenAt
                               ? `Last seen ${new Date(knownUser.lastSeenAt).toLocaleString()}`
@@ -682,37 +684,37 @@ export default function AdminPage() {
                   </div>
                 ) : null}
                 <div>
-                  <label className="mb-1 block text-sm font-medium text-gray-700">
+                  <label className="mb-1 block text-sm font-medium text-text-primary">
                     Role
                   </label>
                   <select
                     value={accessRole}
                     onChange={(e) => setAccessRole(e.target.value as AdminRole)}
-                    className="w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#1B3A5C]/30"
+                    className="w-full rounded-lg border border-input-border bg-surface px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-accent/30"
                   >
                     <option value="sync">Sync Operator</option>
                     <option value="admin">Admin</option>
                     <option value="owner">Owner</option>
                   </select>
                 </div>
-                <div className="rounded-lg bg-white p-3 text-xs leading-5 text-gray-500">
+                <div className="rounded-lg bg-surface p-3 text-xs leading-5 text-text-secondary">
                   <p>
-                    <strong className="text-gray-700">Sync Operator</strong>: can run
+                    <strong className="text-text-primary">Sync Operator</strong>: can run
                     data syncs and classification.
                   </p>
                   <p className="mt-2">
-                    <strong className="text-gray-700">Admin</strong>: can sync data and
+                    <strong className="text-text-primary">Admin</strong>: can sync data and
                     manage itinerary grouping tools.
                   </p>
                   <p className="mt-2">
-                    <strong className="text-gray-700">Owner</strong>: full access,
+                    <strong className="text-text-primary">Owner</strong>: full access,
                     including managing who else gets access.
                   </p>
                 </div>
                 <button
                   onClick={handleGrantAccess}
                   disabled={savingAccess}
-                  className="inline-flex items-center rounded-lg bg-[#1B3A5C] px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-[#1B3A5C]/90 disabled:opacity-50"
+                  className="inline-flex items-center rounded-lg bg-header-bg px-4 py-2 text-sm font-medium text-header-text shadow-sm hover:opacity-90 disabled:opacity-50"
                 >
                   {savingAccess ? "Saving..." : "Save Access"}
                 </button>
@@ -724,8 +726,8 @@ export default function AdminPage() {
       ) : null}
 
       {canViewLogs ? (
-        <div className="mb-8 rounded-xl border border-gray-200 bg-white shadow-sm">
-          <div className="border-b border-gray-200 px-6 py-5">
+        <div className="mb-8 rounded-xl border border-border bg-surface shadow-sm">
+          <div className="border-b border-border px-6 py-5">
             <div className="flex flex-wrap items-start justify-between gap-4">
               <button
                 type="button"
@@ -734,16 +736,16 @@ export default function AdminPage() {
                 className="min-w-0 flex-1 text-left"
               >
                 <div>
-                  <h2 className="text-xl font-semibold text-[#1B3A5C]">Operational Logs</h2>
-                  <p className="mt-1 text-sm text-gray-500">
+                  <h2 className="text-xl font-semibold text-text-primary">Operational Logs</h2>
+                  <p className="mt-1 text-sm text-text-secondary">
                     {getLogsRangeLabel(logsRangeHours)} of sync, classification, and
                     summary activity.
                   </p>
                 </div>
               </button>
               <div className="flex flex-wrap items-center justify-end gap-2">
-                <label className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm">
-                  <span className="text-xs font-medium uppercase tracking-wide text-gray-500">
+                <label className="inline-flex items-center gap-2 rounded-lg border border-input-border bg-surface px-3 py-2 text-sm text-text-primary shadow-sm">
+                  <span className="text-xs font-medium uppercase tracking-wide text-text-secondary">
                     Range
                   </span>
                   <select
@@ -751,7 +753,7 @@ export default function AdminPage() {
                     onChange={(event) =>
                       setLogsRangeHours(Number(event.target.value) as LogsRangeHours)
                     }
-                    className="bg-transparent text-sm font-medium text-gray-700 focus:outline-none"
+                    className="bg-transparent text-sm font-medium text-text-primary focus:outline-none"
                   >
                     {LOG_RANGE_OPTIONS.map((option) => (
                       <option key={option.value} value={option.value}>
@@ -762,13 +764,13 @@ export default function AdminPage() {
                 </label>
                 <button
                   onClick={() => loadOperationLogs()}
-                  className="inline-flex items-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+                  className="inline-flex items-center rounded-lg border border-input-border bg-surface px-4 py-2 text-sm font-medium text-text-primary shadow-sm hover:bg-surface-hover"
                 >
                   Refresh Logs
                 </button>
                 <Link
                   href="/admin/logs"
-                  className="inline-flex items-center rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+                  className="inline-flex items-center rounded-lg border border-input-border bg-surface px-4 py-2 text-sm font-medium text-text-primary shadow-sm hover:bg-surface-hover"
                 >
                   View All Logs
                 </Link>
@@ -777,7 +779,7 @@ export default function AdminPage() {
                   onClick={() => setLogsExpanded((value) => !value)}
                   aria-expanded={logsExpanded}
                   aria-label={logsExpanded ? "Collapse operational logs" : "Expand operational logs"}
-                  className={`inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-gray-300 bg-white text-gray-500 shadow-sm transition-transform hover:bg-gray-50 ${
+                  className={`inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-input-border bg-surface text-text-secondary shadow-sm transition-transform hover:bg-surface-hover ${
                     logsExpanded ? "rotate-180" : ""
                   }`}
                 >
@@ -808,29 +810,29 @@ export default function AdminPage() {
       <>
       {/* Header */}
       <div className="mb-6">
-        <h1 className="text-2xl font-semibold text-[#1B3A5C]">Itinerary Grouping</h1>
-        <p className="mt-1 text-sm text-gray-500">
+        <h1 className="text-2xl font-semibold text-text-primary">Itinerary Grouping</h1>
+        <p className="mt-1 text-sm text-text-secondary">
           Manage how itinerary variants are grouped into parent itineraries
         </p>
       </div>
 
       {/* Stats */}
       <div className="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
-        <div className="rounded-lg border border-gray-200 bg-white p-3">
-          <div className="text-2xl font-bold text-[#1B3A5C]">{stats.total}</div>
-          <div className="text-xs text-gray-500">Raw Itineraries</div>
+        <div className="rounded-lg border border-border bg-surface p-3">
+          <div className="text-2xl font-bold text-text-primary">{stats.total}</div>
+          <div className="text-xs text-text-secondary">Raw Itineraries</div>
         </div>
-        <div className="rounded-lg border border-gray-200 bg-white p-3">
-          <div className="text-2xl font-bold text-[#1B3A5C]">{stats.grouped}</div>
-          <div className="text-xs text-gray-500">Parent Groups</div>
+        <div className="rounded-lg border border-border bg-surface p-3">
+          <div className="text-2xl font-bold text-text-primary">{stats.grouped}</div>
+          <div className="text-xs text-text-secondary">Parent Groups</div>
         </div>
-        <div className="rounded-lg border border-gray-200 bg-white p-3">
+        <div className="rounded-lg border border-border bg-surface p-3">
           <div className="text-2xl font-bold text-green-600">{stats.auto}</div>
-          <div className="text-xs text-gray-500">Auto-Grouped</div>
+          <div className="text-xs text-text-secondary">Auto-Grouped</div>
         </div>
-        <div className="rounded-lg border border-gray-200 bg-white p-3">
+        <div className="rounded-lg border border-border bg-surface p-3">
           <div className="text-2xl font-bold text-blue-600">{stats.manual}</div>
-          <div className="text-xs text-gray-500">Manual Overrides</div>
+          <div className="text-xs text-text-secondary">Manual Overrides</div>
         </div>
       </div>
 
@@ -839,10 +841,10 @@ export default function AdminPage() {
         <button
           onClick={handleRebuild}
           disabled={rebuilding}
-          className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 disabled:opacity-50"
+          className="inline-flex items-center gap-2 rounded-lg border border-input-border bg-surface px-4 py-2 text-sm font-medium text-text-primary shadow-sm hover:bg-surface-hover disabled:opacity-50"
         >
           {rebuilding ? (
-            <div className="h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600" />
+            <div className="h-4 w-4 animate-spin rounded-full border-2 border-input-border border-t-text-secondary" />
           ) : (
             <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
               <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
@@ -853,7 +855,7 @@ export default function AdminPage() {
         <button
           onClick={handleRecompute}
           disabled={recomputing}
-          className="inline-flex items-center gap-2 rounded-lg bg-[#1B3A5C] px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-[#1B3A5C]/90 disabled:opacity-50"
+          className="inline-flex items-center gap-2 rounded-lg bg-header-bg px-4 py-2 text-sm font-medium text-header-text shadow-sm hover:opacity-90 disabled:opacity-50"
         >
           {recomputing ? (
             <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
@@ -873,53 +875,53 @@ export default function AdminPage() {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Search itineraries..."
-          className="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#1B3A5C]/30"
+          className="flex-1 rounded-lg border border-input-border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-accent/30"
         />
         <select
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
-          className="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm"
+          className="rounded-lg border border-input-border bg-surface px-3 py-2 text-sm"
         >
           <option value="all">All statuses</option>
           <option value="auto">Auto-grouped</option>
           <option value="manual">Manual overrides</option>
           <option value="unchanged">Unchanged</option>
         </select>
-        <span className="text-sm text-gray-500 whitespace-nowrap">
+        <span className="text-sm text-text-secondary whitespace-nowrap">
           {filtered.length} of {mappings.length}
         </span>
       </div>
 
       {/* Table */}
-      <div className="rounded-lg border border-gray-200 bg-white shadow-sm overflow-x-auto">
+      <div className="rounded-lg border border-border bg-surface shadow-sm overflow-x-auto">
         {loading ? (
           <div className="flex items-center justify-center py-16">
-            <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-[#1B3A5C]" />
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent" />
           </div>
         ) : mappings.length === 0 ? (
           <div className="py-16 text-center">
-            <p className="text-gray-500">No mappings found. Click &ldquo;Rebuild Mappings&rdquo; to scan reviews.</p>
+            <p className="text-text-secondary">No mappings found. Click &ldquo;Rebuild Mappings&rdquo; to scan reviews.</p>
           </div>
         ) : (
           <table className="w-full text-sm min-w-[800px]">
             <thead>
-              <tr className="border-b border-gray-200 bg-gray-50">
+              <tr className="border-b border-border bg-surface-alt">
                 {columns.map((col) => (
                   <th
                     key={col.key}
-                    className={`px-4 py-3 font-medium text-gray-500 cursor-pointer select-none whitespace-nowrap ${col.align}`}
+                    className={`px-4 py-3 font-medium text-text-secondary cursor-pointer select-none whitespace-nowrap ${col.align}`}
                     onClick={() => handleSort(col.key)}
                   >
                     {col.label}
                     <SortIndicator active={sortKey === col.key} dir={sortDir} />
                   </th>
                 ))}
-                <th className="px-4 py-3 text-right font-medium text-gray-500">Actions</th>
+                <th className="px-4 py-3 text-right font-medium text-text-secondary">Actions</th>
               </tr>
             </thead>
             <tbody>
               {filtered.map((m) => (
-                <tr key={`${m.brand}-${m.rawName}`} className="border-b border-gray-100 hover:bg-gray-50">
+                <tr key={`${m.brand}-${m.rawName}`} className="border-b border-border hover:bg-surface-hover">
                   <td className="px-4 py-3">
                     {renamingRaw === m.rawName ? (
                       <div className="flex items-center gap-2">
@@ -944,16 +946,16 @@ export default function AdminPage() {
                         </button>
                         <button
                           onClick={() => setRenamingRaw(null)}
-                          className="rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 hover:bg-gray-50"
+                          className="rounded border border-input-border px-2 py-1 text-xs text-text-secondary hover:bg-surface-hover"
                         >
                           Cancel
                         </button>
                       </div>
                     ) : (
                       <>
-                        <div className="font-medium text-gray-900">{m.rawName}</div>
+                        <div className="font-medium text-text-primary">{m.rawName}</div>
                         {m.autoParentName !== m.rawName && !m.manualParentName && (
-                          <div className="text-xs text-gray-400 mt-0.5">auto: {m.autoParentName}</div>
+                          <div className="text-xs text-text-tertiary mt-0.5">auto: {m.autoParentName}</div>
                         )}
                       </>
                     )}
@@ -971,18 +973,18 @@ export default function AdminPage() {
                           }}
                           list="parent-names"
                           autoFocus
-                          className="flex-1 rounded border border-[#1B3A5C] px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-[#1B3A5C]/30"
+                          className="flex-1 rounded border border-brand-accent px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-brand-accent/30"
                         />
                         <button
                           onClick={() => saveEdit(m.rawName)}
                           disabled={saving}
-                          className="rounded bg-[#1B3A5C] px-2 py-1 text-xs text-white hover:bg-[#1B3A5C]/90 disabled:opacity-50"
+                          className="rounded bg-header-bg px-2 py-1 text-xs text-header-text hover:opacity-90 disabled:opacity-50"
                         >
                           Save
                         </button>
                         <button
                           onClick={() => setEditingRaw(null)}
-                          className="rounded border border-gray-300 px-2 py-1 text-xs text-gray-600 hover:bg-gray-50"
+                          className="rounded border border-input-border px-2 py-1 text-xs text-text-secondary hover:bg-surface-hover"
                         >
                           Cancel
                         </button>
@@ -990,7 +992,7 @@ export default function AdminPage() {
                     ) : (
                       <button
                         onClick={() => startEdit(m)}
-                        className="text-left text-[#1B3A5C] hover:underline cursor-pointer"
+                        className="text-left text-text-primary hover:underline cursor-pointer"
                         title="Click to edit"
                       >
                         {m.effectiveParentName}

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -1,80 +1,137 @@
 @import "tailwindcss";
 @custom-variant dark (&:where(.dark, .dark *));
 
+/**
+ * :root — fallback token values (used server-side before theme-init.js fires,
+ * and as the default when no brand config has injected its own values yet).
+ *
+ * These match the vanilla defaultTheme defined in src/lib/theme/tokens.ts.
+ * BrandProvider calls injectThemeTokens() on mount, which overwrites these
+ * with the active brand's computed values.
+ *
+ * ⚠️  Do NOT hard-code brand-specific colours here.  Brand customisation lives
+ *    in src/config/brands/<brand>.ts (Phase 1) or Firestore (Phase 2).
+ */
 :root {
-  --background: #f8f9fa;
-  --foreground: #1a1a2e;
-  --surface: #ffffff;
-  --surface-hover: #f9fafb;
-  --surface-alt: #f3f4f6;
-  --border: #e5e7eb;
-  --border-light: #f3f4f6;
-  --text-primary: #111827;
-  --text-secondary: #6b7280;
-  --text-tertiary: #9ca3af;
-  --brand-primary: #1B3A5C;
-  --brand-primary-hover: rgba(27, 58, 92, 0.05);
-  --brand-primary-light: rgba(27, 58, 92, 0.1);
-  --brand-gold: #C5A258;
-  --spinner-track: #d9e0e8;
-  --spinner-accent: #1B3A5C;
-  --nav-bg: #ffffff;
-  --nav-border: #e5e7eb;
-  --input-bg: #ffffff;
-  --input-border: #d1d5db;
-  --badge-gray-bg: #f3f4f6;
-  --badge-gray-text: #6b7280;
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-  --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+  /* Structural */
+  --background:           #f8fafc;
+  --foreground:           #1e293b;
+  --surface:              #ffffff;
+  --surface-hover:        #f8fafc;
+  --surface-alt:          #f1f5f9;
+
+  /* Borders */
+  --border:               rgba(100, 116, 139, 0.2);
+  --border-light:         rgba(100, 116, 139, 0.1);
+
+  /* Text */
+  --text-primary:         #0f172a;
+  --text-secondary:       #64748b;
+  --text-tertiary:        #94a3b8;
+
+  /* Header / Nav */
+  --header-bg:            #1e293b;
+  --header-text:          #ffffff;
+  --nav-active-text:      #1e293b;
+  --nav-active-indicator: #3b82f6;
+  --nav-inactive-text:    #64748b;
+
+  /* Brand accent */
+  --brand-accent:         #3b82f6;
+  --brand-accent-light:   #60a5fa;
+  --brand-accent-hover:   rgba(59, 130, 246, 0.1);
+  --brand-primary-hover:  rgba(30, 41, 59, 0.05);
+  --brand-primary-light:  rgba(30, 41, 59, 0.1);
+
+  /* Inputs */
+  --input-bg:             #ffffff;
+  --input-border:         #cbd5e1;
+
+  /* Badges */
+  --badge-gray-bg:        #f1f5f9;
+  --badge-gray-text:      #64748b;
+
+  /* Spinner */
+  --spinner-track:        #e2e8f0;
+  --spinner-accent:       #3b82f6;
+
+  /* Nav (sub-nav surfaces) */
+  --nav-bg:               #ffffff;
+  --nav-border:           rgba(100, 116, 139, 0.2);
+
+  /* Shadows */
+  --shadow-sm:            0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow:               0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
-.dark {
-  --background: #0c1220;
-  --foreground: #e2e8f0;
-  --surface: #141e30;
-  --surface-hover: #1a2740;
-  --surface-alt: #111927;
-  --border: #1e2d44;
-  --border-light: #182438;
-  --text-primary: #f1f5f9;
-  --text-secondary: #94a3b8;
-  --text-tertiary: #64748b;
-  --brand-primary: #1B3A5C;
-  --brand-primary-hover: rgba(126, 184, 224, 0.08);
-  --brand-primary-light: rgba(126, 184, 224, 0.15);
-  --brand-gold: #d4b06a;
-  --spinner-track: #24354e;
-  --spinner-accent: #7EB8E0;
-  --nav-bg: #111927;
-  --nav-border: #1e2d44;
-  --input-bg: #141e30;
-  --input-border: #2a3a52;
-  --badge-gray-bg: #1e2d44;
-  --badge-gray-text: #94a3b8;
-  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
-  --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.4), 0 1px 2px -1px rgb(0 0 0 / 0.3);
-}
-
+/**
+ * @theme inline — maps CSS custom properties to Tailwind utility names.
+ *
+ * This lets components write e.g. `bg-surface`, `text-text-primary`,
+ * `border-border` etc. and have them resolve to the brand-injected values.
+ *
+ * Add new entries here whenever derive.ts gains a new CSS variable.
+ */
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --color-surface: var(--surface);
-  --color-surface-hover: var(--surface-hover);
-  --color-surface-alt: var(--surface-alt);
-  --color-dm-border: var(--border);
-  --color-dm-border-light: var(--border-light);
-  --color-text-primary: var(--text-primary);
-  --color-text-secondary: var(--text-secondary);
-  --color-text-tertiary: var(--text-tertiary);
-  --color-brand-primary: var(--brand-primary);
-  --color-brand-gold: var(--brand-gold);
-  --color-nav-bg: var(--nav-bg);
-  --color-nav-border: var(--nav-border);
-  --color-input-bg: var(--input-bg);
-  --color-input-border: var(--input-border);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  /* Structural */
+  --color-background:           var(--background);
+  --color-foreground:           var(--foreground);
+  --color-surface:              var(--surface);
+  --color-surface-hover:        var(--surface-hover);
+  --color-surface-alt:          var(--surface-alt);
+
+  /* Borders */
+  --color-border:               var(--border);
+  --color-border-light:         var(--border-light);
+  /* Legacy aliases kept for components not yet migrated */
+  --color-dm-border:            var(--border);
+  --color-dm-border-light:      var(--border-light);
+
+  /* Text */
+  --color-text-primary:         var(--text-primary);
+  --color-text-secondary:       var(--text-secondary);
+  --color-text-tertiary:        var(--text-tertiary);
+
+  /* Header / Nav */
+  --color-header-bg:            var(--header-bg);
+  --color-header-text:          var(--header-text);
+  --color-nav-active-text:      var(--nav-active-text);
+  --color-nav-active-indicator: var(--nav-active-indicator);
+  --color-nav-inactive-text:    var(--nav-inactive-text);
+
+  /* Brand accent */
+  --color-brand-accent:         var(--brand-accent);
+  --color-brand-accent-light:   var(--brand-accent-light);
+
+  /* Nav */
+  --color-nav-bg:               var(--nav-bg);
+  --color-nav-border:           var(--nav-border);
+
+  /* Badges */
+  --color-badge-gray-bg:        var(--badge-gray-bg);
+  --color-badge-gray-text:      var(--badge-gray-text);
+
+  /* Spinner */
+  --color-spinner-track:        var(--spinner-track);
+  --color-spinner-accent:       var(--spinner-accent);
+
+  /* Inputs */
+  --color-input-bg:             var(--input-bg);
+  --color-input-border:         var(--input-border);
+
+  /* Brand hover / light utilities */
+  --color-brand-primary-hover:  var(--brand-primary-hover);
+  --color-brand-primary-light:  var(--brand-primary-light);
+  --color-brand-accent-hover:   var(--brand-accent-hover);
+
+  /* Fonts */
+  --font-sans:                  var(--font-geist-sans);
+  --font-mono:                  var(--font-geist-mono);
 }
+
+/* ---------------------------------------------------------------------------
+ * Base styles
+ * --------------------------------------------------------------------------- */
 
 html,
 body {
@@ -83,136 +140,25 @@ body {
 
 body {
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
-}
-
-/* Dark mode overrides for common Tailwind utilities */
-.dark .bg-white {
-  background-color: var(--surface) !important;
-}
-
-.dark .bg-gray-50 {
-  background-color: var(--surface-alt) !important;
-}
-
-/* Keep the shell transition smooth without animating every card on route changes. */
-body {
+  font-family: var(--font-geist-sans, Arial, Helvetica, sans-serif);
+  /* Smooth background/color transitions on theme toggle only.
+     CSS transitions are not applied during route changes because only the
+     shell (html/body) bears these properties. */
   transition: background-color 0.15s ease, color 0.15s ease;
 }
 
-.dark .border-gray-100 {
-  border-color: var(--border-light) !important;
-}
+/* ---------------------------------------------------------------------------
+ * Recharts — respect theme tokens, no !important hacks needed because we
+ * control the prop values via useThemeColors().
+ * --------------------------------------------------------------------------- */
 
-.dark .border-gray-200 {
-  border-color: var(--border) !important;
-}
-
-.dark .border-gray-300 {
-  border-color: var(--input-border) !important;
-}
-
-.dark .text-gray-900,
-.dark .text-gray-800 {
-  color: var(--text-primary) !important;
-}
-
-.dark .text-gray-700,
-.dark .text-gray-600 {
-  color: var(--text-secondary) !important;
-}
-
-.dark .text-gray-500 {
-  color: var(--text-tertiary) !important;
-}
-
-.dark .text-gray-400 {
-  color: #4b5e78 !important;
-}
-
-.dark .text-\[\#1B3A5C\] {
-  color: #7EB8E0 !important;
-}
-
-.dark .bg-\[\#1B3A5C\]\/5 {
-  background-color: rgba(126, 184, 224, 0.08) !important;
-}
-
-.dark .bg-\[\#1B3A5C\]\/10 {
-  background-color: rgba(126, 184, 224, 0.12) !important;
-}
-
-.dark .border-t-\[\#1B3A5C\] {
-  border-top-color: var(--spinner-accent) !important;
-}
-
-.dark .border-t-gray-600 {
-  border-top-color: var(--spinner-accent) !important;
-}
-
-.dark .text-\[\#C5A258\] {
-  color: #d4b06a !important;
-}
-
-.dark .hover\:bg-gray-50:hover {
-  background-color: var(--surface-hover) !important;
-}
-
-.dark .shadow-sm {
-  box-shadow: var(--shadow-sm) !important;
-}
-
-.dark .shadow-lg {
-  box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.4), 0 4px 6px -4px rgb(0 0 0 / 0.3) !important;
-}
-
-/* Dark mode inputs */
-.dark input,
-.dark select,
-.dark textarea {
-  background-color: var(--input-bg) !important;
-  border-color: var(--input-border) !important;
-  color: var(--text-primary) !important;
-}
-
-.dark input::placeholder {
-  color: var(--text-tertiary) !important;
-}
-
-/* Dark mode for Recharts */
-.dark .recharts-cartesian-axis-tick-value {
-  fill: var(--text-tertiary) !important;
-}
-
-.dark .recharts-cartesian-grid line {
-  stroke: var(--border) !important;
-}
-
-/* Dark mode health badges */
-.dark .bg-green-100 { background-color: rgba(34, 197, 94, 0.15) !important; }
-.dark .bg-blue-100 { background-color: rgba(59, 130, 246, 0.15) !important; }
-.dark .bg-yellow-100 { background-color: rgba(234, 179, 8, 0.15) !important; }
-.dark .bg-red-100 { background-color: rgba(239, 68, 68, 0.15) !important; }
-.dark .bg-gray-100 { background-color: var(--badge-gray-bg) !important; }
-
-.dark .bg-green-50 { background-color: rgba(34, 197, 94, 0.1) !important; }
-.dark .bg-red-50 { background-color: rgba(239, 68, 68, 0.1) !important; }
-.dark .bg-blue-50 { background-color: rgba(59, 130, 246, 0.1) !important; }
-.dark .bg-yellow-50 { background-color: rgba(234, 179, 8, 0.1) !important; }
-
-/* Recharts tooltip dark mode */
-.dark .recharts-tooltip-wrapper .recharts-default-tooltip {
-  background-color: var(--surface) !important;
-  border-color: var(--border) !important;
-}
-
-/* Remove browser focus rings from clickable chart surfaces for mouse focus only.
-   Keyboard focus keeps its normal visible indicator. */
+/* Remove noisy browser focus outlines from clickable chart surfaces.
+   Keyboard navigation keeps its normal visible indicator via :focus-visible. */
 .recharts-wrapper:focus:not(:focus-visible),
 .recharts-wrapper svg:focus:not(:focus-visible),
 .recharts-wrapper [tabindex]:focus:not(:focus-visible) {
-  outline: none !important;
-  box-shadow: none !important;
+  outline: none;
+  box-shadow: none;
 }
 
 .recharts-wrapper,
@@ -220,13 +166,13 @@ body {
   -webkit-tap-highlight-color: transparent;
 }
 
+/* ---------------------------------------------------------------------------
+ * Animations
+ * --------------------------------------------------------------------------- */
+
 @keyframes slide-in-right {
-  from {
-    transform: translateX(100%);
-  }
-  to {
-    transform: translateX(0);
-  }
+  from { transform: translateX(100%); }
+  to   { transform: translateX(0);    }
 }
 
 .animate-slide-in-right {
@@ -234,12 +180,8 @@ body {
 }
 
 @keyframes app-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+  from { transform: rotate(0deg);   }
+  to   { transform: rotate(360deg); }
 }
 
 .animate-spin {

--- a/app/src/app/itineraries/page.tsx
+++ b/app/src/app/itineraries/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useMemo, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useDashboard } from "@/contexts/DashboardContext";
+import { useBrand } from "@/contexts/BrandContext";
 import { usePersistedState } from "@/hooks/usePersistedState";
 import SearchFilter from "@/components/dashboard/SearchFilter";
 import HealthBadge from "@/components/dashboard/HealthBadge";
@@ -18,7 +19,7 @@ export default function ItinerariesPage() {
     <Suspense
       fallback={
         <div className="flex items-center justify-center py-24">
-          <div className="h-10 w-10 animate-spin rounded-full border-4 border-gray-200 border-t-[#1B3A5C]" />
+          <div className="h-10 w-10 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent" />
         </div>
       }
     >
@@ -39,7 +40,8 @@ function ItinerariesContent() {
 }
 
 function ItineraryList() {
-  const { brand, dateRange, dataVersion } = useDashboard();
+  const { merchantQueryId: brand } = useBrand();
+  const { dateRange, dataVersion } = useDashboard();
   const [itineraries, setItineraries] = useState<ItinerarySummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -88,7 +90,7 @@ function ItineraryList() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">
-        <div className="h-10 w-10 animate-spin rounded-full border-4 border-gray-200 border-t-[#1B3A5C]" />
+        <div className="h-10 w-10 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent" />
       </div>
     );
   }
@@ -103,7 +105,7 @@ function ItineraryList() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold text-[#1B3A5C]">Itineraries</h1>
+      <h1 className="text-2xl font-semibold text-text-primary">Itineraries</h1>
 
       <div className="flex flex-col sm:flex-row gap-4">
         <div className="flex-1 max-w-md">
@@ -111,22 +113,22 @@ function ItineraryList() {
         </div>
         <div className="flex items-center gap-3 sm:ml-auto">
           <div className="flex items-center gap-2">
-            <label htmlFor="sort" className="text-sm text-gray-500">Sort by:</label>
+            <label htmlFor="sort" className="text-sm text-text-secondary">Sort by:</label>
             <select
               id="sort"
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value as SortOption)}
-              className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#1B3A5C]/30"
+              className="border border-input-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-accent/30"
             >
               <option value="rating">Rating</option>
               <option value="reviewCount">Review Count</option>
               <option value="name">Name</option>
             </select>
           </div>
-          <div className="flex rounded-lg border border-gray-300 overflow-hidden">
+          <div className="flex rounded-lg border border-input-border overflow-hidden">
             <button
               onClick={() => setViewMode("cards")}
-              className={`p-2 transition-colors ${viewMode === "cards" ? "bg-[#1B3A5C] text-white" : "bg-white text-gray-400 hover:text-gray-600"}`}
+              className={`p-2 transition-colors ${viewMode === "cards" ? "bg-header-bg text-header-text" : "bg-surface text-text-tertiary hover:text-text-secondary"}`}
               title="Card view"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -135,7 +137,7 @@ function ItineraryList() {
             </button>
             <button
               onClick={() => setViewMode("table")}
-              className={`p-2 transition-colors ${viewMode === "table" ? "bg-[#1B3A5C] text-white" : "bg-white text-gray-400 hover:text-gray-600"}`}
+              className={`p-2 transition-colors ${viewMode === "table" ? "bg-header-bg text-header-text" : "bg-surface text-text-tertiary hover:text-text-secondary"}`}
               title="Table view"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -153,22 +155,22 @@ function ItineraryList() {
               <Link
                 key={it.slug}
                 href={`/itineraries?slug=${encodeURIComponent(it.slug)}`}
-                className="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow"
+                className="bg-surface rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow"
               >
-                <h3 className="text-base font-semibold text-[#1B3A5C] mb-2">{it.name}</h3>
-                <p className="text-xs text-gray-500 mb-4">{it.ships.join(", ")}</p>
+                <h3 className="text-base font-semibold text-text-primary mb-2">{it.name}</h3>
+                <p className="text-xs text-text-secondary mb-4">{it.ships.join(", ")}</p>
                 <div className="grid grid-cols-3 gap-3 mb-4">
                   <div>
-                    <p className="text-xs text-gray-400">Avg Rating</p>
-                    <p className="text-lg font-semibold text-[#1B3A5C]">{it.averageRating.toFixed(2)}</p>
+                    <p className="text-xs text-text-tertiary">Avg Rating</p>
+                    <p className="text-lg font-semibold text-text-primary">{it.averageRating.toFixed(2)}</p>
                   </div>
                   <div>
-                    <p className="text-xs text-gray-400">Reviews</p>
-                    <p className="text-lg font-semibold text-[#1B3A5C]">{it.reviewCount}</p>
+                    <p className="text-xs text-text-tertiary">Reviews</p>
+                    <p className="text-lg font-semibold text-text-primary">{it.reviewCount}</p>
                   </div>
                   <div>
-                    <p className="text-xs text-gray-400">5-Star %</p>
-                    <p className="text-lg font-semibold text-[#1B3A5C]">{it.fiveStarPercent.toFixed(1)}%</p>
+                    <p className="text-xs text-text-tertiary">5-Star %</p>
+                    <p className="text-lg font-semibold text-text-primary">{it.fiveStarPercent.toFixed(1)}%</p>
                   </div>
                 </div>
                 <HealthBadge rating={it.averageRating} />
@@ -176,35 +178,35 @@ function ItineraryList() {
             ))}
           </div>
           {filtered.length === 0 && (
-            <p className="text-center text-gray-400 py-12">No itineraries match your search.</p>
+            <p className="text-center text-text-tertiary py-12">No itineraries match your search.</p>
           )}
         </>
       ) : (
-        <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6">
+        <div className="bg-surface rounded-lg shadow-sm p-4 sm:p-6">
           <div className="overflow-x-auto">
             <table className="w-full text-sm min-w-[800px]">
               <thead>
-                <tr className="border-b border-gray-200">
-                  <th className="pb-3 pt-1 pr-6 font-medium text-gray-500 text-left whitespace-nowrap">Name</th>
-                  <th className="pb-3 pt-1 px-4 font-medium text-gray-500 text-right whitespace-nowrap">Avg Rating</th>
-                  <th className="pb-3 pt-1 px-4 font-medium text-gray-500 text-right whitespace-nowrap">Reviews</th>
-                  <th className="pb-3 pt-1 px-4 font-medium text-gray-500 text-right whitespace-nowrap">5-Star %</th>
-                  <th className="pb-3 pt-1 pl-6 font-medium text-gray-500 text-left whitespace-nowrap">Ship(s)</th>
-                  <th className="pb-3 pt-1 pl-6 font-medium text-gray-500 text-right whitespace-nowrap">Health</th>
+                <tr className="border-b border-border">
+                  <th className="pb-3 pt-1 pr-6 font-medium text-text-secondary text-left whitespace-nowrap">Name</th>
+                  <th className="pb-3 pt-1 px-4 font-medium text-text-secondary text-right whitespace-nowrap">Avg Rating</th>
+                  <th className="pb-3 pt-1 px-4 font-medium text-text-secondary text-right whitespace-nowrap">Reviews</th>
+                  <th className="pb-3 pt-1 px-4 font-medium text-text-secondary text-right whitespace-nowrap">5-Star %</th>
+                  <th className="pb-3 pt-1 pl-6 font-medium text-text-secondary text-left whitespace-nowrap">Ship(s)</th>
+                  <th className="pb-3 pt-1 pl-6 font-medium text-text-secondary text-right whitespace-nowrap">Health</th>
                 </tr>
               </thead>
               <tbody>
                 {filtered.map((it) => (
-                  <tr key={it.slug} className="border-b border-gray-100 hover:bg-[#1B3A5C]/5 transition-colors group">
+                  <tr key={it.slug} className="border-b border-border-light hover:bg-brand-primary-hover transition-colors group">
                     <td className="py-3 pr-6 w-[40%]">
-                      <Link href={`/itineraries?slug=${encodeURIComponent(it.slug)}`} className="font-medium text-[#1B3A5C] group-hover:underline">
+                      <Link href={`/itineraries?slug=${encodeURIComponent(it.slug)}`} className="font-medium text-text-primary group-hover:underline">
                         {it.name}
                       </Link>
                     </td>
                     <td className="py-3 px-4 text-right tabular-nums whitespace-nowrap">{it.averageRating.toFixed(2)}</td>
                     <td className="py-3 px-4 text-right tabular-nums whitespace-nowrap">{it.reviewCount.toLocaleString()}</td>
                     <td className="py-3 px-4 text-right tabular-nums whitespace-nowrap">{it.fiveStarPercent.toFixed(1)}%</td>
-                    <td className="py-3 pl-6 pr-4 text-gray-600">{it.ships.join(", ")}</td>
+                    <td className="py-3 pl-6 pr-4 text-text-secondary">{it.ships.join(", ")}</td>
                     <td className="py-3 pl-6 text-right">
                       <HealthBadge rating={it.averageRating} />
                     </td>
@@ -212,7 +214,7 @@ function ItineraryList() {
                 ))}
                 {filtered.length === 0 && (
                   <tr>
-                    <td colSpan={6} className="py-8 text-center text-gray-400">
+                    <td colSpan={6} className="py-8 text-center text-text-tertiary">
                       No itineraries match your search.
                     </td>
                   </tr>

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -4,9 +4,9 @@ import Script from "next/script";
 import "./globals.css";
 import { DashboardProvider } from "@/contexts/DashboardContext";
 import { ThemeProvider } from "@/contexts/ThemeContext";
+import { BrandProviderWithTheme } from "@/contexts/BrandContext";
 import AuthGate from "@/components/layout/AuthGate";
 import Header from "@/components/layout/Header";
-import Navigation from "@/components/layout/Navigation";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -15,7 +15,7 @@ const geistSans = Geist({
 
 export const metadata: Metadata = {
   title: "Feefo Review Intelligence Dashboard",
-  description: "Review analytics for Uniworld and Luxury Gold",
+  description: "Review analytics dashboard",
 };
 
 export default function RootLayout({
@@ -30,17 +30,24 @@ export default function RootLayout({
       </head>
       <body className="min-h-full flex flex-col font-sans" style={{ backgroundColor: 'var(--background)' }}>
         <ThemeProvider>
-          <DashboardProvider>
-            <AuthGate>
-              <div className="sticky top-0 z-40">
-                <Header />
-                <Navigation />
-              </div>
-              <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-6 sm:px-6 lg:px-8">
-                {children}
-              </main>
-            </AuthGate>
-          </DashboardProvider>
+          {/*
+            BrandProviderWithTheme is a thin wrapper that reads the current
+            theme from ThemeContext and passes isDark to BrandProvider so that
+            token injection re-fires on every dark/light toggle.
+          */}
+          <BrandProviderWithTheme>
+            <DashboardProvider>
+              <AuthGate>
+                {/* Single sticky bar — Header now contains inline NavTabs */}
+                <div className="sticky top-0 z-40">
+                  <Header />
+                </div>
+                <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-6 sm:px-6 lg:px-8">
+                  {children}
+                </main>
+              </AuthGate>
+            </DashboardProvider>
+          </BrandProviderWithTheme>
         </ThemeProvider>
       </body>
     </html>

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useDashboard } from "@/contexts/DashboardContext";
+import { useBrand } from "@/contexts/BrandContext";
 import KpiCard from "@/components/dashboard/KpiCard";
 import RatingDistributionChart from "@/components/dashboard/RatingDistributionChart";
 import TrendChart from "@/components/dashboard/TrendChart";
@@ -24,7 +25,8 @@ import {
 } from "@/lib/firestore/queries";
 
 export default function OverviewPage() {
-  const { brand, dateRange, dataVersion } = useDashboard();
+  const { merchantQueryId: brand } = useBrand();
+  const { dateRange, dataVersion } = useDashboard();
 
   const [fleet, setFleet] = useState<FleetSummary | null>(null);
   const [trendPoints, setTrendPoints] = useState<TrendPoint[]>([]);
@@ -124,7 +126,7 @@ export default function OverviewPage() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">
-        <div className="h-10 w-10 animate-spin rounded-full border-4 border-gray-200 border-t-[#1B3A5C]" />
+        <div className="h-10 w-10 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent" />
       </div>
     );
   }
@@ -139,7 +141,7 @@ export default function OverviewPage() {
 
   if (!fleet) {
     return (
-      <div className="rounded-2xl border border-gray-200 bg-white px-6 py-5 text-sm text-gray-600">
+      <div className="rounded-2xl border border-border bg-surface px-6 py-5 text-sm text-text-secondary">
         No overview data is available yet.
       </div>
     );
@@ -159,7 +161,7 @@ export default function OverviewPage() {
 
   return (
     <div className="space-y-8">
-      <h1 className="text-2xl font-bold text-[#1B3A5C]">Overview</h1>
+      <h1 className="text-2xl font-bold text-text-primary">Overview</h1>
 
       {/* KPI Cards */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">

--- a/app/src/app/reviews/page.tsx
+++ b/app/src/app/reviews/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useCallback, useEffect, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { useDashboard } from "@/contexts/DashboardContext";
+import { useBrand } from "@/contexts/BrandContext";
 import { getClientDb } from "@/lib/firebase";
 import {
   collection,
@@ -252,7 +253,8 @@ const DISPLAY_PAGE_SIZE = 10;
 
 function ReviewsContent() {
   const searchParams = useSearchParams();
-  const { brand, dateRange, dataVersion } = useDashboard();
+  const { merchantQueryId: brand } = useBrand();
+  const { dateRange, dataVersion } = useDashboard();
 
   // Parse initial state from URL
   const initial = paramsToFilters(searchParams);
@@ -402,8 +404,7 @@ function ReviewsContent() {
     return (
       <div className="flex items-center justify-center py-24">
         <div
-          className="h-8 w-8 animate-spin rounded-full border-4"
-          style={{ borderColor: "var(--spinner-track)", borderTopColor: "var(--spinner-accent)" }}
+          className="h-8 w-8 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent"
         />
       </div>
     );
@@ -421,8 +422,8 @@ function ReviewsContent() {
     <div>
       {/* Page header */}
       <div className="mb-6">
-        <h1 className="text-2xl font-semibold text-[#1B3A5C]">Reviews Explorer</h1>
-        <p className="mt-1 text-sm text-gray-500">
+        <h1 className="text-2xl font-semibold text-text-primary">Reviews Explorer</h1>
+        <p className="mt-1 text-sm text-text-secondary">
           Search and filter guest reviews across all cruises
         </p>
       </div>
@@ -431,7 +432,7 @@ function ReviewsContent() {
       <div className="flex flex-col sm:flex-row gap-3 mb-6">
         <div className="relative flex-1">
           <svg
-            className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400"
+            className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-tertiary"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -448,12 +449,12 @@ function ReviewsContent() {
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder="Search reviews..."
-            className="w-full border border-gray-300 rounded-lg pl-10 pr-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-[#1B3A5C]/30 focus:border-[#1B3A5C]/30"
+            className="w-full border border-input-border rounded-lg pl-10 pr-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-accent/30 focus:border-brand-accent/30"
           />
         </div>
         <div className="flex items-center gap-3">
           <ExportButton reviews={sorted} />
-          <span className="text-sm text-gray-500 whitespace-nowrap">
+          <span className="text-sm text-text-secondary whitespace-nowrap">
             {sorted.length} review{sorted.length !== 1 ? "s" : ""}
           </span>
         </div>
@@ -463,27 +464,27 @@ function ReviewsContent() {
       <div className="flex items-center justify-between mb-4">
         <button
           onClick={() => setSidebarOpen(!sidebarOpen)}
-          className="lg:hidden inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+          className="lg:hidden inline-flex items-center gap-2 rounded-lg border border-input-border bg-surface px-3 py-2 text-sm font-medium text-text-primary shadow-sm hover:bg-surface-hover"
         >
           <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
             <path strokeLinecap="round" strokeLinejoin="round" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
           </svg>
           Filters
           {activeFilterCount > 0 && (
-            <span className="rounded-full bg-[#1B3A5C] px-1.5 py-0.5 text-xs text-white">
+            <span className="rounded-full bg-header-bg px-1.5 py-0.5 text-xs text-header-text">
               {activeFilterCount}
             </span>
           )}
         </button>
         <div className="flex items-center gap-2 ml-auto">
-          <label htmlFor="sort-select" className="text-sm text-gray-500">
+          <label htmlFor="sort-select" className="text-sm text-text-secondary">
             Sort:
           </label>
           <select
             id="sort-select"
             value={sort}
             onChange={(e) => setSort(e.target.value as SortOption)}
-            className="rounded-lg border border-gray-300 bg-white px-3 py-1.5 text-sm text-gray-700 focus:outline-none focus:ring-2 focus:ring-[#1B3A5C]/30"
+            className="rounded-lg border border-input-border bg-surface px-3 py-1.5 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-brand-accent/30"
           >
             <option value="newest">Newest</option>
             <option value="oldest">Oldest</option>
@@ -507,16 +508,16 @@ function ReviewsContent() {
         <div
           className={`${
             sidebarOpen
-              ? "fixed inset-y-0 left-0 z-50 w-72 overflow-y-auto bg-white p-4 shadow-xl lg:static lg:z-auto lg:w-64 lg:overflow-visible lg:bg-transparent lg:p-0 lg:shadow-none"
+              ? "fixed inset-y-0 left-0 z-50 w-72 overflow-y-auto bg-surface p-4 shadow-xl lg:static lg:z-auto lg:w-64 lg:overflow-visible lg:bg-transparent lg:p-0 lg:shadow-none"
               : "hidden"
           } lg:block lg:w-64 shrink-0`}
         >
-          <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm sticky top-4">
+          <div className="rounded-lg border border-border bg-surface p-4 shadow-sm sticky top-4">
             <div className="flex items-center justify-between lg:hidden mb-3">
-              <span className="text-sm font-semibold text-[#1B3A5C]">Filters</span>
+              <span className="text-sm font-semibold text-text-primary">Filters</span>
               <button
                 onClick={() => setSidebarOpen(false)}
-                className="rounded p-1 hover:bg-gray-100 text-gray-400"
+                className="rounded p-1 hover:bg-surface-hover text-text-tertiary"
                 aria-label="Close filters"
               >
                 <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -535,8 +536,8 @@ function ReviewsContent() {
         {/* Results */}
         <div className="flex-1 min-w-0">
           {sorted.length === 0 ? (
-            <div className="rounded-lg border border-gray-200 bg-white p-12 text-center">
-              <p className="text-gray-500">
+            <div className="rounded-lg border border-border bg-surface p-12 text-center">
+              <p className="text-text-secondary">
                 No reviews match your search and filters.
               </p>
               <button
@@ -544,7 +545,7 @@ function ReviewsContent() {
                   setSearch("");
                   setFilters(emptyFilters);
                 }}
-                className="mt-3 text-sm font-medium text-[#1B3A5C] hover:underline"
+                className="mt-3 text-sm font-medium text-text-primary hover:underline"
               >
                 Clear all filters
               </button>
@@ -567,7 +568,7 @@ function ReviewsContent() {
                   <button
                     onClick={handleLoadMore}
                     disabled={loadingMore}
-                    className="inline-flex items-center gap-2 rounded-lg bg-[#1B3A5C] px-6 py-2.5 text-sm font-medium text-white shadow-sm hover:bg-[#1B3A5C]/90 transition-colors disabled:opacity-50"
+                    className="inline-flex items-center gap-2 rounded-lg bg-header-bg px-6 py-2.5 text-sm font-medium text-header-text shadow-sm hover:opacity-90 transition-colors disabled:opacity-50"
                   >
                     {loadingMore ? (
                       <>
@@ -605,8 +606,7 @@ export default function ReviewsPage() {
       fallback={
         <div className="flex items-center justify-center py-24">
               <div
-                className="h-8 w-8 animate-spin rounded-full border-4"
-                style={{ borderColor: "var(--spinner-track)", borderTopColor: "var(--spinner-accent)" }}
+                className="h-8 w-8 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent"
               />
         </div>
       }

--- a/app/src/app/ships/page.tsx
+++ b/app/src/app/ships/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState, useMemo, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { useDashboard } from "@/contexts/DashboardContext";
+import { useBrand } from "@/contexts/BrandContext";
 import { usePersistedState } from "@/hooks/usePersistedState";
 import SearchFilter from "@/components/dashboard/SearchFilter";
 import HealthBadge from "@/components/dashboard/HealthBadge";
@@ -18,7 +19,7 @@ export default function ShipsPage() {
     <Suspense
       fallback={
         <div className="flex items-center justify-center py-24">
-          <div className="h-10 w-10 animate-spin rounded-full border-4 border-gray-200 border-t-[#1B3A5C]" />
+          <div className="h-10 w-10 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent" />
         </div>
       }
     >
@@ -39,7 +40,8 @@ function ShipsContent() {
 }
 
 function ShipList() {
-  const { brand, dateRange, dataVersion } = useDashboard();
+  const { merchantQueryId: brand } = useBrand();
+  const { dateRange, dataVersion } = useDashboard();
   const [ships, setShips] = useState<ShipSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -88,7 +90,7 @@ function ShipList() {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">
-        <div className="h-10 w-10 animate-spin rounded-full border-4 border-gray-200 border-t-[#1B3A5C]" />
+        <div className="h-10 w-10 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent" />
       </div>
     );
   }
@@ -103,7 +105,7 @@ function ShipList() {
 
   return (
     <div className="space-y-6">
-      <h1 className="text-2xl font-semibold text-[#1B3A5C]">Ships</h1>
+      <h1 className="text-2xl font-semibold text-text-primary">Ships</h1>
 
       <div className="flex flex-col sm:flex-row gap-4">
         <div className="flex-1 max-w-md">
@@ -111,22 +113,22 @@ function ShipList() {
         </div>
         <div className="flex items-center gap-3 sm:ml-auto">
           <div className="flex items-center gap-2">
-            <label htmlFor="sort" className="text-sm text-gray-500">Sort by:</label>
+            <label htmlFor="sort" className="text-sm text-text-secondary">Sort by:</label>
             <select
               id="sort"
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value as SortOption)}
-              className="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#1B3A5C]/30"
+              className="border border-input-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-accent/30"
             >
               <option value="rating">Rating</option>
               <option value="reviewCount">Review Count</option>
               <option value="name">Name</option>
             </select>
           </div>
-          <div className="flex rounded-lg border border-gray-300 overflow-hidden">
+          <div className="flex rounded-lg border border-input-border overflow-hidden">
             <button
               onClick={() => setViewMode("cards")}
-              className={`p-2 transition-colors ${viewMode === "cards" ? "bg-[#1B3A5C] text-white" : "bg-white text-gray-400 hover:text-gray-600"}`}
+              className={`p-2 transition-colors ${viewMode === "cards" ? "bg-header-bg text-header-text" : "bg-surface text-text-tertiary hover:text-text-secondary"}`}
               title="Card view"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -135,7 +137,7 @@ function ShipList() {
             </button>
             <button
               onClick={() => setViewMode("table")}
-              className={`p-2 transition-colors ${viewMode === "table" ? "bg-[#1B3A5C] text-white" : "bg-white text-gray-400 hover:text-gray-600"}`}
+              className={`p-2 transition-colors ${viewMode === "table" ? "bg-header-bg text-header-text" : "bg-surface text-text-tertiary hover:text-text-secondary"}`}
               title="Table view"
             >
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -153,24 +155,24 @@ function ShipList() {
               <Link
                 key={ship.slug}
                 href={`/ships?slug=${encodeURIComponent(ship.slug)}`}
-                className="bg-white rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow"
+                className="bg-surface rounded-lg shadow-sm p-6 hover:shadow-md transition-shadow"
               >
-                <h3 className="text-base font-semibold text-[#1B3A5C] mb-2">{ship.name}</h3>
-                <p className="text-xs text-gray-500 mb-4">
+                <h3 className="text-base font-semibold text-text-primary mb-2">{ship.name}</h3>
+                <p className="text-xs text-text-secondary mb-4">
                   {ship.itineraryCount} itinerar{ship.itineraryCount === 1 ? "y" : "ies"}
                 </p>
                 <div className="grid grid-cols-3 gap-3 mb-4">
                   <div>
-                    <p className="text-xs text-gray-400">Avg Rating</p>
-                    <p className="text-lg font-semibold text-[#1B3A5C]">{ship.averageRating.toFixed(2)}</p>
+                    <p className="text-xs text-text-tertiary">Avg Rating</p>
+                    <p className="text-lg font-semibold text-text-primary">{ship.averageRating.toFixed(2)}</p>
                   </div>
                   <div>
-                    <p className="text-xs text-gray-400">Reviews</p>
-                    <p className="text-lg font-semibold text-[#1B3A5C]">{ship.reviewCount}</p>
+                    <p className="text-xs text-text-tertiary">Reviews</p>
+                    <p className="text-lg font-semibold text-text-primary">{ship.reviewCount}</p>
                   </div>
                   <div>
-                    <p className="text-xs text-gray-400">5-Star %</p>
-                    <p className="text-lg font-semibold text-[#1B3A5C]">{ship.fiveStarPercent.toFixed(1)}%</p>
+                    <p className="text-xs text-text-tertiary">5-Star %</p>
+                    <p className="text-lg font-semibold text-text-primary">{ship.fiveStarPercent.toFixed(1)}%</p>
                   </div>
                 </div>
                 <HealthBadge rating={ship.averageRating} />
@@ -178,28 +180,28 @@ function ShipList() {
             ))}
           </div>
           {filtered.length === 0 && (
-            <p className="text-center text-gray-400 py-12">No ships match your search.</p>
+            <p className="text-center text-text-tertiary py-12">No ships match your search.</p>
           )}
         </>
       ) : (
-        <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6">
+        <div className="bg-surface rounded-lg shadow-sm p-4 sm:p-6">
           <div className="overflow-x-auto">
             <table className="w-full text-sm min-w-[800px]">
               <thead>
-                <tr className="border-b border-gray-200">
-                  <th className="pb-3 pt-1 pr-6 font-medium text-gray-500 text-left whitespace-nowrap">Name</th>
-                  <th className="pb-3 pt-1 px-4 font-medium text-gray-500 text-right whitespace-nowrap">Avg Rating</th>
-                  <th className="pb-3 pt-1 px-4 font-medium text-gray-500 text-right whitespace-nowrap">Reviews</th>
-                  <th className="pb-3 pt-1 px-4 font-medium text-gray-500 text-right whitespace-nowrap">5-Star %</th>
-                  <th className="pb-3 pt-1 pl-6 font-medium text-gray-500 text-right whitespace-nowrap">Itineraries</th>
-                  <th className="pb-3 pt-1 pl-6 font-medium text-gray-500 text-right whitespace-nowrap">Health</th>
+                <tr className="border-b border-border">
+                  <th className="pb-3 pt-1 pr-6 font-medium text-text-secondary text-left whitespace-nowrap">Name</th>
+                  <th className="pb-3 pt-1 px-4 font-medium text-text-secondary text-right whitespace-nowrap">Avg Rating</th>
+                  <th className="pb-3 pt-1 px-4 font-medium text-text-secondary text-right whitespace-nowrap">Reviews</th>
+                  <th className="pb-3 pt-1 px-4 font-medium text-text-secondary text-right whitespace-nowrap">5-Star %</th>
+                  <th className="pb-3 pt-1 pl-6 font-medium text-text-secondary text-right whitespace-nowrap">Itineraries</th>
+                  <th className="pb-3 pt-1 pl-6 font-medium text-text-secondary text-right whitespace-nowrap">Health</th>
                 </tr>
               </thead>
               <tbody>
                 {filtered.map((ship) => (
-                  <tr key={ship.slug} className="border-b border-gray-100 hover:bg-[#1B3A5C]/5 transition-colors group">
+                  <tr key={ship.slug} className="border-b border-border-light hover:bg-brand-primary-hover transition-colors group">
                     <td className="py-3 pr-6 w-[40%]">
-                      <Link href={`/ships?slug=${encodeURIComponent(ship.slug)}`} className="font-medium text-[#1B3A5C] group-hover:underline">
+                      <Link href={`/ships?slug=${encodeURIComponent(ship.slug)}`} className="font-medium text-text-primary group-hover:underline">
                         {ship.name}
                       </Link>
                     </td>
@@ -214,7 +216,7 @@ function ShipList() {
                 ))}
                 {filtered.length === 0 && (
                   <tr>
-                    <td colSpan={6} className="py-8 text-center text-gray-400">
+                    <td colSpan={6} className="py-8 text-center text-text-tertiary">
                       No ships match your search.
                     </td>
                   </tr>

--- a/app/src/components/admin/OperationLogsTable.tsx
+++ b/app/src/components/admin/OperationLogsTable.tsx
@@ -11,7 +11,7 @@ function LevelBadge({ level }: { level: OperationLogLevel }) {
         ? "bg-amber-100 text-amber-700"
         : level === "error"
           ? "bg-red-100 text-red-700"
-          : "bg-slate-100 text-slate-600";
+          : "bg-badge-gray-bg text-badge-gray-text";
 
   return (
     <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${className}`}>
@@ -307,20 +307,20 @@ export default function OperationLogsTable({
   if (loading) {
     return (
       <div className="flex items-center justify-center py-12">
-        <div className="h-6 w-6 animate-spin rounded-full border-4 border-gray-200 border-t-[#1B3A5C]" />
+        <div className="h-6 w-6 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent" />
       </div>
     );
   }
 
   if (logs.length === 0) {
-    return <div className="px-4 py-6 text-sm text-gray-500">{emptyMessage}</div>;
+    return <div className="px-4 py-6 text-sm text-text-secondary">{emptyMessage}</div>;
   }
 
   return (
-    <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white shadow-sm">
+    <div className="overflow-x-auto rounded-lg border border-border bg-surface shadow-sm">
       <table className="w-full min-w-[980px] text-sm">
         <thead>
-          <tr className="bg-gray-50 text-left text-gray-500">
+          <tr className="bg-surface-alt text-left text-text-secondary">
             <th className="px-4 py-3 font-medium">Time</th>
             <th className="px-4 py-3 font-medium">Type</th>
             <th className="px-4 py-3 font-medium">Status</th>
@@ -333,29 +333,29 @@ export default function OperationLogsTable({
             const detailRows = getDetailRows(log);
 
             return (
-              <tr key={log.id} className="border-t border-gray-100 align-top">
-                <td className="px-4 py-3 whitespace-nowrap text-gray-600">
+              <tr key={log.id} className="border-t border-border-light align-top">
+                <td className="px-4 py-3 whitespace-nowrap text-text-secondary">
                   {log.createdAt ? format(new Date(log.createdAt), "M/d/yyyy h:mm:ss a") : "-"}
                 </td>
                 <td className="px-4 py-3">
-                  <span className="inline-flex rounded-full bg-[#1B3A5C]/10 px-2 py-0.5 text-xs font-medium capitalize text-[#1B3A5C]">
+                  <span className="inline-flex rounded-full bg-brand-primary-light px-2 py-0.5 text-xs font-medium capitalize text-text-primary">
                     {log.type}
                   </span>
                 </td>
                 <td className="px-4 py-3">
                   <LevelBadge level={log.level} />
                 </td>
-                <td className="px-4 py-3 text-gray-900">
+                <td className="px-4 py-3 text-text-primary">
                   <div className="font-medium">{log.message}</div>
-                  <div className="mt-1 text-xs text-gray-500">{actionLabel(log.action)}</div>
+                  <div className="mt-1 text-xs text-text-secondary">{actionLabel(log.action)}</div>
                 </td>
-                <td className="px-4 py-3 text-xs leading-5 text-gray-600">
+                <td className="px-4 py-3 text-xs leading-5 text-text-secondary">
                   {detailRows.length > 0 ? (
                     <dl className="space-y-1.5">
                       {detailRows.map((row) => (
                         <div key={`${log.id}-${row.label}`} className="grid grid-cols-[132px_minmax(0,1fr)] gap-2">
-                          <dt className="font-medium text-gray-500">{row.label}</dt>
-                          <dd className="break-words text-gray-700">{row.value}</dd>
+                          <dt className="font-medium text-text-secondary">{row.label}</dt>
+                          <dd className="break-words text-text-primary">{row.value}</dd>
                         </div>
                       ))}
                     </dl>

--- a/app/src/components/dashboard/FleetComparisonTable.tsx
+++ b/app/src/components/dashboard/FleetComparisonTable.tsx
@@ -12,7 +12,9 @@ interface FleetComparisonTableProps {
 type SortKey = "name" | "averageRating" | "reviewCount" | "fiveStarPercent";
 type SortDir = "asc" | "desc";
 
-export default function FleetComparisonTable({ data }: FleetComparisonTableProps) {
+export default function FleetComparisonTable({
+  data,
+}: FleetComparisonTableProps) {
   const [search, setSearch] = useState("");
   const [sortKey, setSortKey] = useState<SortKey>("reviewCount");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
@@ -28,13 +30,15 @@ export default function FleetComparisonTable({ data }: FleetComparisonTableProps
 
   const sorted = useMemo(() => {
     const filtered = data.filter((e) =>
-      e.name.toLowerCase().includes(search.toLowerCase())
+      e.name.toLowerCase().includes(search.toLowerCase()),
     );
     return [...filtered].sort((a, b) => {
       const aVal = a[sortKey];
       const bVal = b[sortKey];
       if (typeof aVal === "string" && typeof bVal === "string") {
-        return sortDir === "asc" ? aVal.localeCompare(bVal) : bVal.localeCompare(aVal);
+        return sortDir === "asc"
+          ? aVal.localeCompare(bVal)
+          : bVal.localeCompare(aVal);
       }
       return sortDir === "asc"
         ? (aVal as number) - (bVal as number)
@@ -43,8 +47,9 @@ export default function FleetComparisonTable({ data }: FleetComparisonTableProps
   }, [data, search, sortKey, sortDir]);
 
   const SortIndicator = ({ col }: { col: SortKey }) => {
-    if (sortKey !== col) return <span className="text-gray-300 ml-1">{"\u2195"}</span>;
-    return <span className="ml-1">{sortDir === "asc" ? "\u2191" : "\u2193"}</span>;
+    if (sortKey !== col)
+      return <span className="ml-1 text-text-tertiary">↕</span>;
+    return <span className="ml-1">{sortDir === "asc" ? "↑" : "↓"}</span>;
   };
 
   const columns: { key: SortKey; label: string; align?: string }[] = [
@@ -54,55 +59,75 @@ export default function FleetComparisonTable({ data }: FleetComparisonTableProps
     { key: "fiveStarPercent", label: "5-Star %", align: "text-right" },
   ];
 
-  const headerAlign = (col: typeof columns[number]) =>
-    `pb-3 pt-1 font-medium text-gray-500 cursor-pointer select-none whitespace-nowrap ${col.key === "name" ? "pr-6 text-left" : "px-4"} ${col.align ?? "text-left"}`;
+  const thClass = (col: (typeof columns)[number]) =>
+    `pb-3 pt-1 font-medium text-text-secondary cursor-pointer select-none whitespace-nowrap ${
+      col.key === "name" ? "pr-6 text-left" : "px-4"
+    } ${col.align ?? "text-left"}`;
 
   return (
-    <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6">
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-4 gap-3">
-        <h3 className="text-lg font-semibold text-[#1B3A5C]">Itinerary Comparison</h3>
+    <div className="rounded-lg bg-surface p-4 shadow-sm sm:p-6">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <h3 className="text-lg font-semibold text-text-primary">
+          Itinerary Comparison
+        </h3>
         <input
           type="text"
           placeholder="Search itineraries..."
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-[#1B3A5C]/30 w-full sm:w-64"
+          className="w-full rounded-lg border border-input-border bg-input-bg px-3 py-1.5 text-sm text-text-primary placeholder:text-text-tertiary focus:outline-none focus:ring-2 sm:w-64"
+          style={{ "--tw-ring-color": "var(--brand-accent)" } as React.CSSProperties}
         />
       </div>
 
       <div className="overflow-x-auto">
-        <table className="w-full text-sm min-w-[800px]">
+        <table className="w-full min-w-[800px] text-sm">
           <thead>
-            <tr className="border-b border-gray-200">
+            <tr className="border-b border-border">
               {columns.map((col) => (
                 <th
                   key={col.key}
-                  className={headerAlign(col)}
+                  className={thClass(col)}
                   onClick={() => handleSort(col.key)}
                 >
                   {col.label}
                   <SortIndicator col={col.key} />
                 </th>
               ))}
-              <th className="pb-3 pt-1 pl-6 font-medium text-gray-500 text-left whitespace-nowrap">Ship(s)</th>
-              <th className="pb-3 pt-1 pl-6 font-medium text-gray-500 text-right whitespace-nowrap">Health</th>
+              <th className="pb-3 pl-6 pt-1 text-left font-medium text-text-secondary whitespace-nowrap">
+                Ship(s)
+              </th>
+              <th className="pb-3 pl-6 pt-1 text-right font-medium text-text-secondary whitespace-nowrap">
+                Health
+              </th>
             </tr>
           </thead>
           <tbody>
             {sorted.map((entity) => (
               <tr
                 key={entity.id}
-                className="border-b border-gray-100 hover:bg-[#1B3A5C]/5 cursor-pointer transition-colors group"
+                className="group cursor-pointer border-b border-border transition-colors hover:bg-brand-primary-hover"
               >
-                <td className="py-3 pr-6 w-[40%]">
-                  <Link href={`/itineraries?slug=${encodeURIComponent(entity.id)}`} className="font-medium text-[#1B3A5C] group-hover:underline">
+                <td className="w-[40%] py-3 pr-6">
+                  <Link
+                    href={`/itineraries?slug=${encodeURIComponent(entity.id)}`}
+                    className="font-medium text-text-primary group-hover:underline"
+                  >
                     {entity.name}
                   </Link>
                 </td>
-                <td className="py-3 px-4 text-right tabular-nums whitespace-nowrap">{entity.averageRating.toFixed(2)}</td>
-                <td className="py-3 px-4 text-right tabular-nums whitespace-nowrap">{entity.reviewCount.toLocaleString()}</td>
-                <td className="py-3 px-4 text-right tabular-nums whitespace-nowrap">{entity.fiveStarPercent.toFixed(1)}%</td>
-                <td className="py-3 pl-6 pr-4 text-gray-600">{entity.ships.join(", ")}</td>
+                <td className="px-4 py-3 text-right tabular-nums whitespace-nowrap text-text-primary">
+                  {entity.averageRating.toFixed(2)}
+                </td>
+                <td className="px-4 py-3 text-right tabular-nums whitespace-nowrap text-text-primary">
+                  {entity.reviewCount.toLocaleString()}
+                </td>
+                <td className="px-4 py-3 text-right tabular-nums whitespace-nowrap text-text-primary">
+                  {entity.fiveStarPercent.toFixed(1)}%
+                </td>
+                <td className="py-3 pl-6 pr-4 text-text-secondary">
+                  {entity.ships.join(", ")}
+                </td>
                 <td className="py-3 pl-6 text-right">
                   <HealthBadge rating={entity.averageRating} />
                 </td>
@@ -110,7 +135,10 @@ export default function FleetComparisonTable({ data }: FleetComparisonTableProps
             ))}
             {sorted.length === 0 && (
               <tr>
-                <td colSpan={6} className="py-8 text-center text-gray-400">
+                <td
+                  colSpan={6}
+                  className="py-8 text-center text-text-tertiary"
+                >
                   No itineraries match your search.
                 </td>
               </tr>

--- a/app/src/components/dashboard/KpiCard.tsx
+++ b/app/src/components/dashboard/KpiCard.tsx
@@ -9,18 +9,24 @@ interface KpiCardProps {
 
 export default function KpiCard({ title, value, delta, trendUp }: KpiCardProps) {
   return (
-    <div className="bg-white rounded-xl border border-gray-100 shadow-md hover:shadow-lg transition-shadow p-5 sm:p-6">
-      <p className="text-xs font-semibold uppercase tracking-wider text-gray-400">{title}</p>
+    <div className="rounded-xl border border-border bg-surface p-5 shadow-sm transition-shadow hover:shadow-md sm:p-6">
+      <p className="text-xs font-semibold uppercase tracking-wider text-text-tertiary">
+        {title}
+      </p>
       <div className="mt-3 flex items-baseline gap-2">
-        <p className="text-3xl sm:text-4xl font-bold text-[#1B3A5C]">{value}</p>
+        <p className="text-3xl font-bold text-text-primary sm:text-4xl">{value}</p>
         {trendUp !== undefined && trendUp !== null && (
-          <span className={`text-lg font-semibold ${trendUp ? "text-emerald-500" : "text-red-500"}`}>
-            {trendUp ? "\u2191" : "\u2193"}
+          <span
+            className={`text-lg font-semibold ${
+              trendUp ? "text-emerald-500" : "text-red-500"
+            }`}
+          >
+            {trendUp ? "↑" : "↓"}
           </span>
         )}
       </div>
       {delta && (
-        <p className="mt-2 text-sm text-gray-400">{delta}</p>
+        <p className="mt-2 text-sm text-text-tertiary">{delta}</p>
       )}
     </div>
   );

--- a/app/src/components/dashboard/QuotesSection.tsx
+++ b/app/src/components/dashboard/QuotesSection.tsx
@@ -19,46 +19,58 @@ interface QuotesSectionProps {
 
 function StarRating({ rating }: { rating: number }) {
   return (
-    <span className="text-[#C5A258]" aria-label={`${rating} out of 5 stars`}>
+    <span className="text-brand-accent" aria-label={`${rating} out of 5 stars`}>
       {Array.from({ length: 5 }, (_, i) => (
-        <span key={i}>{i < rating ? "\u2605" : "\u2606"}</span>
+        <span key={i}>{i < rating ? "★" : "☆"}</span>
       ))}
     </span>
   );
 }
 
-function QuoteCard({ quote, type }: { quote: Quote; type: "positive" | "negative" }) {
+function QuoteCard({
+  quote,
+  type,
+}: {
+  quote: Quote;
+  type: "positive" | "negative";
+}) {
   const [expanded, setExpanded] = useState(false);
   const [needsClamp, setNeedsClamp] = useState(false);
   const textRef = useRef<HTMLParagraphElement>(null);
-  const borderClass = type === "negative" ? "border-l-4 border-l-red-400" : "border-l-4 border-l-[#1B3A5C]";
+
+  const borderClass =
+    type === "negative"
+      ? "border-l-4 border-l-red-400"
+      : "border-l-4 border-l-brand-accent";
 
   useEffect(() => {
     const el = textRef.current;
-    if (el) {
-      setNeedsClamp(el.scrollHeight > el.clientHeight + 1);
-    }
+    if (el) setNeedsClamp(el.scrollHeight > el.clientHeight + 1);
   }, []);
 
   return (
-    <div className={`bg-gray-50 rounded-lg p-4 ${borderClass}`}>
-      <div className="flex items-center justify-between mb-2">
-        <span className="font-medium text-sm text-[#1B3A5C]">{quote.guestName}</span>
+    <div className={`rounded-lg bg-surface-alt p-4 ${borderClass}`}>
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-sm font-medium text-text-primary">
+          {quote.guestName}
+        </span>
         <StarRating rating={quote.rating} />
       </div>
-      <p className="text-xs text-gray-500 mb-2">
-        {quote.itinerary} &middot; {quote.ship}
+      <p className="mb-2 text-xs text-text-secondary">
+        {quote.itinerary} · {quote.ship}
       </p>
       <p
         ref={textRef}
-        className={`text-sm text-gray-700 leading-relaxed ${!expanded ? "line-clamp-4" : ""}`}
+        className={`text-sm leading-relaxed text-text-primary ${
+          !expanded ? "line-clamp-4" : ""
+        }`}
       >
         {quote.text}
       </p>
       {needsClamp && (
         <button
           onClick={() => setExpanded(!expanded)}
-          className="mt-1 text-xs font-medium text-[#1B3A5C] hover:underline"
+          className="mt-1 cursor-pointer text-xs font-medium text-brand-accent hover:underline"
         >
           {expanded ? "Show less" : "Read more"}
         </button>
@@ -67,48 +79,47 @@ function QuoteCard({ quote, type }: { quote: Quote; type: "positive" | "negative
   );
 }
 
-export default function QuotesSection({ positiveQuotes, negativeQuotes }: QuotesSectionProps) {
-  const [activeTab, setActiveTab] = useState<"positive" | "negative">("positive");
+export default function QuotesSection({
+  positiveQuotes,
+  negativeQuotes,
+}: QuotesSectionProps) {
+  const [activeTab, setActiveTab] = useState<"positive" | "negative">(
+    "positive",
+  );
   const quotes = activeTab === "positive" ? positiveQuotes : negativeQuotes;
 
   return (
-    <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6">
-      <h3 className="text-lg font-semibold text-[#1B3A5C] mb-4">Guest Quotes</h3>
+    <div className="rounded-lg bg-surface p-4 shadow-sm sm:p-6">
+      <h3 className="mb-4 text-lg font-semibold text-text-primary">
+        Guest Quotes
+      </h3>
 
-      {/* Tabs */}
-      <div className="flex gap-6 border-b border-gray-200 mb-6">
-        <button
-          onClick={() => setActiveTab("positive")}
-          className={`relative pb-3 text-sm font-medium transition-colors ${
-            activeTab === "positive"
-              ? "text-[#1B3A5C]"
-              : "text-gray-500 hover:text-gray-700"
-          }`}
-        >
-          Positive
-          {activeTab === "positive" && (
-            <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-[#C5A258]" />
-          )}
-        </button>
-        <button
-          onClick={() => setActiveTab("negative")}
-          className={`relative pb-3 text-sm font-medium transition-colors ${
-            activeTab === "negative"
-              ? "text-[#1B3A5C]"
-              : "text-gray-500 hover:text-gray-700"
-          }`}
-        >
-          Needs Improvement
-          {activeTab === "negative" && (
-            <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-[#C5A258]" />
-          )}
-        </button>
+      {/* Tab switcher */}
+      <div className="mb-6 flex gap-6 border-b border-border">
+        {(["positive", "negative"] as const).map((tab) => (
+          <button
+            key={tab}
+            onClick={() => setActiveTab(tab)}
+            className={`relative cursor-pointer pb-3 text-sm font-medium capitalize transition-colors ${
+              activeTab === tab
+                ? "text-text-primary"
+                : "text-text-secondary hover:text-text-primary"
+            }`}
+          >
+            {tab === "positive" ? "Positive" : "Needs Improvement"}
+            {activeTab === tab && (
+              <span className="absolute bottom-0 left-0 right-0 h-0.5 rounded-full bg-nav-active-indicator" />
+            )}
+          </button>
+        ))}
       </div>
 
-      {/* Quote Cards */}
+      {/* Quote cards */}
       <div className="space-y-4">
         {quotes.length === 0 ? (
-          <p className="text-center text-gray-400 py-8">No quotes available.</p>
+          <p className="py-8 text-center text-text-tertiary">
+            No quotes available.
+          </p>
         ) : (
           quotes.map((quote) => (
             <QuoteCard key={quote.id} quote={quote} type={activeTab} />

--- a/app/src/components/dashboard/RatingDistributionChart.tsx
+++ b/app/src/components/dashboard/RatingDistributionChart.tsx
@@ -9,59 +9,78 @@ import {
   ResponsiveContainer,
   Cell,
 } from "recharts";
+import { useThemeColors } from "@/hooks/useThemeColors";
 
 interface RatingDistributionChartProps {
   data: { star: number; count: number }[];
   onBarClick?: (star: number) => void;
 }
 
-const STAR_COLORS: Record<number, string> = {
-  5: "#1B3A5C",
-  4: "#2d5a8c",
-  3: "#C5A258",
-  2: "#e8913a",
-  1: "#ef4444",
-};
-
-const TOOLTIP_STYLE = {
-  backgroundColor: "#172338",
-  border: "1px solid #2d3b58",
-  borderRadius: "12px",
-  color: "#f8fafc",
-  boxShadow: "0 12px 32px rgba(0, 0, 0, 0.28)",
-};
-
-const TOOLTIP_LABEL_STYLE = {
-  color: "#f8fafc",
-  fontWeight: 600,
-};
-
-const TOOLTIP_ITEM_STYLE = {
-  color: "#cbd5e1",
-};
+/**
+ * Star rating colours are intentionally semantic (not brand-specific):
+ *   5★ → brand primary  (top score = brand colour)
+ *   4★ → brand accent   (good score = warm accent)
+ *   3★ → amber          (mid score = neutral warning)
+ *   2★ → orange         (below-par = warm warning)
+ *   1★ → red            (poor = danger)
+ *
+ * Only the 5-star bar uses the brand token; the rest are semantic.
+ */
+function buildStarColors(primary: string, accent: string): Record<number, string> {
+  return {
+    5: primary,
+    4: accent,
+    3: "#eab308",  // amber-500
+    2: "#e8913a",  // orange
+    1: "#ef4444",  // red-500
+  };
+}
 
 export default function RatingDistributionChart({
   data,
   onBarClick,
 }: RatingDistributionChartProps) {
-  const chartData = [...data].sort((a, b) => b.star - a.star).map((d) => ({
-    label: `${d.star} Star`,
-    count: d.count,
-    star: d.star,
-  }));
+  const {
+    primary,
+    accent,
+    tooltipStyle,
+    tooltipLabelStyle,
+    tooltipItemStyle,
+    axisTickFill,
+  } = useThemeColors();
+
+  const starColors = buildStarColors(primary, accent);
+
+  const chartData = [...data]
+    .sort((a, b) => b.star - a.star)
+    .map((d) => ({ label: `${d.star} Star`, count: d.count, star: d.star }));
 
   return (
-    <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6">
-      <h3 className="text-lg font-semibold text-[#1B3A5C] mb-4">Rating Distribution</h3>
+    <div className="rounded-lg bg-surface p-4 shadow-sm sm:p-6">
+      <h3 className="mb-4 text-lg font-semibold text-text-primary">
+        Rating Distribution
+      </h3>
       <ResponsiveContainer width="100%" height={240}>
-        <BarChart data={chartData} layout="vertical" margin={{ left: 10, right: 20, top: 0, bottom: 0 }}>
-          <XAxis type="number" tick={{ fontSize: 12 }} />
-          <YAxis type="category" dataKey="label" width={60} tick={{ fontSize: 12 }} />
+        <BarChart
+          data={chartData}
+          layout="vertical"
+          margin={{ left: 10, right: 20, top: 0, bottom: 0 }}
+        >
+          <XAxis
+            type="number"
+            tick={{ fontSize: 12, fill: axisTickFill }}
+          />
+          <YAxis
+            type="category"
+            dataKey="label"
+            width={60}
+            tick={{ fontSize: 12, fill: axisTickFill }}
+          />
           <Tooltip
             cursor={false}
-            contentStyle={TOOLTIP_STYLE}
-            labelStyle={TOOLTIP_LABEL_STYLE}
-            itemStyle={TOOLTIP_ITEM_STYLE}
+            contentStyle={tooltipStyle}
+            labelStyle={tooltipLabelStyle}
+            itemStyle={tooltipItemStyle}
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             formatter={(value: any) => [Number(value).toLocaleString(), "Reviews"]}
           />
@@ -77,7 +96,10 @@ export default function RatingDistributionChart({
             }}
           >
             {chartData.map((entry) => (
-              <Cell key={`cell-${entry.star}`} fill={STAR_COLORS[entry.star]} />
+              <Cell
+                key={`cell-${entry.star}`}
+                fill={starColors[entry.star]}
+              />
             ))}
           </Bar>
         </BarChart>

--- a/app/src/components/dashboard/ReviewPanel.tsx
+++ b/app/src/components/dashboard/ReviewPanel.tsx
@@ -15,9 +15,12 @@ interface ReviewPanelProps {
 
 function StarRating({ rating }: { rating: number }) {
   return (
-    <span className="text-[#C5A258]" aria-label={`${rating} out of 5 stars`}>
+    <span
+      className="text-brand-accent"
+      aria-label={`${rating} out of 5 stars`}
+    >
       {Array.from({ length: 5 }, (_, i) => (
-        <span key={i}>{i < rating ? "\u2605" : "\u2606"}</span>
+        <span key={i}>{i < rating ? "★" : "☆"}</span>
       ))}
     </span>
   );
@@ -31,23 +34,26 @@ function QuoteCard({
   accent: "positive" | "negative" | "neutral";
 }) {
   const [expanded, setExpanded] = useState(false);
+
   const borderClass =
     accent === "negative"
       ? "border-l-4 border-l-red-400"
       : accent === "positive"
-        ? "border-l-4 border-l-[#1B3A5C]"
-        : "border-l-4 border-l-[#C5A258]";
+        ? "border-l-4 border-l-brand-accent"
+        : "border-l-4 border-l-brand-accent-light";
 
   return (
-    <div className={`bg-gray-50 rounded-lg p-4 ${borderClass}`}>
-      <div className="flex items-center justify-between mb-2">
-        <span className="font-medium text-sm text-[#1B3A5C]">{review.guestName}</span>
+    <div className={`rounded-lg bg-surface-alt p-4 ${borderClass}`}>
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-sm font-medium text-text-primary">
+          {review.guestName}
+        </span>
         <StarRating rating={review.rating} />
       </div>
-      <p className="text-xs text-gray-500 mb-2">
-        {review.itinerary} &middot; {review.ship}
+      <p className="mb-2 text-xs text-text-secondary">
+        {review.itinerary} · {review.ship}
       </p>
-      <p className="text-sm text-gray-700 leading-relaxed">
+      <p className="text-sm leading-relaxed text-text-primary">
         {expanded || review.text.length <= 150
           ? review.text
           : `${review.text.slice(0, 150)}...`}
@@ -55,7 +61,7 @@ function QuoteCard({
       {review.text.length > 150 && (
         <button
           onClick={() => setExpanded(!expanded)}
-          className="mt-1 text-xs font-medium text-[#1B3A5C] hover:underline"
+          className="mt-1 text-xs font-medium text-brand-accent hover:underline cursor-pointer"
         >
           {expanded ? "Show less" : "Read more"}
         </button>
@@ -81,7 +87,7 @@ export default function ReviewPanel({
     (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     },
-    [onClose]
+    [onClose],
   );
 
   useEffect(() => {
@@ -99,35 +105,47 @@ export default function ReviewPanel({
       <div className="absolute inset-0 bg-black/40" onClick={onClose} />
 
       {/* Panel */}
-      <div className="relative w-full max-w-full sm:max-w-md bg-white shadow-xl flex flex-col animate-slide-in-right">
+      <div className="animate-slide-in-right relative flex w-full max-w-full flex-col bg-surface shadow-xl sm:max-w-md">
         {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-[#1e2d44]">
+        <div className="flex items-center justify-between border-b border-border p-6">
           <div>
-            <h2 className="text-lg font-semibold text-[#1B3A5C]">{title}</h2>
-            <p className="text-sm text-gray-500 mt-0.5">
+            <h2 className="text-lg font-semibold text-text-primary">{title}</h2>
+            <p className="mt-0.5 text-sm text-text-secondary">
               {reviews.length} review{reviews.length !== 1 ? "s" : ""}
             </p>
-            <p className="text-xs text-gray-400 mt-1">{subtitle}</p>
+            <p className="mt-1 text-xs text-text-tertiary">{subtitle}</p>
           </div>
           <button
             onClick={onClose}
-            className="rounded-full p-2 hover:bg-gray-100 text-gray-400 hover:text-gray-600 transition-colors"
+            className="cursor-pointer rounded-full p-2 text-text-tertiary transition-colors hover:bg-surface-hover hover:text-text-primary"
             aria-label="Close panel"
           >
-            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              strokeWidth={2}
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
             </svg>
           </button>
         </div>
 
         {/* Reviews */}
-        <div className="flex-1 overflow-y-auto p-6 space-y-4">
+        <div className="flex-1 space-y-4 overflow-y-auto p-6">
           {loading ? (
             <div className="flex items-center justify-center py-12">
-              <div className="h-8 w-8 animate-spin rounded-full border-4 border-gray-200 border-t-[#1B3A5C]" />
+              <div className="h-8 w-8 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent" />
             </div>
           ) : reviews.length === 0 ? (
-            <p className="text-center text-gray-500 py-12">No matching reviews were found.</p>
+            <p className="py-12 text-center text-text-secondary">
+              No matching reviews were found.
+            </p>
           ) : (
             reviews.map((review) => (
               <QuoteCard key={review.id} review={review} accent={accent} />

--- a/app/src/components/dashboard/SearchFilter.tsx
+++ b/app/src/components/dashboard/SearchFilter.tsx
@@ -10,7 +10,7 @@ export default function SearchFilter({ value, onChange, placeholder = "Search...
   return (
     <div className="relative">
       <svg
-        className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400"
+        className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-text-tertiary"
         fill="none"
         viewBox="0 0 24 24"
         stroke="currentColor"
@@ -27,7 +27,7 @@ export default function SearchFilter({ value, onChange, placeholder = "Search...
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
-        className="w-full border border-gray-300 rounded-lg pl-10 pr-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-[#1B3A5C]/30 focus:border-[#1B3A5C]/30"
+        className="w-full border border-input-border rounded-lg pl-10 pr-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-accent/30 focus:border-brand-accent/30"
       />
     </div>
   );

--- a/app/src/components/dashboard/ThemeChart.tsx
+++ b/app/src/components/dashboard/ThemeChart.tsx
@@ -10,6 +10,7 @@ import {
   ResponsiveContainer,
   Cell,
 } from "recharts";
+import { useThemeColors } from "@/hooks/useThemeColors";
 
 interface ThemeChartProps {
   title: string;
@@ -18,28 +19,21 @@ interface ThemeChartProps {
   onBarClick: (theme: string) => void;
 }
 
-const TOOLTIP_STYLE = {
-  backgroundColor: "#172338",
-  border: "1px solid #2d3b58",
-  borderRadius: "12px",
-  color: "#f8fafc",
-  boxShadow: "0 12px 32px rgba(0, 0, 0, 0.28)",
-};
+/**
+ * Generates a 10-step palette blending from colorA (darkest) to colorB (lightest).
+ * Used to give each bar a distinct shade while staying on-brand.
+ */
+function buildPalette(colorA: string, colorB: string, steps = 10): string[] {
+  // We do the blend in CSS so we don't need hex parsing in JS.
+  // Use color-mix where supported, fall back to a static default.
+  return Array.from({ length: steps }, (_, i) => {
+    const pct = Math.round((i / (steps - 1)) * 60); // 0% → 60% blend
+    // color-mix is available in all modern browsers and Safari 16.2+.
+    return `color-mix(in srgb, ${colorB} ${pct}%, ${colorA})`;
+  });
+}
 
-const TOOLTIP_LABEL_STYLE = {
-  color: "#f8fafc",
-  fontWeight: 600,
-};
-
-const TOOLTIP_ITEM_STYLE = {
-  color: "#cbd5e1",
-};
-
-const POSITIVE_COLORS = [
-  "#1B3A5C", "#1e4a73", "#22578a", "#2d6aa0", "#3b82f6",
-  "#4a8ed9", "#5c9be0", "#71a9e6", "#8ab8ec", "#a3c7f2",
-];
-
+// Negative sentiment: fixed warm-red palette (these are semantic, not branded).
 const NEGATIVE_COLORS = [
   "#ef4444", "#f05252", "#f16060", "#f27070", "#e8913a",
   "#eba04e", "#edaf62", "#f0be76", "#f2cd8a", "#f5dc9e",
@@ -48,10 +42,7 @@ const NEGATIVE_COLORS = [
 function useIsMobile(breakpoint = 640) {
   return useSyncExternalStore(
     (callback) => {
-      if (typeof window === "undefined") {
-        return () => {};
-      }
-
+      if (typeof window === "undefined") return () => {};
       const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
       const handler = () => callback();
       mql.addEventListener("change", handler);
@@ -60,35 +51,53 @@ function useIsMobile(breakpoint = 640) {
     () =>
       typeof window !== "undefined" &&
       window.matchMedia(`(max-width: ${breakpoint - 1}px)`).matches,
-    () => false
+    () => false,
   );
 }
 
-export default function ThemeChart({ title, data, type, onBarClick }: ThemeChartProps) {
-  const colors = type === "positive" ? POSITIVE_COLORS : NEGATIVE_COLORS;
+export default function ThemeChart({
+  title,
+  data,
+  type,
+  onBarClick,
+}: ThemeChartProps) {
   const isMobile = useIsMobile();
+  const {
+    primary,
+    accentLight,
+    tooltipStyle,
+    tooltipLabelStyle,
+    tooltipItemStyle,
+    axisTickFill,
+  } = useThemeColors();
+
+  const positiveColors = buildPalette(primary, accentLight);
+  const colors = type === "positive" ? positiveColors : NEGATIVE_COLORS;
 
   return (
-    <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6">
-      <h3 className="text-lg font-semibold text-[#1B3A5C] mb-4">{title}</h3>
+    <div className="rounded-lg bg-surface p-4 shadow-sm sm:p-6">
+      <h3 className="mb-4 text-lg font-semibold text-text-primary">{title}</h3>
       <ResponsiveContainer width="100%" height={isMobile ? 280 : 360}>
         <BarChart
           data={data}
           layout="vertical"
           margin={{ left: 0, right: 10, top: 0, bottom: 0 }}
         >
-          <XAxis type="number" tick={{ fontSize: 11 }} />
+          <XAxis
+            type="number"
+            tick={{ fontSize: 11, fill: axisTickFill }}
+          />
           <YAxis
             type="category"
             dataKey="theme"
             width={isMobile ? 100 : 160}
-            tick={{ fontSize: isMobile ? 10 : 11 }}
+            tick={{ fontSize: isMobile ? 10 : 11, fill: axisTickFill }}
           />
           <Tooltip
             cursor={false}
-            contentStyle={TOOLTIP_STYLE}
-            labelStyle={TOOLTIP_LABEL_STYLE}
-            itemStyle={TOOLTIP_ITEM_STYLE}
+            contentStyle={tooltipStyle}
+            labelStyle={tooltipLabelStyle}
+            itemStyle={tooltipItemStyle}
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             formatter={(value: any) => [Number(value).toLocaleString(), "Reviews"]}
           />

--- a/app/src/components/dashboard/ThemeChart.tsx
+++ b/app/src/components/dashboard/ThemeChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useSyncExternalStore } from "react";
 import {
   BarChart,
   Bar,
@@ -46,16 +46,22 @@ const NEGATIVE_COLORS = [
 ];
 
 function useIsMobile(breakpoint = 640) {
-  const [isMobile, setIsMobile] = useState(
-    () => typeof window !== "undefined" && window.matchMedia(`(max-width: ${breakpoint - 1}px)`).matches
+  return useSyncExternalStore(
+    (callback) => {
+      if (typeof window === "undefined") {
+        return () => {};
+      }
+
+      const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+      const handler = () => callback();
+      mql.addEventListener("change", handler);
+      return () => mql.removeEventListener("change", handler);
+    },
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia(`(max-width: ${breakpoint - 1}px)`).matches,
+    () => false
   );
-  useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mql.addEventListener("change", handler);
-    return () => mql.removeEventListener("change", handler);
-  }, [breakpoint]);
-  return isMobile;
 }
 
 export default function ThemeChart({ title, data, type, onBarClick }: ThemeChartProps) {

--- a/app/src/components/dashboard/TrendChart.tsx
+++ b/app/src/components/dashboard/TrendChart.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useSyncExternalStore } from "react";
 import {
   LineChart,
   Line,
@@ -38,16 +38,22 @@ const TOOLTIP_ITEM_STYLE = {
 };
 
 function useIsMobile(breakpoint = 640) {
-  const [isMobile, setIsMobile] = useState(
-    () => typeof window !== "undefined" && window.matchMedia(`(max-width: ${breakpoint - 1}px)`).matches
+  return useSyncExternalStore(
+    (callback) => {
+      if (typeof window === "undefined") {
+        return () => {};
+      }
+
+      const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
+      const handler = () => callback();
+      mql.addEventListener("change", handler);
+      return () => mql.removeEventListener("change", handler);
+    },
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia(`(max-width: ${breakpoint - 1}px)`).matches,
+    () => false
   );
-  useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
-    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
-    mql.addEventListener("change", handler);
-    return () => mql.removeEventListener("change", handler);
-  }, [breakpoint]);
-  return isMobile;
 }
 
 function granularityLabel(granularity: TrendGranularity): string {

--- a/app/src/components/dashboard/TrendChart.tsx
+++ b/app/src/components/dashboard/TrendChart.tsx
@@ -13,6 +13,7 @@ import {
   CartesianGrid,
 } from "recharts";
 import type { TrendGranularity, TrendPoint } from "@/lib/firestore/queries";
+import { useThemeColors } from "@/hooks/useThemeColors";
 
 interface TrendChartProps {
   data: TrendPoint[];
@@ -20,30 +21,10 @@ interface TrendChartProps {
   onSelectPeriod?: (period: TrendPoint) => void;
 }
 
-const TOOLTIP_STYLE = {
-  backgroundColor: "#172338",
-  border: "1px solid #2d3b58",
-  borderRadius: "12px",
-  color: "#f8fafc",
-  boxShadow: "0 12px 32px rgba(0, 0, 0, 0.28)",
-};
-
-const TOOLTIP_LABEL_STYLE = {
-  color: "#f8fafc",
-  fontWeight: 600,
-};
-
-const TOOLTIP_ITEM_STYLE = {
-  color: "#cbd5e1",
-};
-
 function useIsMobile(breakpoint = 640) {
   return useSyncExternalStore(
     (callback) => {
-      if (typeof window === "undefined") {
-        return () => {};
-      }
-
+      if (typeof window === "undefined") return () => {};
       const mql = window.matchMedia(`(max-width: ${breakpoint - 1}px)`);
       const handler = () => callback();
       mql.addEventListener("change", handler);
@@ -52,7 +33,7 @@ function useIsMobile(breakpoint = 640) {
     () =>
       typeof window !== "undefined" &&
       window.matchMedia(`(max-width: ${breakpoint - 1}px)`).matches,
-    () => false
+    () => false,
   );
 }
 
@@ -69,32 +50,54 @@ export default function TrendChart({
 }: TrendChartProps) {
   const isMobile = useIsMobile();
   const chartHeight = isMobile ? 200 : 260;
+  const {
+    primary,
+    accent,
+    accentLight,
+    tooltipStyle,
+    tooltipLabelStyle,
+    tooltipItemStyle,
+    axisTickFill,
+    gridStroke,
+  } = useThemeColors();
+
+  const tickStyle = { fontSize: isMobile ? 9 : 11, fill: axisTickFill };
 
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-      <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6">
+      {/* Rating Trend */}
+      <div className="rounded-lg bg-surface p-4 shadow-sm sm:p-6">
         <div className="mb-4 flex items-start justify-between gap-3">
-          <h3 className="text-lg font-semibold text-[#1B3A5C]">
+          <h3 className="text-lg font-semibold text-text-primary">
             Rating Trend Over Time
           </h3>
-          <span className="rounded-full bg-[#1B3A5C]/10 px-2.5 py-1 text-xs font-medium text-[#1B3A5C]">
+          <span
+            className="rounded-full px-2.5 py-1 text-xs font-medium"
+            style={{
+              background: `color-mix(in srgb, var(--brand-accent) 15%, transparent)`,
+              color: "var(--text-primary)",
+            }}
+          >
             {granularityLabel(granularity)}
           </span>
         </div>
         <ResponsiveContainer width="100%" height={chartHeight}>
-          <LineChart data={data} margin={{ left: 0, right: 10, top: 5, bottom: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+          <LineChart
+            data={data}
+            margin={{ left: 0, right: 10, top: 5, bottom: 0 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
             <XAxis
               dataKey="label"
-              tick={{ fontSize: isMobile ? 9 : 11 }}
+              tick={tickStyle}
               minTickGap={isMobile ? 18 : 24}
             />
-            <YAxis domain={[4.0, 5.0]} tick={{ fontSize: 11 }} />
+            <YAxis domain={[4.0, 5.0]} tick={{ fontSize: 11, fill: axisTickFill }} />
             <Tooltip
-              cursor={{ stroke: "#36506f", strokeWidth: 1, strokeDasharray: "3 3" }}
-              contentStyle={TOOLTIP_STYLE}
-              labelStyle={TOOLTIP_LABEL_STYLE}
-              itemStyle={TOOLTIP_ITEM_STYLE}
+              cursor={{ stroke: primary, strokeWidth: 1, strokeDasharray: "3 3" }}
+              contentStyle={tooltipStyle}
+              labelStyle={tooltipLabelStyle}
+              itemStyle={tooltipItemStyle}
               labelFormatter={(_, payload) =>
                 payload?.[0]?.payload?.fullLabel ?? ""
               }
@@ -106,34 +109,29 @@ export default function TrendChart({
             <Line
               type="monotone"
               dataKey="averageRating"
-              stroke="#1B3A5C"
+              stroke={primary}
               strokeWidth={2}
               connectNulls={false}
               dot={(dotProps) => {
                 const payload = dotProps.payload as TrendPoint | undefined;
-                if (!payload || payload.averageRating === null) {
-                  return null;
-                }
-
+                if (!payload || payload.averageRating === null) return null;
                 return (
                   <circle
                     cx={dotProps.cx}
                     cy={dotProps.cy}
                     r={isMobile ? 3 : 4}
-                    fill="#1B3A5C"
+                    fill={primary}
                     className={onSelectPeriod ? "cursor-pointer" : undefined}
                     onClick={() => {
-                      if (onSelectPeriod) {
-                        onSelectPeriod(payload);
-                      }
+                      if (onSelectPeriod) onSelectPeriod(payload);
                     }}
                   />
                 );
               }}
               activeDot={{
                 r: isMobile ? 4 : 6,
-                fill: "#7CC0FF",
-                stroke: "#1B3A5C",
+                fill: accentLight,
+                stroke: primary,
                 strokeWidth: 2,
               }}
             />
@@ -141,37 +139,50 @@ export default function TrendChart({
         </ResponsiveContainer>
       </div>
 
-      <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6">
+      {/* Review Volume */}
+      <div className="rounded-lg bg-surface p-4 shadow-sm sm:p-6">
         <div className="mb-4 flex items-start justify-between gap-3">
-          <h3 className="text-lg font-semibold text-[#1B3A5C]">
+          <h3 className="text-lg font-semibold text-text-primary">
             Review Volume Over Time
           </h3>
-          <span className="rounded-full bg-[#C5A258]/15 px-2.5 py-1 text-xs font-medium text-[#8B6C29]">
+          <span
+            className="rounded-full px-2.5 py-1 text-xs font-medium"
+            style={{
+              background: `color-mix(in srgb, var(--brand-accent) 15%, transparent)`,
+              color: "var(--text-secondary)",
+            }}
+          >
             {granularityLabel(granularity)}
           </span>
         </div>
         <ResponsiveContainer width="100%" height={chartHeight}>
-          <BarChart data={data} margin={{ left: 0, right: 10, top: 5, bottom: 0 }}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+          <BarChart
+            data={data}
+            margin={{ left: 0, right: 10, top: 5, bottom: 0 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke={gridStroke} />
             <XAxis
               dataKey="label"
-              tick={{ fontSize: isMobile ? 9 : 11 }}
+              tick={tickStyle}
               minTickGap={isMobile ? 18 : 24}
             />
-            <YAxis tick={{ fontSize: 11 }} />
+            <YAxis tick={{ fontSize: 11, fill: axisTickFill }} />
             <Tooltip
               cursor={false}
-              contentStyle={TOOLTIP_STYLE}
-              labelStyle={TOOLTIP_LABEL_STYLE}
-              itemStyle={TOOLTIP_ITEM_STYLE}
+              contentStyle={tooltipStyle}
+              labelStyle={tooltipLabelStyle}
+              itemStyle={tooltipItemStyle}
               labelFormatter={(_, payload) =>
                 payload?.[0]?.payload?.fullLabel ?? ""
               }
-              formatter={(value) => [Number(value ?? 0).toLocaleString(), "Reviews"]}
+              formatter={(value) => [
+                Number(value ?? 0).toLocaleString(),
+                "Reviews",
+              ]}
             />
             <Bar
               dataKey="reviewCount"
-              fill="#C5A258"
+              fill={accent}
               radius={[4, 4, 0, 0]}
               cursor={onSelectPeriod ? "pointer" : "default"}
               activeBar={false}

--- a/app/src/components/itineraries/ItineraryDetail.tsx
+++ b/app/src/components/itineraries/ItineraryDetail.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
 import { useDashboard } from "@/contexts/DashboardContext";
+import { useBrand } from "@/contexts/BrandContext";
 import KpiCard from "@/components/dashboard/KpiCard";
 import RatingDistributionChart from "@/components/dashboard/RatingDistributionChart";
 import ThemeChart from "@/components/dashboard/ThemeChart";
@@ -18,7 +19,8 @@ import {
 } from "@/lib/firestore/itinerary-queries";
 
 export default function ItineraryDetail({ slug }: { slug: string }) {
-  const { brand, dateRange, dataVersion } = useDashboard();
+  const { merchantQueryId: brand } = useBrand();
+  const { dateRange, dataVersion } = useDashboard();
   const [itinerary, setItinerary] = useState<ItinerarySummary | null>(null);
   const [quotes, setQuotes] = useState<{ positive: Quote[]; negative: Quote[] }>({
     positive: [],
@@ -83,7 +85,7 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">
-        <div className="h-10 w-10 animate-spin rounded-full border-4 border-gray-200 border-t-[#1B3A5C]" />
+        <div className="h-10 w-10 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent" />
       </div>
     );
   }
@@ -99,8 +101,8 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
   if (!itinerary) {
     return (
       <div className="text-center py-24">
-        <h1 className="text-2xl font-semibold text-[#1B3A5C] mb-4">Itinerary Not Found</h1>
-        <Link href="/itineraries" className="text-[#C5A258] hover:underline">Back to Itineraries</Link>
+        <h1 className="text-2xl font-semibold text-text-primary mb-4">Itinerary Not Found</h1>
+        <Link href="/itineraries" className="text-brand-accent hover:underline">Back to Itineraries</Link>
       </div>
     );
   }
@@ -110,12 +112,12 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-2 text-sm text-gray-500">
-        <Link href="/itineraries" className="hover:text-[#1B3A5C]">Itineraries</Link>
+      <div className="flex items-center gap-2 text-sm text-text-secondary">
+        <Link href="/itineraries" className="hover:text-text-primary">Itineraries</Link>
         <span>/</span>
-        <span className="text-[#1B3A5C]">{itinerary.name}</span>
+        <span className="text-text-primary">{itinerary.name}</span>
       </div>
-      <h1 className="text-2xl font-semibold text-[#1B3A5C]">{itinerary.name}</h1>
+      <h1 className="text-2xl font-semibold text-text-primary">{itinerary.name}</h1>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
         <KpiCard title="Avg Rating" value={itinerary.averageRating.toFixed(2)} trendUp={ratingDelta >= 0} delta={`${ratingDelta >= 0 ? "+" : ""}${ratingDelta.toFixed(2)} vs fleet avg`} />
         <KpiCard title="Total Reviews" value={itinerary.reviewCount.toLocaleString()} />
@@ -127,13 +129,13 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
         <ThemeChart title="Positive Themes" data={itinerary.positiveThemes} type="positive" onBarClick={(theme) => openPanel(theme, "positive")} />
         <ThemeChart title="Negative Themes" data={itinerary.negativeThemes} type="negative" onBarClick={(theme) => openPanel(theme, "negative")} />
       </div>
-      <div className="bg-white rounded-lg shadow-sm p-6">
-        <h3 className="text-lg font-semibold text-[#1B3A5C] mb-4">Ships Operating This Itinerary</h3>
+      <div className="bg-surface rounded-lg shadow-sm p-6">
+        <h3 className="text-lg font-semibold text-text-primary mb-4">Ships Operating This Itinerary</h3>
         <div className="flex flex-wrap gap-3">
           {itinerary.ships.map((ship) => (
-            <Link key={ship} href={`/ships?slug=${encodeURIComponent(ship.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, ""))}`} className="inline-flex items-center gap-2 bg-gray-50 rounded-lg px-4 py-3 hover:bg-gray-100 transition-colors">
-              <svg className="h-5 w-5 text-[#1B3A5C]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" /></svg>
-              <span className="text-sm font-medium text-[#1B3A5C]">{ship}</span>
+            <Link key={ship} href={`/ships?slug=${encodeURIComponent(ship.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, ""))}`} className="inline-flex items-center gap-2 bg-surface-alt rounded-lg px-4 py-3 hover:bg-surface-hover transition-colors">
+              <svg className="h-5 w-5 text-text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}><path strokeLinecap="round" strokeLinejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" /></svg>
+              <span className="text-sm font-medium text-text-primary">{ship}</span>
             </Link>
           ))}
         </div>

--- a/app/src/components/layout/AuthButton.tsx
+++ b/app/src/components/layout/AuthButton.tsx
@@ -90,7 +90,7 @@ export default function AuthButton({
       <div
         className={`rounded-full px-3 py-1.5 text-xs ${
           isNeutral
-            ? "border border-slate-200 bg-white text-slate-500 shadow-sm dark:border-white/15 dark:bg-white/5 dark:text-white/70"
+            ? "border border-border bg-surface text-text-secondary shadow-sm"
             : "border border-white/20 bg-white/10 text-white/70"
         }`}
       >
@@ -105,7 +105,7 @@ export default function AuthButton({
         <div
           className={`hidden items-center gap-2 rounded-full px-3 py-1.5 text-xs sm:flex ${
             isNeutral
-              ? "border border-[#1B3A5C]/10 bg-[#1B3A5C]/[0.06] text-[#1B3A5C] dark:border-white/10 dark:bg-white/5 dark:text-white/80"
+              ? "border border-brand-primary-light bg-brand-primary-light text-text-primary"
               : "border border-white/15 bg-white/10 text-white/80"
           }`}
           title={user.email}
@@ -120,7 +120,7 @@ export default function AuthButton({
         <div
           className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-xs ${
             isNeutral
-              ? "border border-[#1B3A5C]/10 bg-[#1B3A5C]/[0.06] text-[#1B3A5C] dark:border-white/10 dark:bg-white/5 dark:text-white/80"
+              ? "border border-brand-primary-light bg-brand-primary-light text-text-primary"
               : "border border-white/15 bg-white/10 text-white/80"
           }`}
           title={user.email ?? "Signed in"}
@@ -134,7 +134,7 @@ export default function AuthButton({
         disabled={busy}
         className={`cursor-pointer rounded-full px-3 py-1.5 text-xs font-semibold transition-colors disabled:opacity-50 ${
           isNeutral
-            ? "border border-slate-200 bg-white text-slate-700 shadow-sm hover:bg-slate-50 dark:border-white/15 dark:bg-white/5 dark:text-white dark:hover:bg-white/10"
+            ? "border border-border bg-surface text-text-primary shadow-sm hover:bg-surface-hover"
             : "border border-white/20 bg-white/10 text-white hover:bg-white/20"
         }`}
       >
@@ -159,7 +159,7 @@ export default function AuthButton({
       {error ? (
         <span
           className={`hidden max-w-[220px] truncate text-xs xl:inline ${
-            isNeutral ? "text-rose-600 dark:text-rose-300" : "text-red-200"
+            isNeutral ? "text-rose-600" : "text-red-200"
           }`}
         >
           {error}

--- a/app/src/components/layout/AuthGate.tsx
+++ b/app/src/components/layout/AuthGate.tsx
@@ -62,7 +62,7 @@ export default function AuthGate({ children }: { children: React.ReactNode }) {
 
   if (configError) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center bg-[#1B3A5C] px-6">
+      <div className="flex min-h-screen flex-col items-center justify-center bg-header-bg px-6">
         <h1 className="text-xl font-semibold text-white">Configuration Error</h1>
         <p className="mt-3 max-w-md text-center text-sm text-white/60">
           {configError}
@@ -73,7 +73,7 @@ export default function AuthGate({ children }: { children: React.ReactNode }) {
 
   if (loading) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-[#1B3A5C]">
+      <div className="flex min-h-screen items-center justify-center bg-header-bg">
         <div className="text-sm text-white/50">Loading...</div>
       </div>
     );
@@ -81,7 +81,7 @@ export default function AuthGate({ children }: { children: React.ReactNode }) {
 
   if (!authenticated) {
     return (
-      <div className="relative flex min-h-screen flex-col items-center justify-center bg-[#1B3A5C] px-6">
+      <div className="relative flex min-h-screen flex-col items-center justify-center bg-header-bg px-6">
         <div
           className="pointer-events-none absolute inset-0"
           style={{
@@ -100,7 +100,7 @@ export default function AuthGate({ children }: { children: React.ReactNode }) {
           <button
             onClick={handleSignIn}
             disabled={busy}
-            className="mt-8 cursor-pointer rounded-full bg-[#C5A258] px-8 py-3 text-sm font-semibold text-white shadow-lg transition-colors hover:bg-[#b3913e] disabled:opacity-50 sm:mt-10 sm:px-10 sm:py-3.5 sm:text-base"
+            className="mt-8 cursor-pointer rounded-full bg-brand-accent px-8 py-3 text-sm font-semibold text-white shadow-lg transition-colors hover:opacity-90 disabled:opacity-50 sm:mt-10 sm:px-10 sm:py-3.5 sm:text-base"
           >
             {busy ? "Signing in..." : "Sign In with Microsoft"}
           </button>

--- a/app/src/components/layout/BrandSwitcher.tsx
+++ b/app/src/components/layout/BrandSwitcher.tsx
@@ -1,31 +1,15 @@
-"use client";
+/**
+ * BrandSwitcher.tsx — compatibility shim.
+ *
+ * The component has been renamed MerchantSwitcher and now reads from
+ * BrandContext instead of the deprecated DashboardContext Brand type.
+ *
+ * This file is a simple re-export so any leftover imports of BrandSwitcher
+ * continue to compile while the migration is in progress. Once all import
+ * sites have been updated to import MerchantSwitcher directly, this file
+ * can be deleted.
+ *
+ * @deprecated Import MerchantSwitcher instead.
+ */
 
-import { useDashboard, type Brand } from "@/contexts/DashboardContext";
-
-const brands: { value: Brand; label: string }[] = [
-  { value: "uniworld", label: "Uniworld" },
-  { value: "luxury-gold", label: "Luxury Gold" },
-  { value: "combined", label: "Combined" },
-];
-
-export default function BrandSwitcher() {
-  const { brand, setBrand } = useDashboard();
-
-  return (
-    <div className="inline-flex items-center rounded-full bg-white/10 p-0.5">
-      {brands.map(({ value, label }) => (
-        <button
-          key={value}
-          onClick={() => setBrand(value)}
-          className={`cursor-pointer rounded-full px-2.5 py-1 text-xs sm:px-4 sm:py-1.5 sm:text-sm font-medium transition-colors whitespace-nowrap ${
-            brand === value
-              ? "bg-[#C5A258] text-white shadow-sm"
-              : "text-white/70 hover:text-white"
-          }`}
-        >
-          {label}
-        </button>
-      ))}
-    </div>
-  );
-}
+export { default } from "./MerchantSwitcher";

--- a/app/src/components/layout/DateRangePicker.tsx
+++ b/app/src/components/layout/DateRangePicker.tsx
@@ -23,6 +23,11 @@ const presets: DatePreset[] = [
 ];
 
 type DateRangePickerProps = {
+  /**
+   * "inverse" (default) — translucent-white styling for use on the dark
+   *   header background.
+   * "neutral" — border + bg styling for use on light surfaces (drawer, etc.).
+   */
   tone?: "inverse" | "neutral";
 };
 
@@ -43,11 +48,11 @@ export default function DateRangePicker({
         dropdownRef.current &&
         !dropdownRef.current.contains(event.target as Node)
       ) {
-        // Delay closing so native date picker interactions aren't interrupted
+        // Delay closing so native date picker interactions aren't interrupted.
         requestAnimationFrame(() => setOpen(false));
       }
     }
-    // Use click (not mousedown) so native date picker popups work
+    // Use click (not mousedown) so native date picker popups work.
     document.addEventListener("click", handleClickOutside);
     return () => document.removeEventListener("click", handleClickOutside);
   }, [open]);
@@ -77,22 +82,26 @@ export default function DateRangePicker({
 
   const displayLabel =
     dateRange.preset === "Custom Range"
-      ? `${format(dateRange.start, "MMM d, yyyy")} - ${format(dateRange.end, "MMM d, yyyy")}`
+      ? `${format(dateRange.start, "MMM d, yyyy")} – ${format(dateRange.end, "MMM d, yyyy")}`
       : dateRange.preset;
 
   return (
     <div className="relative" ref={dropdownRef}>
+      {/* Trigger button */}
       <button
-        onClick={(e) => { e.stopPropagation(); setOpen(!open); }}
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen(!open);
+        }}
         className={`cursor-pointer flex w-full items-center justify-between gap-2 rounded-full px-3.5 py-2 text-sm font-medium shadow-sm transition-colors sm:min-w-[11.5rem] sm:w-auto ${
           isNeutral
-            ? "border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 dark:border-white/15 dark:bg-white/5 dark:text-white dark:hover:bg-white/10"
+            ? "border border-border bg-surface text-text-primary hover:bg-surface-hover dark:border-border"
             : "border border-white/20 bg-white/10 text-white hover:bg-white/20"
         }`}
       >
         <svg
           className={`h-4 w-4 shrink-0 ${
-            isNeutral ? "text-slate-500 dark:text-white/70" : "text-white/70"
+            isNeutral ? "text-text-secondary" : "text-white/70"
           }`}
           fill="none"
           viewBox="0 0 24 24"
@@ -108,7 +117,7 @@ export default function DateRangePicker({
         <span className="truncate">{displayLabel}</span>
         <svg
           className={`h-4 w-4 shrink-0 transition-transform ${
-            isNeutral ? "text-slate-400 dark:text-white/50" : "text-white/50"
+            isNeutral ? "text-text-tertiary" : "text-white/50"
           } ${open ? "rotate-180" : ""}`}
           fill="none"
           viewBox="0 0 24 24"
@@ -123,16 +132,19 @@ export default function DateRangePicker({
         </svg>
       </button>
 
+      {/* Dropdown */}
       {open && (
-        <div className="absolute right-0 z-50 mt-2 w-64 rounded-2xl border border-slate-200 bg-white py-1 shadow-xl dark:border-white/10 dark:bg-[#111927]">
+        <div
+          className="absolute right-0 z-50 mt-2 w-64 rounded-2xl border border-border bg-surface py-1 shadow-xl"
+        >
           {presets.map((preset) => (
             <button
               key={preset}
               onClick={() => handlePresetClick(preset)}
               className={`cursor-pointer w-full px-4 py-2 text-left text-sm transition-colors ${
                 dateRange.preset === preset
-                  ? "bg-[#1B3A5C] text-white"
-                  : "text-slate-700 hover:bg-slate-50 dark:text-white/80 dark:hover:bg-white/5"
+                  ? "bg-brand-accent text-foreground font-medium"
+                  : "text-text-primary hover:bg-surface-hover"
               }`}
             >
               {preset}
@@ -140,32 +152,32 @@ export default function DateRangePicker({
           ))}
 
           {dateRange.preset === "Custom Range" && (
-            <div className="space-y-2 border-t border-slate-100 px-4 py-3 dark:border-white/10">
+            <div className="space-y-2 border-t border-border px-4 py-3">
               <div>
-                <label className="mb-1 block text-xs text-slate-500 dark:text-white/60">
+                <label className="mb-1 block text-xs text-text-secondary">
                   Start Date
                 </label>
                 <input
                   type="date"
                   value={customStart}
                   onChange={(e) => setCustomStart(e.target.value)}
-                  className="w-full rounded border border-slate-200 px-2 py-1 text-sm dark:border-white/15 dark:bg-white/5 dark:text-white"
+                  className="w-full rounded border border-input-border bg-input-bg px-2 py-1 text-sm text-text-primary"
                 />
               </div>
               <div>
-                <label className="mb-1 block text-xs text-slate-500 dark:text-white/60">
+                <label className="mb-1 block text-xs text-text-secondary">
                   End Date
                 </label>
                 <input
                   type="date"
                   value={customEnd}
                   onChange={(e) => setCustomEnd(e.target.value)}
-                  className="w-full rounded border border-slate-200 px-2 py-1 text-sm dark:border-white/15 dark:bg-white/5 dark:text-white"
+                  className="w-full rounded border border-input-border bg-input-bg px-2 py-1 text-sm text-text-primary"
                 />
               </div>
               <button
                 onClick={handleCustomApply}
-                className="cursor-pointer w-full rounded bg-[#C5A258] px-3 py-1.5 text-sm font-medium text-white hover:bg-[#b3913e] transition-colors"
+                className="cursor-pointer w-full rounded bg-brand-accent px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:opacity-90"
               >
                 Apply
               </button>

--- a/app/src/components/layout/Header.tsx
+++ b/app/src/components/layout/Header.tsx
@@ -1,51 +1,111 @@
 "use client";
 
-import AuthButton from "./AuthButton";
-import BrandSwitcher from "./BrandSwitcher";
+/**
+ * Header — single sticky application bar.
+ *
+ * Consolidates the old two-bar layout (Header + Navigation) into one bar.
+ * Renders across all viewports:
+ *
+ * Desktop (md+):
+ *   [App title]  [NavTabs — centred]  [MerchantSwitcher | DatePicker | Refresh | Theme | Auth]
+ *
+ * Mobile (< md):
+ *   [App title]  [Hamburger → MobileDrawer]
+ *
+ * Background is driven by the --header-bg CSS variable injected by
+ * BrandProvider, so the colour updates automatically when the brand or
+ * colour-mode changes.
+ */
+
+import { useState } from "react";
+import { useBrand } from "@/contexts/BrandContext";
+import { hasFirebaseWebConfig } from "@/lib/firebase";
+import NavTabs from "./NavTabs";
+import MerchantSwitcher from "./MerchantSwitcher";
+import MobileDrawer from "./MobileDrawer";
 import DateRangePicker from "./DateRangePicker";
 import RefreshButton from "./RefreshButton";
 import ThemeToggle from "./ThemeToggle";
-import { hasFirebaseWebConfig } from "@/lib/firebase";
+import AuthButton from "./AuthButton";
 
 export default function Header() {
+  const { brand } = useBrand();
   const showAuthControls = hasFirebaseWebConfig();
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   return (
-    <header className="bg-[#1B3A5C] text-white shadow-md">
-      <div className="mx-auto max-w-7xl px-4 py-2 sm:px-6 sm:py-3 lg:px-8">
-        <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between md:gap-4">
-          <div className="flex items-center justify-between gap-3">
-            <h1 className="whitespace-nowrap text-base font-semibold tracking-wide text-white sm:text-lg">
-              Feefo Reviews
-            </h1>
-            <div className="flex items-center gap-2 md:hidden">
-              <DateRangePicker />
-              <ThemeToggle />
+    <>
+      <header
+        className="shadow-sm"
+        style={{ backgroundColor: "var(--header-bg)", color: "var(--header-text)" }}
+      >
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="flex h-14 items-stretch justify-between gap-4 sm:h-16">
+            {/* ── Left: App title ─────────────────────────────────────────── */}
+            <div className="flex shrink-0 items-center">
+              <span
+                className="whitespace-nowrap text-base font-semibold tracking-wide sm:text-lg"
+                style={{ color: "var(--header-text)" }}
+              >
+                {brand.appTitle}
+              </span>
+            </div>
+
+            {/* ── Center: NavTabs (desktop only) ──────────────────────────── */}
+            <div className="hidden flex-1 items-stretch justify-center md:flex">
+              <NavTabs />
+            </div>
+
+            {/* ── Right: Controls (desktop only) ──────────────────────────── */}
+            <div className="hidden items-center gap-2 md:flex">
+              <MerchantSwitcher tone="inverse" />
+              <DateRangePicker tone="inverse" />
               {showAuthControls ? (
-                <AuthButton tone="inverse" showEmail={false} showStatus={false} />
+                <>
+                  <RefreshButton tone="inverse" showSyncLabel />
+                  <AuthButton
+                    tone="inverse"
+                    showEmail
+                    showStatus={false}
+                  />
+                </>
               ) : null}
+              <ThemeToggle />
+            </div>
+
+            {/* ── Mobile: Hamburger ────────────────────────────────────────── */}
+            <div className="flex items-center md:hidden">
+              <button
+                onClick={() => setDrawerOpen(true)}
+                className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-lg border border-white/20 bg-white/10 text-white transition-colors hover:bg-white/20"
+                aria-label="Open menu"
+                aria-expanded={drawerOpen}
+                aria-controls="mobile-drawer"
+              >
+                <svg
+                  className="h-5 w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={2}
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"
+                  />
+                </svg>
+              </button>
             </div>
           </div>
-          <div className="flex items-center justify-between gap-3">
-            <BrandSwitcher />
-            {showAuthControls ? (
-              <div className="md:hidden">
-                <RefreshButton tone="inverse" showSyncLabel={false} />
-              </div>
-            ) : null}
-          </div>
-          <div className="hidden items-center gap-2 md:flex">
-            <DateRangePicker />
-            <ThemeToggle />
-            {showAuthControls ? (
-              <>
-                <RefreshButton tone="inverse" showSyncLabel />
-                <AuthButton tone="inverse" showEmail showStatus={false} />
-              </>
-            ) : null}
-          </div>
         </div>
-      </div>
-    </header>
+      </header>
+
+      {/* Mobile drawer (portal-like, rendered outside the header) */}
+      <MobileDrawer
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+      />
+    </>
   );
 }

--- a/app/src/components/layout/MerchantSwitcher.tsx
+++ b/app/src/components/layout/MerchantSwitcher.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+/**
+ * MerchantSwitcher — pill-style selector for switching between merchant scopes.
+ *
+ * Replaces the old BrandSwitcher component which was hard-wired to
+ * DashboardContext with a static list of brands. This version reads the
+ * dynamic merchant list from BrandContext and only renders when the active
+ * brand has 2 or more merchants (a single-merchant brand has nothing to switch).
+ *
+ * "All" maps to activeMerchant = "all" in BrandContext (→ "combined" query ID).
+ *
+ * Accepts a `tone` prop so it can be used both in the dark header bar and
+ * on lighter surfaces (e.g. the mobile drawer).
+ */
+
+import { useBrand, type ActiveMerchant } from "@/contexts/BrandContext";
+
+type MerchantSwitcherProps = {
+  /**
+   * "inverse" — renders with translucent-white styling for use on the dark
+   *   header background (default).
+   * "neutral" — renders with border/bg styling for use on light surfaces.
+   */
+  tone?: "inverse" | "neutral";
+};
+
+export default function MerchantSwitcher({
+  tone = "inverse",
+}: MerchantSwitcherProps) {
+  const { brand, activeMerchant, setActiveMerchant } = useBrand();
+
+  // Nothing to switch when there is only one (or zero) merchants.
+  if (brand.merchants.length < 2) return null;
+
+  const options: { value: ActiveMerchant; label: string }[] = [
+    { value: "all", label: "All" },
+    ...brand.merchants.map((m) => ({ value: m.id, label: m.label })),
+  ];
+
+  const isInverse = tone === "inverse";
+
+  return (
+    <div
+      className={`inline-flex items-center rounded-full p-0.5 ${
+        isInverse ? "bg-white/10" : "bg-surface-alt border border-border"
+      }`}
+    >
+      {options.map(({ value, label }) => {
+        const isActive = activeMerchant === value;
+        return (
+          <button
+            key={value}
+            onClick={() => setActiveMerchant(value)}
+            className={`cursor-pointer rounded-full px-2.5 py-1 text-xs font-medium transition-colors whitespace-nowrap sm:px-4 sm:py-1.5 sm:text-sm ${
+              isActive
+                ? isInverse
+                  ? "bg-brand-accent text-foreground shadow-sm"
+                  : "bg-surface text-text-primary shadow-sm border border-border"
+                : isInverse
+                  ? "text-white/70 hover:text-white"
+                  : "text-text-secondary hover:text-text-primary"
+            }`}
+            aria-pressed={isActive}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/src/components/layout/MobileDrawer.tsx
+++ b/app/src/components/layout/MobileDrawer.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+/**
+ * MobileDrawer — slide-in side panel for small screens.
+ *
+ * Contains everything that the consolidated header bar hides at < md:
+ *   - Primary nav links (with active state)
+ *   - MerchantSwitcher (if 2+ merchants)
+ *   - DateRangePicker
+ *   - RefreshButton (if Firebase is configured)
+ *   - Dark / light mode toggle
+ *   - Auth button
+ *
+ * The drawer slides in from the right, matching the `animate-slide-in-right`
+ * keyframe defined in globals.css.
+ */
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { onAuthStateChanged, type User } from "firebase/auth";
+import { useBrand } from "@/contexts/BrandContext";
+import { getClientAuth, hasFirebaseWebConfig } from "@/lib/firebase";
+import { getCurrentAdminAccess } from "@/lib/firestore/admin-queries";
+import MerchantSwitcher from "./MerchantSwitcher";
+import DateRangePicker from "./DateRangePicker";
+import RefreshButton from "./RefreshButton";
+import ThemeToggle from "./ThemeToggle";
+import AuthButton from "./AuthButton";
+
+type MobileDrawerProps = {
+  open: boolean;
+  onClose: () => void;
+};
+
+const NAV_LINKS = [
+  { href: "/", label: "Overview" },
+  { href: "/itineraries", label: "Itineraries" },
+  { href: "/reviews", label: "Reviews" },
+  { href: "/ships", label: "Ships" },
+  { href: "/admin", label: "Admin" },
+] as const;
+
+export default function MobileDrawer({ open, onClose }: MobileDrawerProps) {
+  const pathname = usePathname();
+  const { showShipsTab } = useBrand();
+  const showAuthControls = hasFirebaseWebConfig();
+
+  const [user, setUser] = useState<User | null>(null);
+  const [showAdminLink, setShowAdminLink] = useState(false);
+
+  // ── Auth state ──────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!showAuthControls) return;
+    try {
+      const auth = getClientAuth();
+      return onAuthStateChanged(auth, (nextUser) => {
+        setUser(nextUser);
+        if (!nextUser) setShowAdminLink(false);
+      });
+    } catch {
+      return;
+    }
+  }, [showAuthControls]);
+
+  // ── Admin-access check ──────────────────────────────────────────────────
+  useEffect(() => {
+    let cancelled = false;
+    if (!showAuthControls || !user) return;
+    getCurrentAdminAccess()
+      .then((access) => {
+        if (cancelled) return;
+        setShowAdminLink(
+          Boolean(
+            access.permissions.sync ||
+              access.permissions.manageMappings ||
+              access.permissions.manageUsers,
+          ),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setShowAdminLink(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [showAuthControls, user]);
+
+  // Lock body scroll while open.
+  useEffect(() => {
+    if (!open) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  // Close on Escape.
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  // Filter links to visible tabs — mirrors NavTabs logic, including the
+  // async admin-access check so authorized users can reach /admin on mobile.
+  const visibleLinks = NAV_LINKS.filter(({ href }) => {
+    if (href === "/ships") return showShipsTab;
+    if (href === "/admin") return showAdminLink;
+    return true;
+  });
+
+  return (
+    <div className="fixed inset-0 z-50" role="dialog" aria-modal="true">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden
+      />
+
+      {/* Panel */}
+      <div className="animate-slide-in-right absolute right-0 top-0 flex h-full w-72 max-w-[85vw] flex-col bg-surface shadow-xl">
+        {/* Header row */}
+        <div className="flex items-center justify-between border-b border-border px-4 py-4">
+          <span className="text-sm font-semibold text-text-primary">Menu</span>
+          <button
+            onClick={onClose}
+            className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-lg text-text-secondary transition-colors hover:bg-surface-hover hover:text-text-primary"
+            aria-label="Close menu"
+          >
+            <svg
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Scrollable body */}
+        <div className="flex flex-1 flex-col gap-5 overflow-y-auto p-4">
+          {/* Nav links */}
+          <nav aria-label="Mobile navigation">
+            <ul className="space-y-1">
+              {visibleLinks.map(({ href, label }) => {
+                const isActive =
+                  href === "/"
+                    ? pathname === "/"
+                    : pathname.startsWith(href);
+                return (
+                  <li key={href}>
+                    <Link
+                      href={href}
+                      onClick={onClose}
+                      className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
+                        isActive
+                          ? "bg-brand-accent/10 text-text-primary font-semibold"
+                          : "text-text-secondary hover:bg-surface-hover hover:text-text-primary"
+                      }`}
+                    >
+                      {isActive && (
+                        <span className="h-1.5 w-1.5 rounded-full bg-nav-active-indicator" />
+                      )}
+                      {!isActive && <span className="h-1.5 w-1.5" />}
+                      {label}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </nav>
+
+          {/* Divider */}
+          <div className="border-t border-border" />
+
+          {/* Merchant switcher */}
+          <div className="space-y-1.5">
+            <p className="px-1 text-xs font-medium text-text-tertiary uppercase tracking-wide">
+              View
+            </p>
+            <MerchantSwitcher tone="neutral" />
+          </div>
+
+          {/* Date range */}
+          <div className="space-y-1.5">
+            <p className="px-1 text-xs font-medium text-text-tertiary uppercase tracking-wide">
+              Date Range
+            </p>
+            <DateRangePicker tone="neutral" />
+          </div>
+
+          {/* Refresh */}
+          {showAuthControls ? (
+            <div className="space-y-1.5">
+              <p className="px-1 text-xs font-medium text-text-tertiary uppercase tracking-wide">
+                Sync
+              </p>
+              <RefreshButton tone="neutral" showSyncLabel />
+            </div>
+          ) : null}
+
+          {/* Divider */}
+          <div className="border-t border-border" />
+
+          {/* Theme toggle + Auth */}
+          <div className="flex items-center justify-between gap-3">
+            <ThemeToggle tone="neutral" />
+            {showAuthControls ? (
+              <AuthButton tone="neutral" showEmail={false} showStatus />
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/layout/NavTabs.tsx
+++ b/app/src/components/layout/NavTabs.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+/**
+ * NavTabs — horizontal tab bar for the primary app navigation.
+ *
+ * Extracted from Navigation.tsx so it can be embedded directly in the
+ * consolidated Header bar.  Uses BrandContext for the showShipsTab flag
+ * instead of the legacy DashboardContext.
+ */
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { onAuthStateChanged, type User } from "firebase/auth";
+import { getClientAuth, hasFirebaseWebConfig } from "@/lib/firebase";
+import { getCurrentAdminAccess } from "@/lib/firestore/admin-queries";
+import { useBrand } from "@/contexts/BrandContext";
+
+const BASE_TABS = [
+  { href: "/", label: "Overview" },
+  { href: "/itineraries", label: "Itineraries" },
+  { href: "/reviews", label: "Reviews" },
+] as const;
+
+export default function NavTabs() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const { showShipsTab } = useBrand();
+  const showAuthControls = hasFirebaseWebConfig();
+
+  const [user, setUser] = useState<User | null>(null);
+  const [showAdminTab, setShowAdminTab] = useState(false);
+  const [checkingAdminAccess, setCheckingAdminAccess] =
+    useState(showAuthControls);
+
+  // ── Auth state ──────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (!showAuthControls) return;
+    try {
+      const auth = getClientAuth();
+      return onAuthStateChanged(auth, (nextUser) => {
+        setUser(nextUser);
+        if (!nextUser) {
+          setShowAdminTab(false);
+          setCheckingAdminAccess(false);
+        } else {
+          setCheckingAdminAccess(true);
+        }
+      });
+    } catch {
+      return;
+    }
+  }, [showAuthControls]);
+
+  // ── Admin-access check ───────────────────────────────────────────────────
+  useEffect(() => {
+    let cancelled = false;
+    if (!showAuthControls || !user) return;
+
+    queueMicrotask(() => setCheckingAdminAccess(true));
+
+    getCurrentAdminAccess()
+      .then((access) => {
+        if (cancelled) return;
+        setShowAdminTab(
+          Boolean(
+            access.permissions.sync ||
+              access.permissions.manageMappings ||
+              access.permissions.manageUsers,
+          ),
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setShowAdminTab(false);
+      })
+      .finally(() => {
+        if (!cancelled) setCheckingAdminAccess(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [showAuthControls, user]);
+
+  // ── Guard: redirect off /ships when tab is not available ────────────────
+  useEffect(() => {
+    if (!showShipsTab && pathname.startsWith("/ships")) {
+      router.replace("/itineraries");
+    }
+  }, [pathname, router, showShipsTab]);
+
+  // ── Build tab list ───────────────────────────────────────────────────────
+  const tabs = [...BASE_TABS] as { href: string; label: string }[];
+  if (showShipsTab) tabs.splice(2, 0, { href: "/ships", label: "Ships" });
+  if (showAdminTab || (pathname.startsWith("/admin") && checkingAdminAccess)) {
+    tabs.push({ href: "/admin", label: "Admin" });
+  }
+
+  return (
+    <nav aria-label="Main navigation" className="flex items-stretch gap-0.5 sm:gap-1">
+      {tabs.map(({ href, label }) => {
+        const isActive =
+          href === "/" ? pathname === "/" : pathname.startsWith(href);
+
+        return (
+          <Link
+            key={href}
+            href={href}
+            className={`relative flex items-center whitespace-nowrap rounded-md px-2.5 py-2 text-xs font-medium transition-colors sm:px-4 sm:text-sm ${
+              isActive
+                ? "font-semibold text-header-text"
+                : "text-nav-inactive-text hover:text-header-text"
+            }`}
+          >
+            {label}
+            {isActive && (
+              <span
+                aria-hidden
+                className="absolute bottom-0 left-2 right-2 h-0.5 rounded-full bg-nav-active-indicator sm:left-3 sm:right-3"
+              />
+            )}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/app/src/components/layout/Navigation.tsx
+++ b/app/src/components/layout/Navigation.tsx
@@ -1,127 +1,20 @@
-"use client";
-
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
-import { onAuthStateChanged, type User } from "firebase/auth";
-import { getClientAuth, hasFirebaseWebConfig } from "@/lib/firebase";
-import { getCurrentAdminAccess } from "@/lib/firestore/admin-queries";
-import { brandHasShips, useDashboard } from "@/contexts/DashboardContext";
-
-const baseTabs = [
-  { href: "/", label: "Overview" },
-  { href: "/itineraries", label: "Itineraries" },
-  { href: "/reviews", label: "Reviews" },
-];
+/**
+ * Navigation.tsx — deleted / replaced.
+ *
+ * This component has been superseded by NavTabs.tsx which is rendered
+ * directly inside the consolidated Header bar.  The separate two-bar layout
+ * (Header + Navigation) no longer exists.
+ *
+ * This stub exists only to surface a clear error message if something tries
+ * to import this file during the transition period.
+ *
+ * @deprecated Use NavTabs (embedded in Header) instead.
+ */
 
 export default function Navigation() {
-  const router = useRouter();
-  const pathname = usePathname();
-  const { brand } = useDashboard();
-  const showAuthControls = hasFirebaseWebConfig();
-  const [user, setUser] = useState<User | null>(null);
-  const [showAdminTab, setShowAdminTab] = useState(false);
-  const [checkingAdminAccess, setCheckingAdminAccess] = useState(showAuthControls);
-  const showShipsTab = brandHasShips(brand);
-
-  useEffect(() => {
-    if (!showAuthControls) {
-      return;
-    }
-
-    try {
-      const auth = getClientAuth();
-      return onAuthStateChanged(auth, (nextUser) => {
-        setUser(nextUser);
-        if (!nextUser) {
-          setShowAdminTab(false);
-          setCheckingAdminAccess(false);
-        } else {
-          setCheckingAdminAccess(true);
-        }
-      });
-    } catch {
-      return;
-    }
-  }, [showAuthControls]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    if (!showAuthControls || !user) {
-      return;
-    }
-
-    queueMicrotask(() => setCheckingAdminAccess(true));
-
-    getCurrentAdminAccess()
-      .then((access) => {
-        if (cancelled) return;
-        setShowAdminTab(
-          Boolean(
-            access.permissions.sync ||
-              access.permissions.manageMappings ||
-              access.permissions.manageUsers
-          )
-        );
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setShowAdminTab(false);
-      })
-      .finally(() => {
-        if (cancelled) return;
-        setCheckingAdminAccess(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [showAuthControls, user]);
-
-  const tabs = [...baseTabs];
-  if (showShipsTab) {
-    tabs.splice(2, 0, { href: "/ships", label: "Ships" });
-  }
-  if (showAdminTab || (pathname.startsWith("/admin") && checkingAdminAccess)) {
-    tabs.push({ href: "/admin", label: "Admin" });
-  }
-
-  useEffect(() => {
-    if (!showShipsTab && pathname.startsWith("/ships")) {
-      router.replace("/itineraries");
-    }
-  }, [pathname, router, showShipsTab]);
-
-  return (
-    <nav className="border-b border-gray-200 bg-white shadow-sm dark:bg-[#111927] dark:border-[#1e2d44]">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <div className="py-1.5 sm:py-2.5">
-          <div className="flex items-center gap-0.5 sm:gap-1">
-            {tabs.map(({ href, label }) => {
-              const isActive =
-                href === "/" ? pathname === "/" : pathname.startsWith(href);
-
-              return (
-                <Link
-                  key={href}
-                  href={href}
-                  className={`relative whitespace-nowrap rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors sm:px-4 sm:py-2.5 sm:text-sm ${
-                    isActive
-                      ? "font-semibold text-[#1B3A5C] dark:text-white"
-                      : "text-gray-500 hover:text-[#1B3A5C] dark:text-white/60 dark:hover:text-white"
-                  }`}
-                >
-                  {label}
-                  {isActive && (
-                    <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-[#C5A258]" />
-                  )}
-                </Link>
-              );
-            })}
-          </div>
-        </div>
-      </div>
-    </nav>
+  throw new Error(
+    "Navigation.tsx has been deleted. " +
+    "NavTabs is now embedded inside Header.tsx. " +
+    "Remove any import of Navigation from your codebase."
   );
 }

--- a/app/src/components/layout/RefreshButton.tsx
+++ b/app/src/components/layout/RefreshButton.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect } from "react";
 import { format, formatDistanceToNow } from "date-fns";
 import { onAuthStateChanged } from "firebase/auth";
-import { useDashboard, type Brand } from "@/contexts/DashboardContext";
+import { useDashboard } from "@/contexts/DashboardContext";
+import { useBrand, type ActiveMerchant } from "@/contexts/BrandContext";
 import { getClientAuth, getClientDb } from "@/lib/firebase";
 import { postFunction } from "@/lib/functions-client";
 import { doc, getDoc } from "firebase/firestore";
@@ -19,10 +20,8 @@ type SyncMetaState = {
   startedAt: string | null;
 };
 
-const SYNC_BRANDS: Exclude<Brand, "combined">[] = ["uniworld", "luxury-gold"];
-
-function getBrandsToLoad(brand: Brand): Exclude<Brand, "combined">[] {
-  return brand === "combined" ? SYNC_BRANDS : [brand];
+function getBrandsToLoad(activeMerchant: ActiveMerchant, allMerchantIds: string[]): string[] {
+  return activeMerchant === "all" ? allMerchantIds : [activeMerchant];
 }
 
 function getMostStaleTimestamp(syncStates: SyncMetaState[]): string | null {
@@ -40,10 +39,11 @@ function getMostStaleTimestamp(syncStates: SyncMetaState[]): string | null {
 }
 
 function buildSyncTitle(
-  brand: Brand,
+  activeMerchant: ActiveMerchant,
+  allMerchantIds: string[],
   syncStates: Record<string, SyncMetaState>
 ): string {
-  const labels = getBrandsToLoad(brand).map((currentBrand) => {
+  const labels = getBrandsToLoad(activeMerchant, allMerchantIds).map((currentBrand) => {
     const state = syncStates[currentBrand];
 
     if (!state?.lastSyncAt) {
@@ -60,7 +60,9 @@ export default function RefreshButton({
   tone = "neutral",
   showSyncLabel = true,
 }: RefreshButtonProps) {
-  const { brand, lastSynced, setLastSynced, bumpDataVersion } = useDashboard();
+  const { activeMerchant, brand: brandConfig } = useBrand();
+  const allMerchantIds = brandConfig.merchants.map((m) => m.id);
+  const { lastSynced, setLastSynced, bumpDataVersion } = useDashboard();
   const [syncing, setSyncing] = useState(false);
   const [isSignedIn, setIsSignedIn] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
@@ -68,9 +70,9 @@ export default function RefreshButton({
   const [isSyncInProgress, setIsSyncInProgress] = useState(false);
   const isNeutral = tone === "neutral";
 
-  async function loadSyncState(selectedBrand: Brand): Promise<string | null> {
+  async function loadSyncState(selectedMerchant: ActiveMerchant): Promise<string | null> {
     const db = getClientDb();
-    const brands = getBrandsToLoad(selectedBrand);
+    const brands = getBrandsToLoad(selectedMerchant, allMerchantIds);
     const entries = await Promise.all(
       brands.map(async (currentBrand) => {
         const snapshot = await getDoc(doc(db, "sync_meta", currentBrand));
@@ -93,20 +95,20 @@ export default function RefreshButton({
     const displayTimestamp = getMostStaleTimestamp(Object.values(syncStates));
 
     setIsSyncInProgress(anySyncing);
-    setSyncTitle(buildSyncTitle(selectedBrand, syncStates));
+    setSyncTitle(buildSyncTitle(selectedMerchant, allMerchantIds, syncStates));
     setLastSynced(displayTimestamp);
 
     return displayTimestamp;
   }
 
   useEffect(() => {
-    loadSyncState(brand).catch(() => {
+    loadSyncState(activeMerchant).catch(() => {
       setSyncTitle("Sync status unavailable");
       setIsSyncInProgress(false);
       setLastSynced(null);
     });
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- loadSyncState is stable, only brand should trigger reload
-  }, [brand, setLastSynced]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- loadSyncState is stable, only activeMerchant should trigger reload
+  }, [activeMerchant, setLastSynced]);
 
   const syncLabel =
     syncing || isSyncInProgress
@@ -140,7 +142,7 @@ export default function RefreshButton({
     setMessage(null);
     try {
       await postFunction("manualSync", { fullSync: false });
-      await loadSyncState(brand);
+      await loadSyncState(activeMerchant);
       bumpDataVersion();
       setMessage("Sync complete.");
     } catch (err) {
@@ -156,7 +158,7 @@ export default function RefreshButton({
         <span
           title={syncTitle}
           className={`hidden text-xs md:inline ${
-            isNeutral ? "text-slate-500 dark:text-white/60" : "text-white/70"
+            isNeutral ? "text-text-secondary" : "text-white/70"
           }`}
         >
           {syncLabel}
@@ -167,7 +169,7 @@ export default function RefreshButton({
         disabled={syncing || !isSignedIn}
         className={`cursor-pointer flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 ${
           isNeutral
-            ? "border border-slate-200 bg-white text-slate-700 shadow-sm hover:bg-slate-50 dark:border-white/15 dark:bg-white/5 dark:text-white dark:hover:bg-white/10"
+            ? "border border-border bg-surface text-text-primary shadow-sm hover:bg-surface-hover"
             : "border border-white/20 bg-white/10 text-white hover:bg-white/20"
         }`}
       >
@@ -189,7 +191,7 @@ export default function RefreshButton({
       {message ? (
         <span
           className={`hidden max-w-[220px] truncate text-xs xl:inline ${
-            isNeutral ? "text-slate-500 dark:text-white/60" : "text-white/70"
+            isNeutral ? "text-text-secondary" : "text-white/70"
           }`}
         >
           {message}

--- a/app/src/components/layout/ThemeToggle.tsx
+++ b/app/src/components/layout/ThemeToggle.tsx
@@ -2,20 +2,37 @@
 
 import { useTheme } from "@/contexts/ThemeContext";
 
-export default function ThemeToggle() {
+type ThemeToggleProps = {
+  /**
+   * "inverse" (default) — translucent-white styling for use on the dark
+   *   header background.
+   * "neutral" — border + surface styling for use on light backgrounds
+   *   (e.g. the MobileDrawer panel).
+   */
+  tone?: "inverse" | "neutral";
+};
+
+export default function ThemeToggle({ tone = "inverse" }: ThemeToggleProps) {
   const { theme, toggleTheme } = useTheme();
+  const isNeutral = tone === "neutral";
 
   return (
     <button
       onClick={toggleTheme}
-      className="cursor-pointer relative flex items-center justify-center h-8 w-8 rounded-lg border border-white/20 bg-white/10 text-white hover:bg-white/20 transition-colors"
+      className={`cursor-pointer relative flex items-center justify-center h-8 w-8 rounded-lg transition-colors ${
+        isNeutral
+          ? "border border-border bg-surface text-text-secondary hover:bg-surface-hover hover:text-text-primary"
+          : "border border-white/20 bg-white/10 text-white hover:bg-white/20"
+      }`}
       aria-label={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
       title={`Switch to ${theme === "light" ? "dark" : "light"} mode`}
     >
-      {/* Sun icon (shown in dark mode) */}
+      {/* Sun icon — shown in dark mode */}
       <svg
         className={`h-4 w-4 transition-all duration-300 absolute ${
-          theme === "dark" ? "opacity-100 rotate-0 scale-100" : "opacity-0 rotate-90 scale-0"
+          theme === "dark"
+            ? "opacity-100 rotate-0 scale-100"
+            : "opacity-0 rotate-90 scale-0"
         }`}
         fill="none"
         viewBox="0 0 24 24"
@@ -28,10 +45,12 @@ export default function ThemeToggle() {
           d="M12 3v2.25m6.364.386l-1.591 1.591M21 12h-2.25m-.386 6.364l-1.591-1.591M12 18.75V21m-4.773-4.227l-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z"
         />
       </svg>
-      {/* Moon icon (shown in light mode) */}
+      {/* Moon icon — shown in light mode */}
       <svg
         className={`h-4 w-4 transition-all duration-300 absolute ${
-          theme === "light" ? "opacity-100 rotate-0 scale-100" : "opacity-0 -rotate-90 scale-0"
+          theme === "light"
+            ? "opacity-100 rotate-0 scale-100"
+            : "opacity-0 -rotate-90 scale-0"
         }`}
         fill="none"
         viewBox="0 0 24 24"

--- a/app/src/components/reviews/ExportButton.tsx
+++ b/app/src/components/reviews/ExportButton.tsx
@@ -54,7 +54,7 @@ export default function ExportButton({ reviews }: ExportButtonProps) {
     <button
       onClick={handleExport}
       disabled={reviews.length === 0}
-      className="inline-flex items-center gap-2 rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+      className="inline-flex items-center gap-2 rounded-lg border border-border bg-surface px-4 py-2 text-sm font-medium text-text-primary shadow-sm hover:bg-surface-hover disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
     >
       <svg
         className="h-4 w-4"

--- a/app/src/components/reviews/FilterSidebar.tsx
+++ b/app/src/components/reviews/FilterSidebar.tsx
@@ -47,7 +47,7 @@ interface FilterSidebarProps {
 function ChevronIcon({ open }: { open: boolean }) {
   return (
     <svg
-      className={`h-4 w-4 text-gray-400 transition-transform ${open ? "rotate-180" : ""}`}
+      className={`h-4 w-4 text-text-tertiary transition-transform ${open ? "rotate-180" : ""}`}
       fill="none"
       viewBox="0 0 24 24"
       stroke="currentColor"
@@ -70,10 +70,10 @@ function FilterSection({
   const [open, setOpen] = useState(defaultOpen);
 
   return (
-    <div className="border-b border-gray-100 last:border-0">
+    <div className="border-b border-border-light last:border-0">
       <button
         onClick={() => setOpen(!open)}
-        className="flex w-full items-center justify-between py-3 text-sm font-medium text-[#1B3A5C] hover:text-[#1B3A5C]/80"
+        className="flex w-full items-center justify-between py-3 text-sm font-medium text-text-primary hover:text-text-primary/80"
       >
         {title}
         <ChevronIcon open={open} />
@@ -93,12 +93,12 @@ function CheckboxItem({
   onChange: (checked: boolean) => void;
 }) {
   return (
-    <label className="flex items-center gap-2 cursor-pointer text-sm text-gray-600 hover:text-gray-900">
+    <label className="flex items-center gap-2 cursor-pointer text-sm text-text-secondary hover:text-text-primary">
       <input
         type="checkbox"
         checked={checked}
         onChange={(e) => onChange(e.target.checked)}
-        className="h-3.5 w-3.5 rounded border-gray-300 text-[#1B3A5C] focus:ring-[#1B3A5C]/30"
+        className="h-3.5 w-3.5 rounded border-input-border text-text-primary focus:ring-brand-accent/30"
       />
       {label}
     </label>
@@ -168,7 +168,7 @@ export default function FilterSidebar({ filters, onChange, options }: FilterSide
       {activeFilterCount > 0 && (
         <div className="mb-4">
           <div className="flex items-center justify-between mb-2">
-            <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+            <span className="text-xs font-medium text-text-secondary uppercase tracking-wide">
               Active filters ({activeFilterCount})
             </span>
             <button
@@ -182,7 +182,7 @@ export default function FilterSidebar({ filters, onChange, options }: FilterSide
             {chips.map((chip) => (
               <span
                 key={`${chip.key}-${chip.value}`}
-                className="inline-flex items-center gap-1 rounded-full bg-[#1B3A5C]/10 px-2.5 py-1 text-xs font-medium text-[#1B3A5C]"
+                className="inline-flex items-center gap-1 rounded-full bg-brand-primary-light px-2.5 py-1 text-xs font-medium text-text-primary"
               >
                 {chip.label}
                 <button
@@ -199,13 +199,13 @@ export default function FilterSidebar({ filters, onChange, options }: FilterSide
       )}
 
       {/* Media toggle */}
-      <div className="border-b border-gray-100 py-3">
-        <label className="flex items-center gap-2 cursor-pointer text-sm font-medium text-[#1B3A5C]">
+      <div className="border-b border-border-light py-3">
+        <label className="flex items-center gap-2 cursor-pointer text-sm font-medium text-text-primary">
           <input
             type="checkbox"
             checked={filters.hasMedia}
             onChange={(e) => onChange({ ...filters, hasMedia: e.target.checked })}
-            className="h-3.5 w-3.5 rounded border-gray-300 text-[#1B3A5C] focus:ring-[#1B3A5C]/30"
+            className="h-3.5 w-3.5 rounded border-input-border text-text-primary focus:ring-brand-accent/30"
           />
           Only reviews with photos or videos
         </label>

--- a/app/src/components/reviews/MediaThumbnails.tsx
+++ b/app/src/components/reviews/MediaThumbnails.tsx
@@ -57,7 +57,7 @@ export default function MediaThumbnails({ media, size = "md" }: MediaThumbnailsP
               e.stopPropagation();
               setLightboxIndex(i);
             }}
-            className={`${sizeClass} rounded-lg overflow-hidden border border-gray-200 hover:border-[#1B3A5C] hover:shadow-sm transition-all flex-shrink-0`}
+            className={`${sizeClass} rounded-lg overflow-hidden border border-border hover:border-brand-accent hover:shadow-sm transition-all flex-shrink-0`}
           >
             <img
               src={photo.url}
@@ -75,10 +75,10 @@ export default function MediaThumbnails({ media, size = "md" }: MediaThumbnailsP
             target="_blank"
             rel="noopener noreferrer"
             onClick={(e) => e.stopPropagation()}
-            className={`${sizeClass} rounded-lg overflow-hidden border border-gray-200 hover:border-[#1B3A5C] hover:shadow-sm transition-all flex-shrink-0 relative bg-[#1B3A5C]/10 flex items-center justify-center`}
+            className={`${sizeClass} rounded-lg overflow-hidden border border-border hover:border-brand-accent hover:shadow-sm transition-all flex-shrink-0 relative bg-brand-primary-light flex items-center justify-center`}
           >
             <svg
-              className="w-6 h-6 text-[#1B3A5C]/70"
+              className="w-6 h-6 text-text-secondary"
               fill="currentColor"
               viewBox="0 0 24 24"
             >

--- a/app/src/components/reviews/ReviewCard.tsx
+++ b/app/src/components/reviews/ReviewCard.tsx
@@ -33,7 +33,7 @@ export interface ReviewData {
 
 function StarRating({ rating }: { rating: number }) {
   return (
-    <span className="text-[#C5A258]" aria-label={`${rating} out of 5 stars`}>
+    <span className="text-brand-accent" aria-label={`${rating} out of 5 stars`}>
       {Array.from({ length: 5 }, (_, i) => (
         <span key={i}>{i < rating ? "\u2605" : "\u2606"}</span>
       ))}
@@ -63,14 +63,14 @@ export default function ReviewCard({ review, onThemeClick }: ReviewCardProps) {
   }, [fullText]);
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-5 shadow-sm">
+    <div className="rounded-lg border border-border bg-surface p-5 shadow-sm">
       {/* Header */}
       <div className="flex items-start justify-between gap-3 mb-2">
         <div>
-          <span className="font-medium text-[#1B3A5C]">
+          <span className="font-medium text-text-primary">
             {review.customerName || "Trusted Customer"}
           </span>
-          <span className="ml-2 text-xs text-gray-400">
+          <span className="ml-2 text-xs text-text-tertiary">
             {new Date(review.date).toLocaleDateString("en-GB", {
               day: "numeric",
               month: "short",
@@ -82,17 +82,17 @@ export default function ReviewCard({ review, onThemeClick }: ReviewCardProps) {
       </div>
 
       {/* Meta — clickable itinerary and ship links */}
-      <div className="text-xs text-gray-500 mb-3 space-y-0.5">
+      <div className="text-xs text-text-secondary mb-3 space-y-0.5">
         {review.parentItinerary && (
           <div className="flex items-center gap-1.5">
             <Link
               href={`/itineraries?slug=${encodeURIComponent(slugify(review.parentItinerary))}`}
-              className="text-[#1B3A5C]/70 hover:text-[#1B3A5C] hover:underline"
+              className="text-text-primary/70 hover:text-text-primary hover:underline"
             >
               {review.parentItinerary}
             </Link>
             {review.brand && (
-              <span className="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-600 uppercase">
+              <span className="rounded bg-surface-alt px-1.5 py-0.5 text-[10px] font-medium text-text-secondary uppercase">
                 {review.brand}
               </span>
             )}
@@ -102,7 +102,7 @@ export default function ReviewCard({ review, onThemeClick }: ReviewCardProps) {
           <div>
             <Link
               href={`/ships?slug=${encodeURIComponent(slugify(review.ship))}`}
-              className="text-[#1B3A5C]/70 hover:text-[#1B3A5C] hover:underline"
+              className="text-text-primary/70 hover:text-text-primary hover:underline"
             >
               {review.ship}
             </Link>
@@ -113,7 +113,7 @@ export default function ReviewCard({ review, onThemeClick }: ReviewCardProps) {
       {/* Review text */}
       <div
         ref={textRef}
-        className={`text-sm text-gray-700 leading-relaxed ${
+        className={`text-sm text-text-primary leading-relaxed ${
           expanded ? "" : "line-clamp-4"
         }`}
       >
@@ -122,7 +122,7 @@ export default function ReviewCard({ review, onThemeClick }: ReviewCardProps) {
       {clamped && (
         <button
           onClick={() => setExpanded(!expanded)}
-          className="mt-1 text-xs font-medium text-[#1B3A5C] hover:underline"
+          className="mt-1 text-xs font-medium text-text-primary hover:underline"
         >
           {expanded ? "Show less" : "Read more"}
         </button>
@@ -142,7 +142,7 @@ export default function ReviewCard({ review, onThemeClick }: ReviewCardProps) {
             <button
               key={`pos-${theme}`}
               onClick={() => onThemeClick?.(theme, "positive")}
-              className="rounded-full bg-[#1B3A5C]/10 px-2.5 py-0.5 text-xs font-medium text-[#1B3A5C] hover:bg-[#1B3A5C]/20 transition-colors"
+              className="rounded-full bg-brand-primary-light px-2.5 py-0.5 text-xs font-medium text-text-primary hover:bg-brand-primary-light/50 transition-colors"
             >
               {theme}
             </button>

--- a/app/src/components/ships/ShipDetail.tsx
+++ b/app/src/components/ships/ShipDetail.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
 import { useDashboard } from "@/contexts/DashboardContext";
+import { useBrand } from "@/contexts/BrandContext";
 import KpiCard from "@/components/dashboard/KpiCard";
 import HealthBadge from "@/components/dashboard/HealthBadge";
 import RatingDistributionChart from "@/components/dashboard/RatingDistributionChart";
@@ -19,7 +20,8 @@ import {
 } from "@/lib/firestore/ship-queries";
 
 export default function ShipDetail({ slug }: { slug: string }) {
-  const { brand, dateRange, dataVersion } = useDashboard();
+  const { merchantQueryId: brand } = useBrand();
+  const { dateRange, dataVersion } = useDashboard();
   const [ship, setShip] = useState<ShipSummary | null>(null);
   const [quotes, setQuotes] = useState<{ positive: Quote[]; negative: Quote[] }>({
     positive: [],
@@ -78,7 +80,7 @@ export default function ShipDetail({ slug }: { slug: string }) {
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">
-        <div className="h-10 w-10 animate-spin rounded-full border-4 border-gray-200 border-t-[#1B3A5C]" />
+        <div className="h-10 w-10 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent" />
       </div>
     );
   }
@@ -94,8 +96,8 @@ export default function ShipDetail({ slug }: { slug: string }) {
   if (!ship) {
     return (
       <div className="text-center py-24">
-        <h1 className="text-2xl font-semibold text-[#1B3A5C] mb-4">Ship Not Found</h1>
-        <Link href="/ships" className="text-[#C5A258] hover:underline">Back to Ships</Link>
+        <h1 className="text-2xl font-semibold text-text-primary mb-4">Ship Not Found</h1>
+        <Link href="/ships" className="text-brand-accent hover:underline">Back to Ships</Link>
       </div>
     );
   }
@@ -105,12 +107,12 @@ export default function ShipDetail({ slug }: { slug: string }) {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-2 text-sm text-gray-500">
-        <Link href="/ships" className="hover:text-[#1B3A5C]">Ships</Link>
+      <div className="flex items-center gap-2 text-sm text-text-secondary">
+        <Link href="/ships" className="hover:text-text-primary">Ships</Link>
         <span>/</span>
-        <span className="text-[#1B3A5C]">{ship.name}</span>
+        <span className="text-text-primary">{ship.name}</span>
       </div>
-      <h1 className="text-2xl font-semibold text-[#1B3A5C]">{ship.name}</h1>
+      <h1 className="text-2xl font-semibold text-text-primary">{ship.name}</h1>
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4">
         <KpiCard title="Avg Rating" value={ship.averageRating.toFixed(2)} trendUp={ratingDelta >= 0} delta={`${ratingDelta >= 0 ? "+" : ""}${ratingDelta.toFixed(2)} vs fleet avg`} />
         <KpiCard title="Total Reviews" value={ship.reviewCount.toLocaleString()} />
@@ -122,16 +124,16 @@ export default function ShipDetail({ slug }: { slug: string }) {
         <ThemeChart title="Positive Themes" data={ship.positiveThemes} type="positive" onBarClick={(theme) => openPanel(theme, "positive")} />
         <ThemeChart title="Negative Themes" data={ship.negativeThemes} type="negative" onBarClick={(theme) => openPanel(theme, "negative")} />
       </div>
-      <div className="bg-white rounded-lg shadow-sm p-6">
-        <h3 className="text-lg font-semibold text-[#1B3A5C] mb-4">Itineraries on This Ship</h3>
+      <div className="bg-surface rounded-lg shadow-sm p-6">
+        <h3 className="text-lg font-semibold text-text-primary mb-4">Itineraries on This Ship</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {ship.itineraries.map((it) => (
-            <Link key={it.slug} href={`/itineraries?slug=${encodeURIComponent(it.slug)}`} className="bg-gray-50 rounded-lg p-4 hover:bg-gray-100 transition-colors">
-              <h4 className="text-sm font-semibold text-[#1B3A5C] mb-3">{it.name}</h4>
+            <Link key={it.slug} href={`/itineraries?slug=${encodeURIComponent(it.slug)}`} className="bg-surface-alt rounded-lg p-4 hover:bg-surface-hover transition-colors">
+              <h4 className="text-sm font-semibold text-text-primary mb-3">{it.name}</h4>
               <div className="grid grid-cols-3 gap-2 mb-3">
-                <div><p className="text-xs text-gray-400">Rating</p><p className="text-sm font-semibold text-[#1B3A5C]">{it.averageRating.toFixed(2)}</p></div>
-                <div><p className="text-xs text-gray-400">Reviews</p><p className="text-sm font-semibold text-[#1B3A5C]">{it.reviewCount}</p></div>
-                <div><p className="text-xs text-gray-400">5-Star</p><p className="text-sm font-semibold text-[#1B3A5C]">{it.fiveStarPercent.toFixed(1)}%</p></div>
+                <div><p className="text-xs text-text-tertiary">Rating</p><p className="text-sm font-semibold text-text-primary">{it.averageRating.toFixed(2)}</p></div>
+                <div><p className="text-xs text-text-tertiary">Reviews</p><p className="text-sm font-semibold text-text-primary">{it.reviewCount}</p></div>
+                <div><p className="text-xs text-text-tertiary">5-Star</p><p className="text-sm font-semibold text-text-primary">{it.fiveStarPercent.toFixed(1)}%</p></div>
               </div>
               <HealthBadge rating={it.averageRating} />
             </Link>

--- a/app/src/components/ui/EmptyState.tsx
+++ b/app/src/components/ui/EmptyState.tsx
@@ -12,9 +12,9 @@ export default function EmptyState({ title, description, icon }: EmptyStateProps
           {icon}
         </span>
       )}
-      <h3 className="text-lg font-semibold text-gray-700 mb-1">{title}</h3>
+      <h3 className="text-lg font-semibold text-text-primary mb-1">{title}</h3>
       {description && (
-        <p className="text-sm text-gray-500 max-w-sm">{description}</p>
+        <p className="text-sm text-text-secondary max-w-sm">{description}</p>
       )}
     </div>
   );

--- a/app/src/components/ui/ErrorBoundary.tsx
+++ b/app/src/components/ui/ErrorBoundary.tsx
@@ -56,16 +56,16 @@ export default class ErrorBoundary extends React.Component<
               />
             </svg>
           </div>
-          <h2 className="text-xl font-semibold text-gray-800 mb-2">
+          <h2 className="text-xl font-semibold text-text-primary mb-2">
             Something went wrong
           </h2>
-          <p className="text-sm text-gray-500 mb-6 max-w-md">
+          <p className="text-sm text-text-secondary mb-6 max-w-md">
             An unexpected error occurred. Please try again or contact support if
             the problem persists.
           </p>
           <button
             onClick={this.handleRetry}
-            className="inline-flex items-center gap-2 rounded-lg bg-[#1B3A5C] px-5 py-2.5 text-sm font-medium text-white shadow-sm hover:bg-[#1B3A5C]/90 transition-colors"
+            className="inline-flex items-center gap-2 rounded-lg bg-header-bg px-5 py-2.5 text-sm font-medium text-header-text shadow-sm hover:opacity-90 transition-colors"
           >
             <svg
               className="h-4 w-4"

--- a/app/src/config/brands/index.ts
+++ b/app/src/config/brands/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Phase 1 brand config loader.
+ *
+ * This is the single import point for BrandContext. In Phase 2, replace
+ * the static import below with a Firestore fetch keyed on the authenticated
+ * user's brand ID — the BrandContext interface stays identical.
+ *
+ * To add a new brand in Phase 1:
+ *   1. Create src/config/brands/<brand-id>.ts (copy uniworld-journeys.ts)
+ *   2. Import it here and add to the BRAND_CONFIGS map
+ *   3. Update ACTIVE_BRAND_ID to point to the new brand
+ */
+
+import type { BrandTheme } from "@/lib/theme/tokens";
+import { defaultTheme } from "@/lib/theme/tokens";
+import uniworldJourneysConfig from "./uniworld-journeys";
+
+const BRAND_CONFIGS: Record<string, BrandTheme> = {
+  "uniworld-journeys": uniworldJourneysConfig,
+};
+
+/**
+ * The brand ID to load in Phase 1.
+ * In Phase 2 this is determined by the authenticated user's Firestore record.
+ */
+const ACTIVE_BRAND_ID = "uniworld-journeys";
+
+/**
+ * Returns the active brand config for Phase 1.
+ * Falls back to the vanilla default if the brand ID is not found.
+ */
+export function getActiveBrandConfig(): BrandTheme {
+  return BRAND_CONFIGS[ACTIVE_BRAND_ID] ?? defaultTheme;
+}

--- a/app/src/config/brands/uniworld-journeys.ts
+++ b/app/src/config/brands/uniworld-journeys.ts
@@ -1,0 +1,60 @@
+/**
+ * Uniworld Journeys brand configuration.
+ *
+ * This file is the Phase 1 stand-in for what will eventually be a Firestore
+ * document at brands/uniworld-journeys. Its shape exactly matches BrandTheme
+ * so that BrandContext can swap to a Firestore fetch in Phase 2 without any
+ * structural changes — only the data source changes.
+ *
+ * Palette: King & Partners Brand Identity R6, March 2026.
+ * Warm neutrals — Charcoal anchor, Taupe mid-tone, Plaster background.
+ * Gold accent used with relaxed rule: tab indicators, star ratings, and
+ * badges in addition to the logo/badge mark.
+ *
+ * Extended palette reference (for future Settings colour-picker defaults):
+ *   Dark Charcoal   #1E1C1C   Charcoal 95  #433F3F
+ *   Charcoal 90     #494545   Charcoal 85  #514D4D
+ *   Dark Taupe      #5A5246   Taupe 95     #766B5C
+ *   Dark Willow     #8B7C69   Willow       #9F907C
+ *   Willow 95       #A5967E   Willow 90    #AC9E88
+ *   Dark Parchment  #BFB9AE   Parchment    #D6D0C5
+ *   Parchment 95    #DED7CB   Plaster 95   #F3F1EC
+ *   Plaster 90      #F7F5F2   Plaster 85   #FBFBF9
+ *   White           #FFFFFF
+ *
+ * WCAG AA notes (per K&P compliance chart):
+ *   - Charcoal family passes AA against all Plaster shades and White ✓
+ *   - Taupe / Dark Taupe passes AA against Plaster shades and White ✓
+ *   - Willow shades do NOT pass AA on light backgrounds — decorative use only
+ *   - Gold does NOT pass AA for text — icons, indicators, badges only
+ */
+
+import type { BrandTheme } from "@/lib/theme/tokens";
+
+const uniworldJourneysConfig: BrandTheme = {
+  id: "uniworld-journeys",
+  name: "Uniworld Journeys",
+  appTitle: "Feefo Reviews",
+  tokens: {
+    primary: "#373535",    // Charcoal
+    primaryDark: "#1E1C1C", // Dark Charcoal
+    accent: "#C2AB82",     // Gold — dark end of gradient
+    accentLight: "#E7D39C", // Gold — light end of gradient
+    neutral: "#655E51",    // Taupe
+    surfaceWarm: "#F1EEEA", // Plaster
+  },
+  merchants: [
+    {
+      id: "uniworld",
+      label: "Uniworld",
+      showShips: true,
+    },
+    {
+      id: "luxury-gold",
+      label: "Luxury Gold",
+      showShips: false,
+    },
+  ],
+};
+
+export default uniworldJourneysConfig;

--- a/app/src/contexts/BrandContext.tsx
+++ b/app/src/contexts/BrandContext.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+/**
+ * BrandContext — brand config, merchant switching, and theme injection.
+ *
+ * Responsibilities:
+ *  - Loads the active brand config (Phase 1: from src/config/brands/index.ts)
+ *  - Manages which merchant is currently active (the data-scope filter)
+ *  - Exposes a Firestore-compatible query ID for the active merchant
+ *  - Drives theme token injection whenever brand or dark/light mode changes
+ *
+ * Phase 2 migration: replace getActiveBrandConfig() with a Firestore fetch
+ * keyed on the authenticated user's brand ID. The rest of this file stays
+ * identical — components never need to change.
+ */
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+  type ReactNode,
+} from "react";
+import { getActiveBrandConfig } from "@/config/brands";
+import { injectThemeTokens } from "@/lib/theme/inject";
+import { defaultTheme, type BrandTheme } from "@/lib/theme/tokens";
+import { usePersistedState } from "@/hooks/usePersistedState";
+import { useTheme } from "@/contexts/ThemeContext";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * The merchant selector value.
+ * "all"   → combined view (all merchants for this brand)
+ * string  → a specific merchant ID from brand.merchants[n].id
+ */
+export type ActiveMerchant = "all" | string;
+
+interface BrandContextValue {
+  /** The full brand config for the current tenant. */
+  brand: BrandTheme;
+  /**
+   * The currently selected merchant scope.
+   * "all" means show data from every merchant in this brand.
+   */
+  activeMerchant: ActiveMerchant;
+  setActiveMerchant: (id: ActiveMerchant) => void;
+  /**
+   * The legacy Firestore query string for the active merchant.
+   * Maps "all" → "combined" so existing query functions need no changes.
+   * All page components and data hooks should use this value when querying.
+   */
+  merchantQueryId: string;
+  /**
+   * Whether the Ships nav tab should be shown for the current merchant scope.
+   * True if the active merchant (or any merchant when "all") has showShips: true.
+   */
+  showShipsTab: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const BrandContext = createContext<BrandContextValue | null>(null);
+
+const MERCHANT_STORAGE_KEY = "pref:merchant";
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+export function BrandProvider({
+  children,
+  isDark,
+}: {
+  children: ReactNode;
+  /** Current dark-mode state — passed in so we can re-inject tokens on toggle. */
+  isDark: boolean;
+}) {
+  // Phase 1: load synchronously from static config.
+  // Phase 2: replace with async Firestore fetch and surface isLoading.
+  const [brand] = useState<BrandTheme>(() => {
+    try {
+      return getActiveBrandConfig();
+    } catch {
+      return defaultTheme;
+    }
+  });
+
+  const [activeMerchant, setActiveMerchantState] =
+    usePersistedState<ActiveMerchant>(MERCHANT_STORAGE_KEY, "all");
+
+  // Validate persisted merchant is still valid for the current brand config.
+  // If not (e.g., merchant removed), reset to "all".
+  useEffect(() => {
+    if (activeMerchant === "all") return;
+    const valid = brand.merchants.some((m) => m.id === activeMerchant);
+    if (!valid) {
+      setActiveMerchantState("all");
+    }
+  }, [brand, activeMerchant, setActiveMerchantState]);
+
+  const setActiveMerchant = useCallback(
+    (id: ActiveMerchant) => {
+      setActiveMerchantState(id);
+    },
+    [setActiveMerchantState],
+  );
+
+  // Inject CSS variables whenever brand tokens or dark/light mode changes.
+  useEffect(() => {
+    injectThemeTokens(brand.tokens, isDark);
+  }, [brand, isDark]);
+
+  // ---------------------------------------------------------------------------
+  // Derived values
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Legacy Firestore query string.
+   * Existing query functions use brand === "combined" as the "all" sentinel.
+   * We keep that contract here so no query code needs to change.
+   */
+  const merchantQueryId: string =
+    activeMerchant === "all" ? "combined" : activeMerchant;
+
+  /**
+   * Ships tab visibility.
+   * Show if the active merchant has showShips: true, or — when viewing
+   * "all" merchants — if any merchant in the brand has showShips: true.
+   */
+  const showShipsTab: boolean =
+    activeMerchant === "all"
+      ? brand.merchants.some((m) => m.showShips === true)
+      : (brand.merchants.find((m) => m.id === activeMerchant)?.showShips ??
+        false);
+
+  return (
+    <BrandContext.Provider
+      value={{
+        brand,
+        activeMerchant,
+        setActiveMerchant,
+        merchantQueryId,
+        showShipsTab,
+      }}
+    >
+      {children}
+    </BrandContext.Provider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useBrand(): BrandContextValue {
+  const context = useContext(BrandContext);
+  if (!context) {
+    throw new Error("useBrand must be used within a BrandProvider");
+  }
+  return context;
+}
+
+// ---------------------------------------------------------------------------
+// Convenience wrapper for layout.tsx
+// Reads isDark from ThemeContext so BrandProvider re-injects tokens on toggle.
+// ---------------------------------------------------------------------------
+
+export function BrandProviderWithTheme({ children }: { children: ReactNode }) {
+  const { theme } = useTheme();
+  return (
+    <BrandProvider isDark={theme === "dark"}>
+      {children}
+    </BrandProvider>
+  );
+}

--- a/app/src/contexts/DashboardContext.tsx
+++ b/app/src/contexts/DashboardContext.tsx
@@ -1,5 +1,13 @@
 "use client";
 
+/**
+ * DashboardContext — date range and data-version state.
+ *
+ * Brand / merchant selection has moved to BrandContext.
+ * All page components that previously read `brand` from here should
+ * now read `merchantQueryId` from `useBrand()` instead.
+ */
+
 import {
   createContext,
   useContext,
@@ -8,13 +16,6 @@ import {
   type ReactNode,
 } from "react";
 import { subMonths, subYears, startOfMonth, startOfYear, startOfWeek } from "date-fns";
-import { usePersistedState } from "@/hooks/usePersistedState";
-
-export type Brand = "uniworld" | "luxury-gold" | "combined";
-
-export function brandHasShips(brand: Brand): boolean {
-  return brand !== "luxury-gold";
-}
 
 export type DatePreset =
   | "This Week"
@@ -36,8 +37,6 @@ export interface DateRange {
 }
 
 interface DashboardContextValue {
-  brand: Brand;
-  setBrand: (brand: Brand) => void;
   dateRange: DateRange;
   setDateRange: (range: DateRange) => void;
   lastSynced: string | null;
@@ -111,7 +110,6 @@ function getInitialDateRange(): DateRange {
 }
 
 export function DashboardProvider({ children }: { children: ReactNode }) {
-  const [brand, setBrand] = usePersistedState<Brand>("pref:brand", "uniworld");
   const [dateRange, setDateRangeState] = useState<DateRange>(getInitialDateRange);
   const [lastSynced, setLastSynced] = useState<string | null>(null);
   const [dataVersion, setDataVersion] = useState(0);
@@ -120,13 +118,12 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     setDateRangeState(range);
     try {
       if (range.preset === "Custom Range") {
-        // Can't reconstruct custom dates on hydration, so clear the key
         localStorage.removeItem("pref:datePreset");
       } else {
         localStorage.setItem("pref:datePreset", JSON.stringify(range.preset));
       }
     } catch {
-      // Ignore
+      // Ignore storage errors
     }
   }, []);
 
@@ -135,14 +132,12 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const bumpDataVersion = useCallback(() => {
-    setDataVersion((value) => value + 1);
+    setDataVersion((v) => v + 1);
   }, []);
 
   return (
     <DashboardContext.Provider
       value={{
-        brand,
-        setBrand,
         dateRange,
         setDateRange: handleSetDateRange,
         lastSynced,

--- a/app/src/contexts/ThemeContext.tsx
+++ b/app/src/contexts/ThemeContext.tsx
@@ -60,10 +60,10 @@ function subscribeToTheme(callback: () => void): () => void {
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const theme = useSyncExternalStore(
+  const theme = useSyncExternalStore<Theme>(
     subscribeToTheme,
     readThemeSnapshot,
-    () => "light"
+    () => "light" as Theme
   );
 
   // Apply class to document

--- a/app/src/contexts/ThemeContext.tsx
+++ b/app/src/contexts/ThemeContext.tsx
@@ -3,9 +3,9 @@
 import {
   createContext,
   useContext,
-  useState,
   useEffect,
   useCallback,
+  useSyncExternalStore,
   type ReactNode,
 } from "react";
 
@@ -17,15 +17,55 @@ interface ThemeContextValue {
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null);
+const THEME_STORAGE_KEY = "theme";
+const THEME_CHANGE_EVENT = "theme-change";
+
+function readThemeSnapshot(): Theme {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  const saved = localStorage.getItem(THEME_STORAGE_KEY) as Theme | null;
+  if (saved === "dark" || saved === "light") {
+    return saved;
+  }
+
+  return window.matchMedia("(prefers-color-scheme: dark)").matches
+    ? "dark"
+    : "light";
+}
+
+function subscribeToTheme(callback: () => void): () => void {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+  const handleChange = () => callback();
+  const handleStorage = (event: StorageEvent) => {
+    if (event.key === null || event.key === THEME_STORAGE_KEY) {
+      callback();
+    }
+  };
+
+  mediaQuery.addEventListener("change", handleChange);
+  window.addEventListener("storage", handleStorage);
+  window.addEventListener(THEME_CHANGE_EVENT, handleChange);
+
+  return () => {
+    mediaQuery.removeEventListener("change", handleChange);
+    window.removeEventListener("storage", handleStorage);
+    window.removeEventListener(THEME_CHANGE_EVENT, handleChange);
+  };
+}
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>(() => {
-    if (typeof window === "undefined") return "light";
-    const saved = localStorage.getItem("theme") as Theme | null;
-    if (saved === "dark" || saved === "light") return saved;
-    if (window.matchMedia("(prefers-color-scheme: dark)").matches) return "dark";
-    return "light";
-  });
+  const theme = useSyncExternalStore(
+    subscribeToTheme,
+    readThemeSnapshot,
+    () => "light"
+  );
+
   // Apply class to document
   useEffect(() => {
     const root = document.documentElement;
@@ -36,12 +76,14 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       root.classList.remove("dark");
       root.style.colorScheme = "light";
     }
-    localStorage.setItem("theme", theme);
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
   }, [theme]);
 
   const toggleTheme = useCallback(() => {
-    setTheme((prev) => (prev === "light" ? "dark" : "light"));
-  }, []);
+    const nextTheme = theme === "light" ? "dark" : "light";
+    localStorage.setItem(THEME_STORAGE_KEY, nextTheme);
+    window.dispatchEvent(new Event(THEME_CHANGE_EVENT));
+  }, [theme]);
 
   return (
     <ThemeContext.Provider value={{ theme, toggleTheme }}>

--- a/app/src/hooks/useThemeColors.ts
+++ b/app/src/hooks/useThemeColors.ts
@@ -1,0 +1,175 @@
+"use client";
+
+/**
+ * useThemeColors — reads brand CSS custom properties from :root and returns
+ * them as plain strings that Recharts props can consume.
+ *
+ * Why this exists:
+ *   Recharts components accept colour values as plain strings / style objects,
+ *   not as CSS variable names.  Because the brand injects its palette via
+ *   document.documentElement.style.setProperty() at runtime, we must read the
+ *   resolved values from the computed style rather than hard-code them.
+ *
+ * This hook subscribes to mutations on the <html> element's style and class
+ * attributes so it re-renders automatically whenever:
+ *   - The brand changes (BrandProvider re-injects tokens)
+ *   - Dark / light mode is toggled (ThemeContext adds/removes the .dark class)
+ *
+ * Usage:
+ *   const { accent, tooltipStyle, axisTickFill } = useThemeColors();
+ *   <Line stroke={accent} />
+ *   <Tooltip contentStyle={tooltipStyle} />
+ *   <XAxis tick={{ fill: axisTickFill }} />
+ */
+
+import { useSyncExternalStore } from "react";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function getCssVar(name: string): string {
+  if (typeof window === "undefined") return "";
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim();
+}
+
+/** Snapshot of all CSS variables we care about, serialised to a string. */
+function buildSnapshot(): string {
+  return [
+    getCssVar("--header-bg"),
+    getCssVar("--brand-accent"),
+    getCssVar("--brand-accent-light"),
+    getCssVar("--surface"),
+    getCssVar("--border"),
+    getCssVar("--text-primary"),
+    getCssVar("--text-secondary"),
+    getCssVar("--text-tertiary"),
+  ].join("|");
+}
+
+const SERVER_SNAPSHOT = "|||||||| ";
+
+/** Watch the <html> style and class attributes — both change on brand/theme injection. */
+function subscribe(callback: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  const observer = new MutationObserver(callback);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["style", "class"],
+  });
+  return () => observer.disconnect();
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export interface ThemeColors {
+  /** --header-bg: primary dark brand colour (e.g. charcoal for Uniworld). */
+  primary: string;
+  /** --brand-accent: e.g. warm gold for Uniworld. */
+  accent: string;
+  /** --brand-accent-light: lighter tint of accent. */
+  accentLight: string;
+  /** --surface: card / panel background. */
+  surface: string;
+  /** --border: default border colour. */
+  border: string;
+  /** --text-primary */
+  textPrimary: string;
+  /** --text-secondary */
+  textSecondary: string;
+  /** --text-tertiary */
+  textTertiary: string;
+
+  // ── Recharts convenience objects ──────────────────────────────────────────
+
+  /** Pass directly to <Tooltip contentStyle={…}> */
+  tooltipStyle: {
+    backgroundColor: string;
+    border: string;
+    borderRadius: string;
+    color: string;
+    boxShadow: string;
+  };
+
+  /** Pass to <Tooltip labelStyle={…}> */
+  tooltipLabelStyle: { color: string; fontWeight: number };
+
+  /** Pass to <Tooltip itemStyle={…}> */
+  tooltipItemStyle: { color: string };
+
+  /** Fill for axis tick labels (XAxis / YAxis tick prop). */
+  axisTickFill: string;
+
+  /** Stroke for CartesianGrid lines. */
+  gridStroke: string;
+}
+
+// Fallback values match the Uniworld Journeys light-mode palette so SSR
+// and the first paint look correct even before the hook re-subscribes.
+const FALLBACK: Omit<
+  ThemeColors,
+  "tooltipStyle" | "tooltipLabelStyle" | "tooltipItemStyle"
+> = {
+  primary:       "#373535",
+  accent:        "#c2ab82",
+  accentLight:   "#e7d39c",
+  surface:       "#ffffff",
+  border:        "rgba(101,94,81,0.2)",
+  textPrimary:   "#1e1c1c",
+  textSecondary: "#655e51",
+  textTertiary:  "#9d988e",
+  axisTickFill:  "#9d988e",
+  gridStroke:    "rgba(101,94,81,0.2)",
+};
+
+export function useThemeColors(): ThemeColors {
+  // useSyncExternalStore is safe for SSR (returns serverSnapshot on server).
+  const snapshot = useSyncExternalStore(subscribe, buildSnapshot, () => SERVER_SNAPSHOT);
+
+  // Destructure by position (matches buildSnapshot order).
+  const [
+    primary,
+    accent,
+    accentLight,
+    surface,
+    border,
+    textPrimary,
+    textSecondary,
+    textTertiary,
+  ] = snapshot.split("|").map((v) => v.trim());
+
+  const colors = {
+    primary:       primary       || FALLBACK.primary,
+    accent:        accent        || FALLBACK.accent,
+    accentLight:   accentLight   || FALLBACK.accentLight,
+    surface:       surface       || FALLBACK.surface,
+    border:        border        || FALLBACK.border,
+    textPrimary:   textPrimary   || FALLBACK.textPrimary,
+    textSecondary: textSecondary || FALLBACK.textSecondary,
+    textTertiary:  textTertiary  || FALLBACK.textTertiary,
+  };
+
+  return {
+    ...colors,
+    axisTickFill:  colors.textTertiary,
+    gridStroke:    colors.border,
+    tooltipStyle: {
+      backgroundColor: colors.surface,
+      border:          `1px solid ${colors.border}`,
+      borderRadius:    "12px",
+      color:           colors.textPrimary,
+      boxShadow:       "0 12px 32px rgba(0,0,0,0.12)",
+    },
+    tooltipLabelStyle: {
+      color:      colors.textPrimary,
+      fontWeight: 600,
+    },
+    tooltipItemStyle: {
+      color: colors.textSecondary,
+    },
+  };
+}

--- a/app/src/lib/theme/derive.ts
+++ b/app/src/lib/theme/derive.ts
@@ -1,0 +1,184 @@
+/**
+ * Theme derivation engine.
+ *
+ * Takes the 6 minimal brand tokens and produces a complete map of
+ * CSS custom property names → values for both light and dark modes.
+ * All colour mixing is done in JS so the output is plain hex/rgba strings
+ * that can be injected directly onto :root via inject.ts.
+ */
+
+import type { BrandTokens } from "./tokens";
+
+// ---------------------------------------------------------------------------
+// Colour utilities
+// ---------------------------------------------------------------------------
+
+/** Parse a 3- or 6-digit hex string to [r, g, b] (0–255). */
+function hexToRgb(hex: string): [number, number, number] {
+  const clean = hex.replace("#", "");
+  const full = clean.length === 3
+    ? clean.split("").map((c) => c + c).join("")
+    : clean;
+  const n = parseInt(full, 16);
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
+}
+
+/** Convert [r, g, b] (0–255) back to a lowercase hex string. */
+function rgbToHex(r: number, g: number, b: number): string {
+  return (
+    "#" +
+    [r, g, b]
+      .map((c) => Math.round(Math.min(255, Math.max(0, c))).toString(16).padStart(2, "0"))
+      .join("")
+  );
+}
+
+/**
+ * Equivalent to CSS `color-mix(in srgb, colorA pct%, colorB)`.
+ * pct is how much of colorA to use (0–100); the remainder is colorB.
+ */
+function mix(colorA: string, pct: number, colorB: string): string {
+  const [ar, ag, ab] = hexToRgb(colorA);
+  const [br, bg, bb] = hexToRgb(colorB);
+  const t = pct / 100;
+  return rgbToHex(
+    ar * t + br * (1 - t),
+    ag * t + bg * (1 - t),
+    ab * t + bb * (1 - t),
+  );
+}
+
+/**
+ * Return an rgba() string for a hex colour at the given opacity (0–1).
+ * Used for semi-transparent hover/border tokens.
+ */
+function alpha(hex: string, opacity: number): string {
+  const [r, g, b] = hexToRgb(hex);
+  return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export type CssVarMap = Record<string, string>;
+
+/**
+ * Derive the full set of CSS custom properties from 6 brand tokens.
+ *
+ * The returned map uses CSS variable names as keys (e.g. `--background`)
+ * and resolved colour strings as values.  Pass `isDark: true` to get the
+ * dark-mode variant of every token.
+ */
+export function deriveTokens(tokens: BrandTokens, isDark: boolean): CssVarMap {
+  const { primary, primaryDark, accent, accentLight, neutral, surfaceWarm } =
+    tokens;
+
+  if (isDark) {
+    return {
+      // --- Structural ---
+      "--background": primaryDark,
+      "--foreground": surfaceWarm,
+      "--surface": mix(primaryDark, 92, surfaceWarm),
+      "--surface-hover": mix(primaryDark, 85, surfaceWarm),
+      "--surface-alt": mix(primaryDark, 95, surfaceWarm),
+
+      // --- Borders ---
+      "--border": mix(primaryDark, 75, neutral),
+      "--border-light": mix(primaryDark, 85, neutral),
+
+      // --- Text ---
+      "--text-primary": surfaceWarm,
+      "--text-secondary": mix(neutral, 40, surfaceWarm),
+      "--text-tertiary": neutral,
+
+      // --- Header / Nav ---
+      "--header-bg": primaryDark,
+      "--header-text": surfaceWarm,
+      "--nav-active-text": surfaceWarm,
+      "--nav-active-indicator": accent,
+      "--nav-inactive-text": mix(surfaceWarm, 60, primaryDark),
+
+      // --- Brand accent ---
+      "--brand-accent": accentLight, // lighter on dark backgrounds
+      "--brand-accent-light": accentLight,
+      "--brand-accent-hover": alpha(accentLight, 0.1),
+      "--brand-primary-hover": alpha(accentLight, 0.08),
+      "--brand-primary-light": alpha(accentLight, 0.15),
+
+      // --- Inputs ---
+      "--input-bg": mix(primaryDark, 92, surfaceWarm),
+      "--input-border": mix(primaryDark, 65, neutral),
+
+      // --- Badges ---
+      "--badge-gray-bg": mix(primaryDark, 80, neutral),
+      "--badge-gray-text": mix(neutral, 40, surfaceWarm),
+
+      // --- Spinner ---
+      "--spinner-track": mix(primaryDark, 80, neutral),
+      "--spinner-accent": accentLight,
+
+      // --- Nav bg (used in some components) ---
+      "--nav-bg": mix(primaryDark, 95, surfaceWarm),
+      "--nav-border": mix(primaryDark, 75, neutral),
+
+      // --- Shadows (darker for depth on dark bg) ---
+      "--shadow-sm": "0 1px 2px 0 rgb(0 0 0 / 0.3)",
+      "--shadow":
+        "0 1px 3px 0 rgb(0 0 0 / 0.4), 0 1px 2px -1px rgb(0 0 0 / 0.3)",
+    };
+  }
+
+  return {
+    // --- Structural ---
+    "--background": surfaceWarm,
+    "--foreground": primary,
+    "--surface": "#ffffff",
+    "--surface-hover": mix(surfaceWarm, 60, "#ffffff"),
+    "--surface-alt": mix(surfaceWarm, 80, "#ffffff"),
+
+    // --- Borders ---
+    "--border": alpha(neutral, 0.2),
+    "--border-light": alpha(neutral, 0.1),
+
+    // --- Text ---
+    "--text-primary": primaryDark,
+    "--text-secondary": neutral,
+    "--text-tertiary": mix(neutral, 60, surfaceWarm),
+
+    // --- Header / Nav ---
+    "--header-bg": primary,
+    "--header-text": "#ffffff",
+    "--nav-active-text": primary,
+    "--nav-active-indicator": accent,
+    "--nav-inactive-text": neutral,
+
+    // --- Brand accent ---
+    "--brand-accent": accent,
+    "--brand-accent-light": accentLight,
+    "--brand-accent-hover": alpha(accent, 0.1),
+    "--brand-primary-hover": alpha(primary, 0.05),
+    "--brand-primary-light": alpha(primary, 0.1),
+
+    // --- Inputs ---
+    "--input-bg": "#ffffff",
+    "--input-border": mix(neutral, 30, surfaceWarm),
+
+    // --- Badges ---
+    "--badge-gray-bg": mix(surfaceWarm, 70, neutral),
+    "--badge-gray-text": neutral,
+
+    // --- Spinner ---
+    "--spinner-track": mix(surfaceWarm, 40, neutral),
+    "--spinner-accent": accent,
+
+    // --- Nav bg (used in some components) ---
+    "--nav-bg": "#ffffff",
+    "--nav-border": alpha(neutral, 0.2),
+
+    // --- Shadows ---
+    "--shadow-sm": "0 1px 2px 0 rgb(0 0 0 / 0.05)",
+    "--shadow":
+      "0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)",
+  };
+}

--- a/app/src/lib/theme/inject.ts
+++ b/app/src/lib/theme/inject.ts
@@ -1,0 +1,37 @@
+/**
+ * Runtime CSS variable injection.
+ *
+ * Calls deriveTokens() with the current brand tokens + dark-mode flag,
+ * then writes every resulting variable onto document.documentElement.
+ *
+ * This runs:
+ *  1. On initial mount (from BrandContext / ThemeContext)
+ *  2. When the user toggles dark / light mode
+ *
+ * For pre-hydration flash prevention, theme-init.js applies the
+ * brand tokens from localStorage before React mounts (Phase 1: uses
+ * the hardcoded Uniworld Journeys defaults baked into that file).
+ */
+
+import { deriveTokens } from "./derive";
+import type { BrandTokens } from "./tokens";
+
+/**
+ * Apply the full set of derived CSS variables for the given brand tokens
+ * and colour scheme to the document root.
+ *
+ * Safe to call during SSR — exits early when `window` is unavailable.
+ */
+export function injectThemeTokens(
+  tokens: BrandTokens,
+  isDark: boolean,
+): void {
+  if (typeof window === "undefined") return;
+
+  const vars = deriveTokens(tokens, isDark);
+  const root = document.documentElement;
+
+  for (const [key, value] of Object.entries(vars)) {
+    root.style.setProperty(key, value);
+  }
+}

--- a/app/src/lib/theme/tokens.ts
+++ b/app/src/lib/theme/tokens.ts
@@ -1,0 +1,74 @@
+/**
+ * Brand theme token system — type definitions and default fallback only.
+ *
+ * This file intentionally contains NO brand-specific configuration.
+ * Brand configs (Uniworld Journeys, etc.) live in src/config/brands/ and
+ * are loaded by BrandContext. In Phase 2 they will be fetched from Firestore
+ * instead — BrandContext is the only consumer that changes.
+ *
+ * Each brand/tenant exposes 6 minimal tokens. All other CSS variables
+ * (surfaces, borders, text colours, dark-mode variants, etc.) are
+ * derived programmatically in derive.ts.
+ */
+
+export interface BrandTokens {
+  /** Header background, active states, primary actions */
+  primary: string;
+  /** Deepest tone — dark-mode page background, strong emphasis */
+  primaryDark: string;
+  /** Tab indicators, star ratings, badges */
+  accent: string;
+  /** Accent hover / glow states */
+  accentLight: string;
+  /** Mid-tone — secondary text, borders, muted UI */
+  neutral: string;
+  /** Warm tint for page backgrounds and card surfaces (light mode) */
+  surfaceWarm: string;
+}
+
+export interface BrandMerchant {
+  /** Feefo merchant ID (used as the data-filter key) */
+  id: string;
+  /** Display label shown in the merchant switcher */
+  label: string;
+  /**
+   * Whether to show the Ships nav tab when this merchant is active.
+   * When activeMerchant is "all", ships are shown if ANY merchant
+   * has showShips: true.
+   */
+  showShips?: boolean;
+}
+
+export interface BrandTheme {
+  id: string;
+  name: string;
+  tokens: BrandTokens;
+  /** URL to logo image (Phase 2: uploaded via Settings page) */
+  logo?: string;
+  /** Accessible alt text for the logo */
+  logoAlt?: string;
+  /** Text shown in the header when no logo is set */
+  appTitle: string;
+  /** One or more Feefo merchant IDs belonging to this brand */
+  merchants: BrandMerchant[];
+}
+
+// ---------------------------------------------------------------------------
+// Default / vanilla fallback theme
+// Used when no brand config is available (e.g. new tenant before Phase 2).
+// ---------------------------------------------------------------------------
+
+export const defaultTheme: BrandTheme = {
+  id: "default",
+  name: "Default",
+  tokens: {
+    primary: "#1e293b", // Slate 800
+    primaryDark: "#0f172a", // Slate 900
+    accent: "#3b82f6", // Blue 500
+    accentLight: "#60a5fa", // Blue 400
+    neutral: "#64748b", // Slate 500
+    surfaceWarm: "#f8fafc", // Slate 50
+  },
+  appTitle: "Feefo Reviews",
+  merchants: [],
+};

--- a/docs/plans/2026-04-02-multi-tenant-roadmap.md
+++ b/docs/plans/2026-04-02-multi-tenant-roadmap.md
@@ -1,0 +1,301 @@
+# Multi-Tenant Platform Roadmap
+
+**Date:** 2026-04-02
+**Status:** Planning
+**Overview:** Transform the Feefo Reviews dashboard from a single-brand tool into a multi-tenant platform where each brand has its own theme, settings, users, and Feefo merchant IDs.
+
+---
+
+## Architecture Vision
+
+```
+┌─────────────────────────────────────────────────────┐
+│                    Application                       │
+│                                                     │
+│  ┌─────────────┐  ┌──────────────┐  ┌────────────┐ │
+│  │ Brand Theme  │  │ Brand Config │  │ User Auth  │ │
+│  │ (6 tokens)   │  │ (merchants,  │  │ (MS 365    │ │
+│  │              │  │  settings,   │  │  SSO, role  │ │
+│  │ Derives:     │  │  logo)       │  │  mapping)  │ │
+│  │ - Light mode │  │              │  │            │ │
+│  │ - Dark mode  │  │              │  │            │ │
+│  │ - All CSS    │  │              │  │            │ │
+│  └──────┬───────┘  └──────┬───────┘  └─────┬──────┘ │
+│         │                 │                │        │
+│         └────────┬────────┘                │        │
+│                  │                         │        │
+│         ┌────────▼────────┐       ┌────────▼──────┐ │
+│         │  BrandContext   │       │  AuthContext   │ │
+│         │  (theme +       │◄──────│  (user →      │ │
+│         │   config +      │       │   brand       │ │
+│         │   merchants)    │       │   mapping)    │ │
+│         └────────┬────────┘       └───────────────┘ │
+│                  │                                   │
+│         ┌────────▼────────┐                         │
+│         │  Dashboard UI   │                         │
+│         │  (themed,       │                         │
+│         │   data-scoped   │                         │
+│         │   per merchant) │                         │
+│         └─────────────────┘                         │
+└─────────────────────────────────────────────────────┘
+```
+
+### Data Model (Firestore)
+
+```
+brands/
+  {brandId}/
+    name: string
+    theme: {
+      primary: string
+      primaryDark: string
+      accent: string
+      accentLight: string
+      neutral: string
+      surfaceWarm: string
+    }
+    logo: string (URL)
+    logoAlt: string
+    appTitle: string
+    merchants: [
+      { id: string, label: string, feefoMerchantId: string }
+    ]
+    settings: {
+      defaultDateRange: string
+      showShipsPage: boolean
+      // ... extensible
+    }
+    createdAt: timestamp
+    updatedAt: timestamp
+
+brands/{brandId}/users/
+  {userId}/
+    email: string
+    role: 'admin' | 'viewer'
+    displayName: string
+    addedAt: timestamp
+
+brands/{brandId}/reviews/
+  // ... existing review data structure, per merchant
+```
+
+---
+
+## Phase 1: Theme Engine & UI Refresh (Current)
+
+**Status:** Planned
+**Detailed plan:** `2026-04-02-theme-engine-and-ui-refresh-phase1.md`
+
+**Deliverables:**
+- Configurable 6-token theme system with programmatic derivation
+- Uniworld Journeys brand applied as first theme
+- Brand-aware dark mode
+- Consolidated single-bar header with inline navigation
+- Mobile hamburger drawer
+- Full CSS variable migration (no hardcoded colors)
+- Responsive improvements (auto card view on mobile, chart theming)
+- Default/vanilla fallback theme
+
+**Brand config is hardcoded** in Phase 1 (in `tokens.ts`). No admin UI yet.
+
+---
+
+## Phase 2: Settings UI & Brand Configuration
+
+**Status:** Not started
+**Depends on:** Phase 1 complete
+
+### Scope
+
+Build the `/settings` page where brand admins can configure their brand.
+
+### Settings Page Sections
+
+**2a. Theme Configuration**
+- Color picker for each of the 6 brand tokens
+- Live preview panel showing how the theme looks (header, card, chart sample)
+- "Reset to default" button
+- Save persists to Firestore `brands/{brandId}/theme`
+- Validation: warn if selected colors fail WCAG AA contrast checks
+
+**2b. Brand Identity**
+- Logo upload (stored in Firebase Storage, URL saved to brand doc)
+- App title text field
+- Logo alt text field
+
+**2c. Merchant ID Management**
+- List current merchants with labels
+- Add new merchant: Feefo merchant ID + display label
+- Remove merchant (with confirmation — does not delete data)
+- Reorder merchants (drag or up/down)
+- Each merchant's Feefo API credentials (if applicable)
+
+**2d. General Settings**
+- Default date range (last 30 days, last 90 days, last year, all time)
+- Show/hide Ships page toggle
+- Show/hide specific dashboard sections
+- Export settings (CSV format preferences, etc.)
+
+### Implementation Notes
+
+- `/settings` page gated by `role: 'admin'` permission
+- Settings nav item only visible to admins (same pattern as current Admin page)
+- BrandContext switches from hardcoded config to Firestore listener
+- Changes to theme tokens trigger real-time re-derivation and CSS injection
+- Logo upload uses Firebase Storage with brand-scoped paths
+
+### Key Files
+
+| File | Purpose |
+|---|---|
+| `src/app/settings/page.tsx` | Settings page with tabbed sections |
+| `src/components/settings/ThemeConfigurator.tsx` | Color pickers + live preview |
+| `src/components/settings/BrandIdentityForm.tsx` | Logo upload + app title |
+| `src/components/settings/MerchantManager.tsx` | CRUD for merchant IDs |
+| `src/components/settings/GeneralSettings.tsx` | Toggles and preferences |
+| `src/lib/firestore/brand-queries.ts` | Firestore read/write for brand config |
+
+---
+
+## Phase 3: Microsoft 365 SSO & User-to-Brand Mapping
+
+**Status:** Not started
+**Depends on:** Phase 2 complete
+**Related doc:** `project_auth.md` in memory
+
+### Scope
+
+Replace the current auth system with Microsoft 365 SSO. Map authenticated users to their brand, which determines the theme and data they see.
+
+### Auth Flow
+
+```
+User visits app
+  → Redirected to Microsoft 365 login
+  → Authenticated, receives user profile (email, name, etc.)
+  → App queries Firestore: which brand does this user belong to?
+    → brands/{brandId}/users/{userId} exists?
+      → Yes: Load brand config, apply theme, show dashboard
+      → No: Show "Access Denied" or "Contact your admin" page
+```
+
+### User Management (in Settings)
+
+- **Add user:** Admin enters email, selects role (admin/viewer)
+- **Remove user:** Admin removes user from brand
+- **Role management:** Admin can promote viewer → admin or demote
+- **Self-service:** Users cannot change their own role
+- **Super-admin concept (optional):** A platform-level admin who can manage all brands (likely just a Firestore flag, not a full UI in Phase 3)
+
+### Implementation Notes
+
+- Use `@azure/msal-browser` or `next-auth` with Microsoft Entra ID provider
+- AuthGate component updated to check brand membership after SSO
+- BrandContext loads based on authenticated user's brand mapping
+- Current email/password auth (if any) removed or kept as fallback during transition
+- Session management: JWT or Firebase custom token after SSO validation
+
+### Key Files
+
+| File | Purpose |
+|---|---|
+| `src/lib/auth/msal.ts` | MSAL configuration and initialization |
+| `src/lib/auth/user-brand-mapping.ts` | Query user's brand from Firestore |
+| `src/components/layout/AuthGate.tsx` | Updated: SSO flow + brand loading |
+| `src/components/layout/AuthButton.tsx` | Updated: MS 365 profile, sign out |
+| `src/components/settings/UserManager.tsx` | Add/remove/role-manage users |
+| `src/app/access-denied/page.tsx` | Shown when user has no brand |
+
+---
+
+## Phase 4: Multi-Brand Onboarding
+
+**Status:** Future
+**Depends on:** Phase 3 complete
+
+### Scope
+
+Enable entirely new brands/companies to onboard onto the platform.
+
+### Brand Provisioning
+
+When a new brand signs up or is provisioned:
+1. Create `brands/{brandId}` document with default theme
+2. Configure their Feefo merchant ID(s)
+3. Add initial admin user(s)
+4. Brand admin customizes theme, logo, settings via Settings page
+5. Brand admin invites their users
+
+### Provisioning UI Options
+
+**Option A: Self-service onboarding**
+- Public sign-up flow for new brands
+- Guided wizard: brand name → merchant IDs → theme → invite users
+- Requires billing/subscription model (out of scope for this doc)
+
+**Option B: Admin-provisioned**
+- A platform super-admin creates new brands manually
+- Super-admin dashboard (separate page or section)
+- Simpler, appropriate if new brands are onboarded infrequently
+
+**Recommendation:** Start with **Option B** — admin-provisioned. Build a minimal super-admin page where a platform admin can create a new brand, set initial config, and add the first admin user. Self-service can come later if the platform scales.
+
+### Data Isolation
+
+- Each brand's reviews, settings, and users are scoped under `brands/{brandId}/`
+- Firestore security rules enforce that users can only read/write their own brand's data
+- No cross-brand data access at the application or database level
+- API routes (if added) must validate brand membership on every request
+
+### Key Considerations
+
+- **Firestore security rules:** Must be written/updated to enforce brand-level isolation
+- **Firebase Storage:** Logo uploads scoped to `brands/{brandId}/assets/`
+- **Algolia:** Search indices may need brand-scoping (prefix or separate index per brand)
+- **Feefo API sync:** Cloud function needs to know which merchant IDs belong to which brand
+- **Cost model:** Consider Firestore read/write costs as brands scale
+
+---
+
+## Phase Summary & Dependencies
+
+```
+Phase 1: Theme Engine & UI Refresh
+  │ (no external dependencies)
+  │
+  ▼
+Phase 2: Settings UI & Brand Configuration
+  │ (depends on: Phase 1 theme system)
+  │
+  ▼
+Phase 3: MS 365 SSO & User-to-Brand Mapping
+  │ (depends on: Phase 2 user management UI)
+  │ (depends on: Microsoft Entra ID app registration)
+  │
+  ▼
+Phase 4: Multi-Brand Onboarding
+  │ (depends on: Phase 3 auth system)
+  │ (depends on: Firestore security rules)
+```
+
+### Estimated Complexity
+
+| Phase | Scope | Key Risk |
+|---|---|---|
+| Phase 1 | Medium — mostly UI refactoring, token system | Getting derivation right for all edge cases (contrast, dark mode) |
+| Phase 2 | Medium — CRUD UI + Firestore integration | Live preview performance, logo upload edge cases |
+| Phase 3 | Large — SSO integration, auth flow rewrite | Microsoft Entra ID configuration, token refresh handling |
+| Phase 4 | Medium — provisioning + security rules | Data isolation correctness, Firestore security rule complexity |
+
+---
+
+## Design Principles (All Phases)
+
+1. **Semantic tokens over hardcoded values** — Every color in the UI references a semantic CSS variable, never a raw hex
+2. **Derive, don't duplicate** — Dark mode and variant colors are computed from 6 tokens, not manually specified
+3. **Brand = tenant** — A brand is the unit of isolation for data, theme, settings, and users
+4. **Login determines brand** — No brand selection UI; the authenticated user's brand mapping controls everything
+5. **Merchant switcher for data scope** — Within a brand, the merchant switcher filters which Feefo data is displayed
+6. **Progressive enhancement** — Each phase builds on the last; the app works at every stage (Phase 1 has hardcoded config, Phase 2 adds UI, Phase 3 adds auth, Phase 4 adds onboarding)
+7. **WCAG AA compliance** — All text/background combinations must meet 4.5:1 contrast ratio per the brand guide's ADA compliance chart
+8. **Mobile-first** — Responsive behavior is a first-class concern, not an afterthought

--- a/docs/plans/2026-04-02-theme-engine-and-ui-refresh-phase1.md
+++ b/docs/plans/2026-04-02-theme-engine-and-ui-refresh-phase1.md
@@ -1,0 +1,591 @@
+# Phase 1: Theme Engine & UI Refresh
+
+**Date:** 2026-04-02
+**Status:** Complete (Steps 1–5 implemented; Step 6 QA pending)
+**Scope:** Build configurable theme engine, apply Uniworld Journeys brand, consolidate header/nav, responsive improvements
+
+---
+
+## Context
+
+The Feefo Reviews dashboard is evolving from a single-brand tool (Uniworld/Luxury Gold) into a multi-tenant platform. Each brand/tenant will have its own theme, settings, logo, and one or more Feefo merchant IDs. Phase 1 lays the foundation by building the theme engine and applying the first brand theme (Uniworld Journeys), while also modernizing the header/navigation layout for better responsive behavior.
+
+### Brand Background
+
+- Uniworld is absorbing the Luxury Gold brand and rebranding to "Uniworld Journeys"
+- Historical reviews remain split by Feefo merchant ID, so the merchant switcher must persist
+- New brand identity designed by King & Partners (R6, March 2026)
+- Palette is warm neutrals: Charcoal, Taupe, Willow, Parchment, Plaster, with restrained Gold accent
+
+### Key Decisions Made
+
+- **6 minimal tokens** per brand theme — all other colors derived programmatically
+- **Brand-aware dark mode** — derived from the same 6 tokens, not configured separately
+- **Consolidated single header bar** — header and nav merge into one row
+- **Gold accent usage: relaxed** — allowed for tab indicators, star ratings, and badges (not just logo)
+- **Typography: Geist Sans retained** — neutral, data-friendly, works across brands
+- **Settings page (Phase 2)** — separate from Admin, handles brand config
+- **Phase 1 scope** — theme engine + Uniworld reskin + responsive header; Settings UI and multi-tenant auth deferred
+
+---
+
+## 1. Theme Token System
+
+### 1.1 Token Definitions
+
+Create `src/lib/theme/tokens.ts`:
+
+```typescript
+export interface BrandTheme {
+  id: string;
+  name: string;
+  // The 6 minimal configurable tokens
+  tokens: {
+    primary: string;       // Header bg, active states, primary actions
+    primaryDark: string;   // Deepest tone — dark mode bg, strong emphasis
+    accent: string;        // Tab indicators, star ratings, badges
+    accentLight: string;   // Accent hover/glow states
+    neutral: string;       // Mid-tone — secondary text, borders, muted UI
+    surfaceWarm: string;   // Warm tint for backgrounds and surfaces
+  };
+  // Brand assets
+  logo?: string;           // URL to logo image
+  logoAlt?: string;        // Alt text for logo
+  appTitle: string;        // Displayed in header (e.g., "Feefo Reviews")
+  // Merchant IDs
+  merchants: {
+    id: string;
+    label: string;         // Display name (e.g., "Uniworld", "Luxury Gold")
+  }[];
+}
+```
+
+### 1.2 Uniworld Journeys Theme
+
+```typescript
+export const uniworldJourneysTheme: BrandTheme = {
+  id: 'uniworld-journeys',
+  name: 'Uniworld Journeys',
+  tokens: {
+    primary: '#373535',       // Charcoal
+    primaryDark: '#1E1C1C',   // Dark Charcoal
+    accent: '#C2AB82',        // Gold (dark end of gradient)
+    accentLight: '#E7D39C',   // Gold (light end of gradient)
+    neutral: '#655E51',       // Taupe
+    surfaceWarm: '#F1EEEA',   // Plaster
+  },
+  appTitle: 'Feefo Reviews',
+  merchants: [
+    { id: 'uniworld', label: 'Uniworld' },
+    { id: 'luxury-gold', label: 'Luxury Gold' },
+  ],
+};
+```
+
+### 1.3 Default/Vanilla Theme
+
+```typescript
+export const defaultTheme: BrandTheme = {
+  id: 'default',
+  name: 'Default',
+  tokens: {
+    primary: '#1e293b',       // Slate 800
+    primaryDark: '#0f172a',   // Slate 900
+    accent: '#3b82f6',        // Blue 500
+    accentLight: '#60a5fa',   // Blue 400
+    neutral: '#64748b',       // Slate 500
+    surfaceWarm: '#f8fafc',   // Slate 50
+  },
+  appTitle: 'Feefo Reviews',
+  merchants: [],
+};
+```
+
+### 1.4 Derivation Logic
+
+Create `src/lib/theme/derive.ts`:
+
+Takes the 6 brand tokens and produces a full set of CSS custom properties for both light and dark modes. Use CSS `color-mix()` for browser-native color manipulation where possible; fall back to JS hex manipulation for older browser support if needed.
+
+**Light mode derivations:**
+
+| CSS Variable | Derivation |
+|---|---|
+| `--background` | `surfaceWarm` |
+| `--foreground` | `primary` |
+| `--surface` | `#ffffff` |
+| `--surface-hover` | `color-mix(in srgb, surfaceWarm 60%, white)` |
+| `--surface-alt` | `color-mix(in srgb, surfaceWarm 80%, white)` |
+| `--border` | `color-mix(in srgb, neutral 20%, transparent)` |
+| `--border-light` | `color-mix(in srgb, neutral 10%, transparent)` |
+| `--text-primary` | `primaryDark` |
+| `--text-secondary` | `neutral` |
+| `--text-tertiary` | `color-mix(in srgb, neutral 60%, surfaceWarm)` |
+| `--header-bg` | `primary` |
+| `--header-text` | `#ffffff` (or derive from contrast check against primary) |
+| `--nav-active-text` | `primary` |
+| `--nav-active-indicator` | `accent` |
+| `--nav-inactive-text` | `neutral` |
+| `--brand-accent` | `accent` |
+| `--brand-accent-light` | `accentLight` |
+| `--brand-accent-hover` | `color-mix(in srgb, accent 10%, transparent)` |
+| `--brand-primary-hover` | `color-mix(in srgb, primary 5%, transparent)` |
+| `--brand-primary-light` | `color-mix(in srgb, primary 10%, transparent)` |
+| `--input-bg` | `#ffffff` |
+| `--input-border` | `color-mix(in srgb, neutral 30%, surfaceWarm)` |
+| `--badge-gray-bg` | `color-mix(in srgb, surfaceWarm 70%, neutral)` |
+| `--badge-gray-text` | `neutral` |
+| `--spinner-accent` | `accent` |
+| `--shadow-sm` | `0 1px 2px 0 rgb(0 0 0 / 0.05)` |
+| `--shadow` | `0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)` |
+
+**Dark mode derivations:**
+
+| CSS Variable | Derivation |
+|---|---|
+| `--background` | `primaryDark` |
+| `--foreground` | `surfaceWarm` |
+| `--surface` | `color-mix(in srgb, primaryDark 92%, surfaceWarm)` |
+| `--surface-hover` | `color-mix(in srgb, primaryDark 85%, surfaceWarm)` |
+| `--surface-alt` | `color-mix(in srgb, primaryDark 95%, surfaceWarm)` |
+| `--border` | `color-mix(in srgb, primaryDark 75%, neutral)` |
+| `--border-light` | `color-mix(in srgb, primaryDark 85%, neutral)` |
+| `--text-primary` | `surfaceWarm` |
+| `--text-secondary` | `color-mix(in srgb, neutral 40%, surfaceWarm)` |
+| `--text-tertiary` | `neutral` |
+| `--header-bg` | `primaryDark` |
+| `--header-text` | `surfaceWarm` |
+| `--nav-active-text` | `surfaceWarm` |
+| `--nav-active-indicator` | `accent` |
+| `--nav-inactive-text` | `color-mix(in srgb, surfaceWarm 60%, primaryDark)` |
+| `--brand-accent` | `accentLight` (lighter variant for dark backgrounds) |
+| `--brand-accent-light` | `accentLight` |
+| `--brand-accent-hover` | `color-mix(in srgb, accentLight 10%, transparent)` |
+| `--brand-primary-hover` | `color-mix(in srgb, accentLight 8%, transparent)` |
+| `--brand-primary-light` | `color-mix(in srgb, accentLight 15%, transparent)` |
+| `--input-bg` | `color-mix(in srgb, primaryDark 92%, surfaceWarm)` |
+| `--input-border` | `color-mix(in srgb, primaryDark 65%, neutral)` |
+| `--badge-gray-bg` | `color-mix(in srgb, primaryDark 80%, neutral)` |
+| `--badge-gray-text` | `color-mix(in srgb, neutral 40%, surfaceWarm)` |
+| `--spinner-accent` | `accentLight` |
+| `--shadow-sm` | `0 1px 2px 0 rgb(0 0 0 / 0.3)` |
+| `--shadow` | `0 1px 3px 0 rgb(0 0 0 / 0.4), 0 1px 2px -1px rgb(0 0 0 / 0.3)` |
+
+### 1.5 Token Injection
+
+Create `src/lib/theme/inject.ts`:
+
+```typescript
+export function injectThemeTokens(theme: BrandTheme, isDark: boolean): void {
+  const vars = deriveTokens(theme.tokens, isDark);
+  const root = document.documentElement;
+  for (const [key, value] of Object.entries(vars)) {
+    root.style.setProperty(key, value);
+  }
+}
+```
+
+This runs:
+- On initial app load (from BrandContext provider)
+- When dark/light mode toggles
+- The `theme-init.js` script should be updated to apply a minimal set of tokens before hydration to prevent flash
+
+---
+
+## 2. Consolidated Header & Navigation
+
+### 2.1 New Header Layout
+
+Rewrite `src/components/layout/Header.tsx` to be a single bar containing both branding and navigation.
+
+**Desktop (lg+):**
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ [Logo/Title]  Overview  Itineraries  Ships  Reviews  Admin  Settings │
+│                                         [MerchantSwitcher] [DatePicker] [ThemeToggle] [Auth] │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+- `height: 48-56px` (down from ~100px with two bars)
+- Background: `var(--header-bg)`
+- Text: `var(--header-text)`
+- Max-width: `7xl` inner container (matches content area)
+- Flexbox: logo + nav left, utilities right
+- Active tab: `var(--nav-active-indicator)` underline (2px), `font-semibold`
+- Inactive tab: `var(--header-text)` at 60% opacity, hover to 80%
+
+**Tablet (md):**
+- Same single bar
+- Nav tabs may use shorter labels if space is tight
+- DateRangePicker shows compact icon trigger (calendar icon, expands on click)
+
+**Mobile (below md):**
+```
+┌──────────────────────────────────┐
+│ [Logo/Title]       [Hamburger ☰] │
+└──────────────────────────────────┘
+```
+
+- Logo/title left, hamburger icon right
+- Hamburger opens a slide-out drawer (from right, animated)
+- Drawer contains (in order):
+  1. Nav links (Overview, Itineraries, Ships, Reviews, Admin, Settings)
+  2. Divider
+  3. Merchant Switcher (if 2+ merchants)
+  4. Date Range Picker
+  5. Theme Toggle
+  6. Auth / Sign Out
+- Drawer closes on: navigation, outside tap, close button
+- Backdrop overlay behind drawer
+
+### 2.2 Navigation Component
+
+The current `Navigation.tsx` merges into `Header.tsx` as an inline element. Options:
+- **Option A:** Delete `Navigation.tsx`, inline the tab rendering into Header
+- **Option B:** Keep `Navigation.tsx` as a sub-component imported by Header (cleaner separation)
+
+Recommend **Option B** — keep as sub-component `NavTabs.tsx` that renders the tab list, imported by Header for desktop and by the mobile drawer.
+
+### 2.3 BrandSwitcher → MerchantSwitcher
+
+Rename and refactor:
+- Only renders when `brand.merchants.length > 1`
+- Dropdown or segmented control showing merchant labels
+- Include an "All" option to view combined data
+- Styled with theme tokens (not hardcoded colors)
+- In mobile drawer: renders as a list of radio-style options
+
+### 2.4 RefreshButton
+
+Absorb into DateRangePicker as an inline icon button. No longer a standalone header element. The refresh icon sits inside the date picker component, next to the date display.
+
+### 2.5 Layout.tsx Changes
+
+```tsx
+// Before (two sticky bars)
+<div className="sticky top-0 z-40">
+  <Header />
+  <Navigation />
+</div>
+
+// After (single sticky bar)
+<div className="sticky top-0 z-40">
+  <Header />  {/* Now contains nav inline */}
+</div>
+```
+
+---
+
+## 3. CSS Variable Migration
+
+### 3.1 globals.css Overhaul
+
+**Replace the current structure:**
+
+Current `globals.css` has:
+- `:root` with hardcoded light mode variables
+- `.dark` class with hardcoded dark mode variables
+- Dozens of `.dark .bg-white`, `.dark .text-gray-*` overrides with `!important`
+- `@theme inline` Tailwind mapping
+
+**New structure:**
+
+```css
+/* 1. Brand token slots (overridden at runtime by inject.ts) */
+:root {
+  /* These are defaults — will be overridden by JS */
+  --brand-primary: #1e293b;
+  --brand-primary-dark: #0f172a;
+  --brand-accent: #3b82f6;
+  --brand-accent-light: #60a5fa;
+  --brand-neutral: #64748b;
+  --brand-surface-warm: #f8fafc;
+}
+
+/* 2. Semantic tokens derived from brand tokens */
+:root {
+  --background: var(--derived-background);
+  --foreground: var(--derived-foreground);
+  --surface: var(--derived-surface);
+  /* ... all semantic tokens ... */
+}
+
+/* 3. Dark mode — just swaps which derived values are active */
+/* (handled by inject.ts re-running with isDark=true) */
+
+/* 4. Tailwind theme mapping */
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-surface: var(--surface);
+  /* ... mapped to Tailwind utilities ... */
+}
+
+/* 5. Utility styles (animations, focus rings, etc.) */
+/* Keep non-color utilities as-is */
+```
+
+**What gets deleted:**
+- ALL `.dark .bg-white { background-color: ... !important }` overrides
+- ALL `.dark .text-gray-*` overrides
+- ALL `.dark .border-gray-*` overrides
+- ALL `.dark input, .dark select` overrides
+- The hardcoded Recharts dark mode overrides (replace with token-based)
+- Any hardcoded hex color that has a semantic equivalent
+
+### 3.2 Component Migration
+
+Every component with hardcoded colors needs updating. Here is the systematic find-and-replace map:
+
+| Find (hardcoded) | Replace with |
+|---|---|
+| `bg-[#1B3A5C]` | `bg-[var(--header-bg)]` |
+| `text-[#1B3A5C]` | `text-[var(--text-primary)]` or `text-[var(--nav-active-text)]` |
+| `text-[#C5A258]` / `bg-[#C5A258]` | `text-[var(--brand-accent)]` / `bg-[var(--brand-accent)]` |
+| `dark:bg-[#111927]` | Remove — handled by semantic token |
+| `dark:border-[#1e2d44]` | Remove — handled by semantic token |
+| `dark:text-white/60` | Remove — handled by semantic token |
+| `hover:text-[#1B3A5C]` | `hover:text-[var(--nav-active-text)]` |
+| `bg-white` (cards/surfaces) | `bg-[var(--surface)]` |
+| `text-gray-900` | `text-[var(--text-primary)]` |
+| `text-gray-500` / `text-gray-600` | `text-[var(--text-secondary)]` |
+| `text-gray-400` | `text-[var(--text-tertiary)]` |
+| `border-gray-200` | `border-[var(--border)]` |
+| `border-gray-100` | `border-[var(--border-light)]` |
+| `bg-gray-50` / `bg-gray-100` | `bg-[var(--surface-alt)]` |
+| `hover:bg-[#1B3A5C]/5` | `hover:bg-[var(--brand-primary-hover)]` |
+
+### 3.3 Recharts Theme Integration
+
+Update chart components to use CSS variables:
+- Axis tick text: `var(--text-secondary)`
+- Grid lines: `var(--border)`
+- Bar fills: `var(--brand-accent)` (primary series), `var(--brand-primary-light)` (secondary)
+- Tooltip bg: `var(--surface)`, border: `var(--border)`, text: `var(--text-primary)`
+- Line stroke: `var(--brand-accent)`
+
+Use a `useThemeColors()` hook that reads computed CSS variable values for Recharts props (since Recharts needs actual hex values, not CSS var references).
+
+### 3.4 theme-init.js Update
+
+The `public/theme-init.js` script runs before React hydration to prevent theme flash. Update it to:
+
+1. Read dark/light preference from localStorage (existing behavior)
+2. Read brand token overrides from localStorage cache (new)
+3. Apply minimal CSS variables to `:root` immediately
+4. The full derivation runs once React hydrates and BrandContext loads
+
+---
+
+## 4. BrandContext
+
+### 4.1 New Context
+
+Create `src/contexts/BrandContext.tsx`:
+
+```typescript
+interface BrandContextValue {
+  brand: BrandTheme;
+  activeMerchant: string | 'all';
+  setActiveMerchant: (id: string | 'all') => void;
+  isLoading: boolean;
+}
+```
+
+**Responsibilities:**
+- Loads brand config (hardcoded in Phase 1, from Firestore in Phase 2)
+- Provides brand theme to the injection system
+- Manages active merchant selection
+- Replaces the brand-related state currently in DashboardContext
+
+### 4.2 DashboardContext Refactor
+
+Remove brand-switching logic from DashboardContext. It should retain:
+- Date range state
+- Data version / refresh triggers
+- Any other data-layer concerns
+
+The `selectedBrand` state in DashboardContext gets replaced by `activeMerchant` from BrandContext.
+
+---
+
+## 5. Responsive Improvements
+
+### 5.1 Table Auto-View on Mobile
+
+For Itineraries and Ships pages:
+- Below `md` breakpoint, default to card view instead of table view
+- The view toggle still exists so users can switch, but the smart default avoids horizontal scrolling
+- Persist user's choice per page in localStorage
+
+### 5.2 Chart Responsiveness
+
+- Recharts containers should use `ResponsiveContainer` (likely already in use — verify)
+- On mobile, trend chart grid (`lg:grid-cols-2`) correctly falls to single column
+- No changes needed if already working
+
+### 5.3 Date Picker Mobile
+
+- Verify the calendar dropdown doesn't overflow the viewport on small screens
+- If it does, switch to a bottom sheet or full-screen modal on mobile
+
+---
+
+## 6. Uniworld Journeys Brand Reference
+
+### Complete Color Palette (from K&P Brand Identity R6)
+
+**Primary Colors:**
+
+| Name | Hex | Usage |
+|---|---|---|
+| Plaster | `#F1EEEA` | Light backgrounds, page bg |
+| Parchment | `#D6D0C5` | Secondary light surfaces |
+| Taupe | `#655E51` | Mid-tone, secondary text |
+| Charcoal | `#373535` | Primary anchor, header bg |
+| Willow | `#9F907C` | Warm gray-green accent |
+
+**Secondary Colors:**
+
+| Name | Hex | Usage |
+|---|---|---|
+| Gold (light) | `#E7D39C` | Logo gradient start, accent hover |
+| Gold (dark) | `#C2AB82` | Logo gradient end, primary accent |
+
+**Extended Digital Palette:**
+
+| Name | Hex |
+|---|---|
+| Dark Charcoal | `#1E1C1C` |
+| Charcoal 95 | `#433F3F` |
+| Charcoal 90 | `#494545` |
+| Charcoal 85 | `#514D4D` |
+| Dark Taupe | `#5A5246` |
+| Taupe 95 | `#766B5C` |
+| Dark Willow | `#8B7C69` |
+| Willow 95 | `#A5967E` |
+| Willow 90 | `#AC9E88` |
+| Willow 85 | `#B7AB98` |
+| Dark Parchment | `#BFB9AE` |
+| Parchment 95 | `#DED7CB` |
+| Plaster 95 | `#F3F1EC` |
+| Plaster 90 | `#F7F5F2` |
+| Plaster 85 | `#FBFBF9` |
+| White | `#FFFFFF` |
+
+### WCAG AA Compliance Notes
+
+- Dark Charcoal, Charcoal, Charcoal 95, Charcoal 90, Charcoal 85 all pass AA against Plaster, Plaster 95, Plaster 90, Plaster 85, and White backgrounds
+- Taupe and Dark Taupe pass AA against all Plaster shades and White
+- Willow shades do NOT pass AA against light backgrounds — use only for decorative/non-essential text
+- Gold does NOT pass AA for text on light backgrounds — use only for icons, indicators, badges (non-text)
+
+---
+
+## 7. Implementation Order
+
+Execute in this sequence:
+
+### Step 1: Theme Token Foundation
+1. Create `src/lib/theme/tokens.ts` — types, default theme, Uniworld theme
+2. Create `src/lib/theme/derive.ts` — derivation logic with all light/dark mappings
+3. Create `src/lib/theme/inject.ts` — CSS variable injection utility
+4. Write unit tests for derivation logic
+
+### Step 2: BrandContext & Integration
+5. Create `src/contexts/BrandContext.tsx`
+6. Refactor `src/contexts/DashboardContext.tsx` — remove brand state
+7. Update `src/app/layout.tsx` — add BrandContext provider, wire up token injection
+8. Update `public/theme-init.js` — brand-aware pre-hydration
+9. Update `src/contexts/ThemeContext.tsx` — integrate with brand token system
+
+### Step 3: CSS Migration
+10. Overhaul `src/app/globals.css` — new token structure, delete dark mode overrides
+11. Update Tailwind `@theme inline` block
+12. Migrate all components from hardcoded hex → semantic CSS variables (systematic find-and-replace per Section 3.2 table)
+
+### Step 4: Header Consolidation
+13. Create `src/components/layout/NavTabs.tsx` — extracted tab navigation
+14. Create `src/components/layout/MobileDrawer.tsx` — hamburger slide-out menu
+15. Rewrite `src/components/layout/Header.tsx` — single bar with inline nav
+16. Refactor `src/components/layout/BrandSwitcher.tsx` → MerchantSwitcher
+17. Absorb RefreshButton into DateRangePicker
+18. Update `src/app/layout.tsx` — remove Navigation import, single Header
+19. Delete or archive `src/components/layout/Navigation.tsx`
+
+### Step 5: Responsive Polish
+20. Auto-default to card view on mobile for Itineraries/Ships pages
+21. Verify date picker mobile behavior
+22. Create `useThemeColors()` hook for Recharts
+23. Update all chart components to use theme-derived colors
+
+### Step 6: Testing & QA
+24. Visual regression: light mode, dark mode, mobile, tablet, desktop
+25. Verify all WCAG AA compliance per brand guide
+26. Test with default theme (vanilla) to ensure it works without Uniworld config
+27. Test merchant switcher with single merchant (should not render) and multiple merchants
+28. Cross-browser testing (Chrome, Firefox, Safari, Edge)
+
+---
+
+## 8. Files Changed Summary
+
+### New Files
+| File | Purpose |
+|---|---|
+| `src/lib/theme/tokens.ts` | Token type definitions + vanilla default theme only — no brand-specific data |
+| `src/lib/theme/derive.ts` | 6 tokens → full CSS variable derivation |
+| `src/lib/theme/inject.ts` | Runtime CSS variable injection |
+| `src/config/brands/uniworld-journeys.ts` | Uniworld Journeys brand config (Phase 1 stand-in for Firestore doc) |
+| `src/config/brands/index.ts` | Phase 1 brand loader — swap for Firestore fetch in Phase 2 |
+| `src/contexts/BrandContext.tsx` | Brand/merchant state management |
+| `src/components/layout/NavTabs.tsx` | Extracted tab navigation sub-component |
+| `src/components/layout/MobileDrawer.tsx` | Hamburger menu slide-out drawer |
+| `src/hooks/useThemeColors.ts` | Read computed CSS vars for Recharts |
+
+### Modified Files
+| File | Changes |
+|---|---|
+| `src/app/globals.css` | Full overhaul: semantic tokens, delete dark overrides |
+| `src/app/layout.tsx` | BrandContext provider, single Header layout |
+| `src/components/layout/Header.tsx` | Full rewrite: single bar, inline nav, hamburger |
+| `src/components/layout/BrandSwitcher.tsx` | Rename to MerchantSwitcher, conditional render |
+| `src/components/layout/ThemeToggle.tsx` | Move into new header, update token usage |
+| `src/components/layout/DateRangePicker.tsx` | Add compact mode, absorb RefreshButton |
+| `src/components/layout/AuthButton.tsx` | Move into new header layout |
+| `src/contexts/DashboardContext.tsx` | Remove brand state (moved to BrandContext) |
+| `src/contexts/ThemeContext.tsx` | Integrate with brand token derivation |
+| `public/theme-init.js` | Brand-aware pre-hydration tokens |
+| `src/app/page.tsx` | Replace hardcoded colors with semantic tokens |
+| `src/app/reviews/page.tsx` | Replace hardcoded colors with semantic tokens |
+| `src/app/itineraries/page.tsx` | Replace hardcoded colors, mobile card default |
+| `src/app/ships/page.tsx` | Replace hardcoded colors, mobile card default |
+| `src/app/admin/page.tsx` | Replace hardcoded colors with semantic tokens |
+| `src/components/dashboard/*.tsx` | All: replace hardcoded colors |
+| `src/components/reviews/*.tsx` | All: replace hardcoded colors |
+| `src/components/itineraries/*.tsx` | Replace hardcoded colors |
+| `src/components/ships/*.tsx` | Replace hardcoded colors |
+| `src/components/ui/*.tsx` | Replace hardcoded colors |
+
+### Deleted Files
+| File | Reason |
+|---|---|
+| `src/components/layout/Navigation.tsx` | Merged into Header as NavTabs sub-component |
+| `src/components/layout/RefreshButton.tsx` | Absorbed into DateRangePicker |
+
+---
+
+## 9. Acceptance Criteria
+
+- [x] Dashboard renders with Uniworld Journeys warm neutral palette (Charcoal header, Plaster backgrounds, Gold accents)
+- [x] Dark mode derives from the same brand tokens and feels cohesive (warm-tinted, not generic gray)
+- [x] Header and nav occupy a single row on desktop (~48-56px)
+- [x] Mobile hamburger menu works with smooth slide-out animation
+- [x] No hardcoded hex color values remain in component files (all use CSS variables)
+- [x] All `.dark .class { !important }` overrides removed from globals.css
+- [x] Merchant switcher only appears when brand has 2+ merchant IDs
+- [x] Default/vanilla theme renders correctly when no brand config is present
+- [x] Charts use theme-derived colors in both light and dark mode
+- [x] Itineraries and Ships pages default to card view on mobile
+- [ ] All text passes WCAG AA contrast requirements per brand guide  *(to verify in QA — palette follows brand guide)*
+- [ ] No visual regression in existing functionality  *(manual QA pass required)*


### PR DESCRIPTION
## Summary

- **Theme engine** — 6-token brand system (`src/lib/theme/`) with programmatic light/dark derivation, runtime CSS variable injection via `BrandContext`, and flash-free pre-hydration via `public/theme-init.js`
- **Uniworld Journeys reskin** — warm neutral palette (Charcoal, Taupe, Plaster, Gold accent) applied across all 30+ CSS custom property tokens; `globals.css` fully migrated to `@theme inline` Tailwind v4 mappings
- **Responsive header consolidation** — two-bar layout (Header + Navigation) replaced by a single sticky bar with embedded `NavTabs` on desktop and a `MobileDrawer` hamburger menu on mobile; admin link in drawer gated by the same async auth check as the desktop tabs

## What changed

| Area | Files |
|---|---|
| Theme engine | `src/lib/theme/tokens.ts`, `derive.ts`, `inject.ts` |
| Brand config | `src/config/brands/` |
| Context bridge | `src/contexts/BrandContext.tsx`, `ThemeContext.tsx` |
| Pre-hydration | `public/theme-init.js` |
| Global styles | `src/app/globals.css` |
| Header / nav | `Header.tsx`, `NavTabs.tsx`, `MobileDrawer.tsx`, `MerchantSwitcher.tsx` |
| Recharts colors | `src/hooks/useThemeColors.ts`, `TrendChart`, `ThemeChart`, `RatingDistributionChart` |
| All UI components | Semantic token adoption across dashboard, reviews, ships, itineraries, admin |

## Test plan

- [ ] Light mode — all pages, verify warm neutral palette renders correctly
- [ ] Dark mode toggle — verify instant re-injection, no flash
- [ ] Mobile (< 768px) — hamburger opens drawer, nav links work, admin link visible when signed in with access
- [ ] Desktop (≥ 768px) — single header bar, NavTabs visible, MobileDrawer hidden
- [ ] WCAG AA contrast — header text on `--header-bg`, body text on `--background`
- [ ] Build passes — `npm run build` exits 0, TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)