### PR TITLE
feat: show review counts per star rating in filter sidebar

### DIFF
--- a/app/src/app/reviews/page.tsx
+++ b/app/src/app/reviews/page.tsx
@@ -367,6 +367,15 @@ function ReviewsContent() {
 
   const options = filterOptions;
 
+  // Per-rating counts from all loaded reviews (independent of active filters).
+  const ratingCounts = useMemo(() => {
+    const counts: Record<number, number> = {};
+    for (const review of allReviews) {
+      counts[review.rating] = (counts[review.rating] ?? 0) + 1;
+    }
+    return counts;
+  }, [allReviews]);
+
   // Client-side filtering (text search, themes, rating, brand sub-filter)
   const filtered = useMemo(() => {
     return applyClientFilters(allReviews, filters, search);
@@ -529,6 +538,7 @@ function ReviewsContent() {
               filters={filters}
               onChange={setFilters}
               options={options}
+              ratingCounts={ratingCounts}
             />
           </div>
         </div>

--- a/app/src/components/reviews/FilterSidebar.tsx
+++ b/app/src/components/reviews/FilterSidebar.tsx
@@ -42,6 +42,8 @@ interface FilterSidebarProps {
     regions: string[];
     loyaltyLevels: string[];
   };
+  /** Map of star value → number of reviews at that rating (from all loaded reviews). */
+  ratingCounts?: Record<number, number>;
 }
 
 function ChevronIcon({ open }: { open: boolean }) {
@@ -112,7 +114,7 @@ function formatBrandName(slug: string): string {
     .join(" ");
 }
 
-export default function FilterSidebar({ filters, onChange, options }: FilterSidebarProps) {
+export default function FilterSidebar({ filters, onChange, options, ratingCounts }: FilterSidebarProps) {
   const activeFilterCount = Object.entries(filters).reduce(
     (sum, [key, val]) => sum + (key === "hasMedia" ? (val ? 1 : 0) : (val as unknown[]).length),
     0
@@ -225,14 +227,18 @@ export default function FilterSidebar({ filters, onChange, options }: FilterSide
 
       {/* Star Rating */}
       <FilterSection title="Star Rating" defaultOpen>
-        {(options.ratings.length > 0 ? options.ratings : [5, 4, 3, 2, 1]).map((star) => (
-          <CheckboxItem
-            key={star}
-            label={`${"★".repeat(star)}${"☆".repeat(5 - star)} (${star})`}
-            checked={filters.rating.includes(star)}
-            onChange={() => toggleArrayFilter("rating", star)}
-          />
-        ))}
+        {(options.ratings.length > 0 ? options.ratings : [5, 4, 3, 2, 1]).map((star) => {
+          const count = ratingCounts?.[star];
+          const countLabel = count !== undefined ? ` (${count.toLocaleString()})` : "";
+          return (
+            <CheckboxItem
+              key={star}
+              label={`${star} ${"★".repeat(star)}${"☆".repeat(5 - star)}${countLabel}`}
+              checked={filters.rating.includes(star)}
+              onChange={() => toggleArrayFilter("rating", star)}
+            />
+          );
+        })}
       </FilterSection>
 
       {/* Ship */}


### PR DESCRIPTION
## Summary

- Replaces the star number in parentheses (e.g. `(5)`) with the actual count of loaded reviews at that rating (e.g. `(1,234)`)
- Moves the numeric star value to the left of the stars: `5 ★★★★★ (1,234)` / `4 ★★★★☆ (856)` etc.
- Counts are derived with `useMemo` from the already-loaded `allReviews` array — no additional Firestore reads required
- New optional `ratingCounts?: Record<number, number>` prop added to `FilterSidebar` (gracefully omits the count if not provided)

## Test plan

- [ ] Open the Reviews page and expand the **Star Rating** filter section
- [ ] Verify labels show `5 ★★★★★ (N)`, `4 ★★★★☆ (N)`, etc. with real counts
- [ ] Verify counts update after changing the date range (new data load)
- [ ] Verify selecting other filters does **not** change the counts (counts are from all loaded reviews, not filtered set)
- [ ] Verify comma-formatting on counts ≥ 1,000

🤖 Generated with [Claude Code](https://claude.com/claude-code)