### PR TITLE
Fix dark mode persistence and inactive nav tab contrast

### DIFF
--- a/app/public/theme-init.js
+++ b/app/public/theme-init.js
@@ -39,7 +39,7 @@
     "--header-text":          "#ffffff",
     "--nav-active-text":      "#373535",
     "--nav-active-indicator": "#c2ab82",
-    "--nav-inactive-text":    "#655e51",
+    "--nav-inactive-text":    "#a7a4a2",
     "--brand-accent":         "#c2ab82",
     "--brand-accent-light":   "#e7d39c",
     "--brand-accent-hover":   "rgba(194,171,130,0.1)",

--- a/app/src/contexts/ThemeContext.tsx
+++ b/app/src/contexts/ThemeContext.tsx
@@ -66,7 +66,12 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     (): Theme => "light"
   );
 
-  // Apply class to document
+  // Apply .dark class and color-scheme to the document.
+  // NOTE: do NOT write to localStorage here — that would corrupt the saved
+  // preference on every hydration, because the SSR server snapshot always
+  // starts as "light" and the effect fires before useSyncExternalStore can
+  // correct the value to what localStorage actually contains.
+  // Persistence is handled exclusively by toggleTheme().
   useEffect(() => {
     const root = document.documentElement;
     if (theme === "dark") {
@@ -76,7 +81,6 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
       root.classList.remove("dark");
       root.style.colorScheme = "light";
     }
-    localStorage.setItem(THEME_STORAGE_KEY, theme);
   }, [theme]);
 
   const toggleTheme = useCallback(() => {

--- a/app/src/lib/theme/derive.ts
+++ b/app/src/lib/theme/derive.ts
@@ -147,11 +147,15 @@ export function deriveTokens(tokens: BrandTokens, isDark: boolean): CssVarMap {
     "--text-tertiary": mix(neutral, 60, surfaceWarm),
 
     // --- Header / Nav ---
+    // The header background is always the dark primary colour, even in light
+    // mode. nav-inactive-text must therefore be a light tone — using neutral
+    // (Taupe) here gives ~1.9:1 contrast against Charcoal, which fails WCAG AA.
+    // mix(surfaceWarm, 60%, primary) ≈ #a7a4a2 → ~5.1:1 on the Charcoal header.
     "--header-bg": primary,
     "--header-text": "#ffffff",
     "--nav-active-text": primary,
     "--nav-active-indicator": accent,
-    "--nav-inactive-text": neutral,
+    "--nav-inactive-text": mix(surfaceWarm, 60, primary),
 
     // --- Brand accent ---
     "--brand-accent": accent,


### PR DESCRIPTION
## Summary

- **Dark mode not persisting on refresh** — the `useEffect` in `ThemeContext` was writing the current theme to `localStorage` on every render. During hydration the SSR server snapshot is always `"light"`, so the effect fired first and overwrote the user's saved `"dark"` preference before `useSyncExternalStore` could correct it. Removed the `localStorage.setItem` call from the effect; `toggleTheme()` already handles persistence.

- **Inactive nav tabs low contrast** — `--nav-inactive-text` in light mode was set to `neutral` (Taupe `#655e51`), giving ~1.9:1 contrast against the Charcoal header — well below WCAG AA. The header is always dark regardless of light/dark mode, so the inactive text must be a light tone. Changed to `mix(surfaceWarm, 60%, primary)` ≈ `#a7a4a2`, which achieves ~5.1:1 contrast. Updated the matching hardcoded value in `theme-init.js` to keep pre-hydration tokens in sync.

## Files changed

| File | Change |
|---|---|
| `src/contexts/ThemeContext.tsx` | Remove `localStorage.setItem` from the `useEffect` |
| `src/lib/theme/derive.ts` | Light mode `--nav-inactive-text`: `neutral` → `mix(surfaceWarm, 60%, primary)` |
| `public/theme-init.js` | LIGHT map `--nav-inactive-text`: `#655e51` → `#a7a4a2` |

## Test plan

- [ ] Set dark mode, refresh — dark mode is preserved
- [ ] Set light mode, refresh — light mode is preserved
- [ ] Inactive nav tabs readable on Charcoal header in light mode
- [ ] Inactive nav tabs readable in dark mode (unchanged)
- [ ] No flash of wrong theme on refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)