### PR TITLE
fix: align star rating labels and use accurate date-range counts

### DIFF
--- a/app/src/app/reviews/page.tsx
+++ b/app/src/app/reviews/page.tsx
@@ -60,7 +60,7 @@ function mapReviewDoc(
 // ---------------------------------------------------------------------------
 
 const EMPTY_FILTER_OPTIONS: FilterOptions = {
-  brands: [], ratings: [], ships: [], itineraries: [],
+  brands: [], ratings: [], ratingCounts: {}, ships: [], itineraries: [],
   positiveThemes: [], negativeThemes: [],
   bookingTypes: [], regions: [], loyaltyLevels: [],
 };
@@ -367,15 +367,6 @@ function ReviewsContent() {
 
   const options = filterOptions;
 
-  // Per-rating counts from all loaded reviews (independent of active filters).
-  const ratingCounts = useMemo(() => {
-    const counts: Record<number, number> = {};
-    for (const review of allReviews) {
-      counts[review.rating] = (counts[review.rating] ?? 0) + 1;
-    }
-    return counts;
-  }, [allReviews]);
-
   // Client-side filtering (text search, themes, rating, brand sub-filter)
   const filtered = useMemo(() => {
     return applyClientFilters(allReviews, filters, search);
@@ -538,7 +529,6 @@ function ReviewsContent() {
               filters={filters}
               onChange={setFilters}
               options={options}
-              ratingCounts={ratingCounts}
             />
           </div>
         </div>

--- a/app/src/components/reviews/FilterSidebar.tsx
+++ b/app/src/components/reviews/FilterSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import React, { useState } from "react";
 
 export interface Filters {
   brand: string[];
@@ -34,6 +34,8 @@ interface FilterSidebarProps {
   options: {
     brands: string[];
     ratings: number[];
+    /** Count of reviews per star value, keyed by the star number (1–5). */
+    ratingCounts?: Record<number, number>;
     ships: string[];
     itineraries: string[];
     positiveThemes: string[];
@@ -42,8 +44,6 @@ interface FilterSidebarProps {
     regions: string[];
     loyaltyLevels: string[];
   };
-  /** Map of star value → number of reviews at that rating (from all loaded reviews). */
-  ratingCounts?: Record<number, number>;
 }
 
 function ChevronIcon({ open }: { open: boolean }) {
@@ -90,7 +90,7 @@ function CheckboxItem({
   checked,
   onChange,
 }: {
-  label: string;
+  label: React.ReactNode;
   checked: boolean;
   onChange: (checked: boolean) => void;
 }) {
@@ -100,7 +100,7 @@ function CheckboxItem({
         type="checkbox"
         checked={checked}
         onChange={(e) => onChange(e.target.checked)}
-        className="h-3.5 w-3.5 rounded border-input-border text-text-primary focus:ring-brand-accent/30"
+        className="h-3.5 w-3.5 shrink-0 rounded border-input-border text-text-primary focus:ring-brand-accent/30"
       />
       {label}
     </label>
@@ -114,7 +114,7 @@ function formatBrandName(slug: string): string {
     .join(" ");
 }
 
-export default function FilterSidebar({ filters, onChange, options, ratingCounts }: FilterSidebarProps) {
+export default function FilterSidebar({ filters, onChange, options }: FilterSidebarProps) {
   const activeFilterCount = Object.entries(filters).reduce(
     (sum, [key, val]) => sum + (key === "hasMedia" ? (val ? 1 : 0) : (val as unknown[]).length),
     0
@@ -228,14 +228,29 @@ export default function FilterSidebar({ filters, onChange, options, ratingCounts
       {/* Star Rating */}
       <FilterSection title="Star Rating" defaultOpen>
         {(options.ratings.length > 0 ? options.ratings : [5, 4, 3, 2, 1]).map((star) => {
-          const count = ratingCounts?.[star];
-          const countLabel = count !== undefined ? ` (${count.toLocaleString()})` : "";
+          const count = options.ratingCounts?.[star];
           return (
             <CheckboxItem
               key={star}
-              label={`${star} ${"★".repeat(star)}${"☆".repeat(5 - star)}${countLabel}`}
               checked={filters.rating.includes(star)}
               onChange={() => toggleArrayFilter("rating", star)}
+              label={
+                <span className="flex items-center gap-1.5">
+                  {/* Fixed-width digit so stars always start in the same column */}
+                  <span className="w-3 shrink-0 text-right tabular-nums">{star}</span>
+                  {/* Each star occupies the same fixed width to prevent glyph-width drift */}
+                  <span className="flex">
+                    {Array.from({ length: 5 }, (_, i) => (
+                      <span key={i} className="inline-block w-[1em] text-center leading-none">
+                        {i < star ? "★" : "☆"}
+                      </span>
+                    ))}
+                  </span>
+                  {count !== undefined && (
+                    <span className="text-text-tertiary">({count.toLocaleString()})</span>
+                  )}
+                </span>
+              }
             />
           );
         })}

--- a/app/src/lib/firestore/queries.ts
+++ b/app/src/lib/firestore/queries.ts
@@ -499,6 +499,8 @@ export async function getEntitySummariesByDateRange(
 export interface FilterOptions {
   brands: string[];
   ratings: number[];
+  /** Count of reviews for each star value, keyed by the star number (1–5). */
+  ratingCounts: Record<number, number>;
   ships: string[];
   itineraries: string[];
   positiveThemes: string[];
@@ -531,6 +533,7 @@ export async function getFilterOptions(
 
   const brands = new Set<string>();
   const ratings = new Set<number>();
+  const ratingCounts: Record<number, number> = {};
   const ships = new Set<string>();
   const itineraries = new Set<string>();
   const positiveThemes = new Set<string>();
@@ -543,7 +546,11 @@ export async function getFilterOptions(
     const data = d.data();
     if (data.brand) brands.add(data.brand);
     const rating = data.ratings?.product ?? data.ratings?.service;
-    if (rating != null) ratings.add(Math.round(rating));
+    if (rating != null) {
+      const star = Math.round(rating);
+      ratings.add(star);
+      ratingCounts[star] = (ratingCounts[star] ?? 0) + 1;
+    }
     if (data.tags?.ship) ships.add(data.tags.ship);
     if (data.tags?.tour) itineraries.add(data.tags.tour);
     if (data.tags?.bookingType) bookingTypes.add(data.tags.bookingType);
@@ -556,6 +563,7 @@ export async function getFilterOptions(
   return {
     brands: [...brands].sort(),
     ratings: [...ratings].sort((a, b) => b - a),
+    ratingCounts,
     ships: [...ships].sort(),
     itineraries: [...itineraries].sort(),
     positiveThemes: [...positiveThemes].sort(),


### PR DESCRIPTION
## Summary

- **Star alignment**: each star character is now rendered in a fixed-width `inline-block` so filled `★` and empty `☆` glyphs (which have different natural widths in most fonts) always occupy the same space — the 1-star row no longer appears shorter than the 5-star row
- **Accurate counts**: moved `ratingCounts` computation into `getFilterOptions()`, which fetches all documents in the selected date range without a pagination limit — previously counts were derived from the paginated `allReviews` array (capped at 50), so they stayed stale for any date range returning more than 50 reviews; now they update correctly when the date range changes

## Test plan

- [ ] Open the Reviews page → Star Rating filter section — verify all 5 rows have their stars perfectly aligned
- [ ] With **Last 12 Months** selected, note the counts for each star rating
- [ ] Switch to **All Time** — verify the counts increase (more reviews in range)
- [ ] Switch back to **Last Quarter** — verify counts decrease accordingly
- [ ] Confirm changing other filters (ship, region, etc.) does **not** alter the star counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)