### PR TITLE
Fix DateRangePicker height misalignment in header

### DIFF
--- a/app/src/components/layout/DateRangePicker.tsx
+++ b/app/src/components/layout/DateRangePicker.tsx
@@ -93,7 +93,7 @@ export default function DateRangePicker({
           e.stopPropagation();
           setOpen(!open);
         }}
-        className={`cursor-pointer flex w-full items-center justify-between gap-2 rounded-full px-3.5 py-2 text-sm font-medium shadow-sm transition-colors sm:min-w-[11.5rem] sm:w-auto ${
+        className={`cursor-pointer flex w-full items-center justify-between gap-2 rounded-full px-3.5 py-1.5 text-sm font-medium shadow-sm transition-colors sm:min-w-[11.5rem] sm:w-auto ${
           isNeutral
             ? "border border-border bg-surface text-text-primary hover:bg-surface-hover dark:border-border"
             : "border border-white/20 bg-white/10 text-white hover:bg-white/20"


### PR DESCRIPTION
## Summary

- The date range picker trigger button was `py-2` (8px padding) while the merchant switcher pills and refresh button both use `py-1.5` (6px), making it visibly taller in the header row.
- Change `py-2` → `py-1.5` on the trigger button to align all three controls to the same height.

## Test plan

- [ ] Header row 2: all three controls (merchant pills, date picker, refresh button) sit at the same height
- [ ] Date picker dropdown still opens and functions correctly
- [ ] Neutral tone (mobile drawer) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)