### PR TITLE
Add Review Updated/Created date filter to align with Feefo defaults

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -96,5 +96,5 @@ jobs:
       - name: Build frontend
         run: npm --prefix app run build
 
-      - name: Deploy Hosting and Functions
-        run: firebase deploy --project feefo-reviews --only functions,hosting --non-interactive
+      - name: Deploy Hosting, Functions, and Firestore indexes
+        run: firebase deploy --project feefo-reviews --only functions,hosting,firestore:indexes --non-interactive

--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useBrand } from "@/contexts/BrandContext";
 import { getClientAuth, getClientDb } from "@/lib/firebase";
+import { dateFieldPath } from "@/lib/firestore/queries";
 import { collection, query, where, getDocs, orderBy, QueryConstraint } from "firebase/firestore";
 import {
   getCurrentAdminAccess,
@@ -86,7 +87,7 @@ function SortIndicator({ active, dir }: { active: boolean; dir: SortDir }) {
 export default function AdminPage() {
   const router = useRouter();
   const { merchantQueryId: brand } = useBrand();
-  const { dateRange, dataVersion } = useDashboard();
+  const { dateRange, dateField, dataVersion } = useDashboard();
   const [user, setUser] = useState<User | null>(null);
   const [authResolved, setAuthResolved] = useState(false);
   const [currentAccess, setCurrentAccess] = useState<CurrentAdminAccess | null>(null);
@@ -165,10 +166,11 @@ export default function AdminPage() {
       // Query reviews within date range for tour counts
       const db = getClientDb();
       const ref = collection(db, "reviews");
+      const path = dateFieldPath(dateField);
       const constraints: QueryConstraint[] = [
-        where("dates.created", ">=", dateStart),
-        where("dates.created", "<=", dateEnd),
-        orderBy("dates.created", "desc"),
+        where(path, ">=", dateStart),
+        where(path, "<=", dateEnd),
+        orderBy(path, "desc"),
       ];
       if (brand !== "combined") {
         constraints.unshift(where("brand", "==", brand));
@@ -193,7 +195,7 @@ export default function AdminPage() {
     }
     setLoading(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- dataVersion is intentional to force reload after sync
-  }, [brand, dateStart, dateEnd, dataVersion]);
+  }, [brand, dateStart, dateEnd, dateField, dataVersion]);
 
   useEffect(() => {
     try {

--- a/app/src/app/itineraries/page.tsx
+++ b/app/src/app/itineraries/page.tsx
@@ -41,7 +41,7 @@ function ItinerariesContent() {
 
 function ItineraryList() {
   const { merchantQueryId: brand } = useBrand();
-  const { dateRange, dataVersion } = useDashboard();
+  const { dateRange, dateField, dataVersion } = useDashboard();
   const [itineraries, setItineraries] = useState<ItinerarySummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -56,7 +56,7 @@ function ItineraryList() {
       setLoading(true);
       setError(null);
     });
-    getItineraries(brand, dateRange).then((data) => {
+    getItineraries(brand, dateRange, dateField).then((data) => {
       if (cancelled) return;
       setItineraries(data);
       setLoading(false);
@@ -67,7 +67,7 @@ function ItineraryList() {
       setLoading(false);
     });
     return () => { cancelled = true; };
-  }, [brand, dateRange, dataVersion]);
+  }, [brand, dateRange, dateField, dataVersion]);
 
   const filtered = useMemo(() => {
     const result = itineraries.filter((it) =>

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -26,7 +26,7 @@ import {
 
 export default function OverviewPage() {
   const { merchantQueryId: brand } = useBrand();
-  const { dateRange, dataVersion } = useDashboard();
+  const { dateRange, dateField, dataVersion } = useDashboard();
 
   const [fleet, setFleet] = useState<FleetSummary | null>(null);
   const [trendPoints, setTrendPoints] = useState<TrendPoint[]>([]);
@@ -52,15 +52,15 @@ export default function OverviewPage() {
     const isAllTime = dateRange.preset === "All Time";
     const fleetPromise = isAllTime
       ? getFleetSummary(brand)
-      : getFleetSummaryByDateRange(brand, dateRange.start, dateRange.end);
+      : getFleetSummaryByDateRange(brand, dateRange.start, dateRange.end, dateField);
 
     const entityPromise = isAllTime
       ? getEntitySummaries(brand)
-      : getEntitySummariesByDateRange(brand, dateRange.start, dateRange.end);
+      : getEntitySummariesByDateRange(brand, dateRange.start, dateRange.end, dateField);
 
     Promise.all([
       fleetPromise,
-      getTrendSeries(brand, dateRange.start, dateRange.end),
+      getTrendSeries(brand, dateRange.start, dateRange.end, dateField),
       entityPromise,
     ]).then(([f, trend, e]) => {
       if (cancelled) return;
@@ -85,7 +85,7 @@ export default function OverviewPage() {
     return () => {
       cancelled = true;
     };
-  }, [brand, dateRange, dataVersion]);
+  }, [brand, dateRange, dateField, dataVersion]);
 
   const openPanel = useCallback(
     async (selection: {
@@ -105,7 +105,8 @@ export default function OverviewPage() {
           brand,
           dateRange.start,
           dateRange.end,
-          selection.filter
+          selection.filter,
+          dateField
         );
         setPanelReviews(reviews);
       } catch (err) {
@@ -115,7 +116,7 @@ export default function OverviewPage() {
         setPanelLoading(false);
       }
     },
-    [brand, dateRange.end, dateRange.start]
+    [brand, dateRange.end, dateRange.start, dateField]
   );
 
   const closePanel = useCallback(() => {

--- a/app/src/app/reviews/page.tsx
+++ b/app/src/app/reviews/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useMemo, useCallback, useEffect, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
-import { useDashboard } from "@/contexts/DashboardContext";
+import { useDashboard, type DateField } from "@/contexts/DashboardContext";
 import { useBrand } from "@/contexts/BrandContext";
 import { getClientDb } from "@/lib/firebase";
 import {
@@ -17,7 +17,12 @@ import {
   DocumentData,
   QueryConstraint,
 } from "firebase/firestore";
-import { getFilterOptions, getParentNameLookup, type FilterOptions } from "@/lib/firestore/queries";
+import {
+  dateFieldPath,
+  getFilterOptions,
+  getParentNameLookup,
+  type FilterOptions,
+} from "@/lib/firestore/queries";
 import FilterSidebar, {
   type Filters,
   emptyFilters,
@@ -31,10 +36,20 @@ import ExportButton from "@/components/reviews/ExportButton";
 
 function mapReviewDoc(
   doc: QueryDocumentSnapshot<DocumentData>,
+  dateField: DateField,
   parentLookup?: Map<string, string>
 ): ReviewData {
   const d = doc.data();
   const rawItinerary = d.tags?.tour || d.product?.title || "";
+  const dates = d.dates as { created?: unknown; lastUpdated?: unknown } | undefined;
+  const primary = dateField === "lastUpdated" ? dates?.lastUpdated : dates?.created;
+  const fallback = dateField === "lastUpdated" ? dates?.created : dates?.lastUpdated;
+  const date =
+    typeof primary === "string"
+      ? primary
+      : typeof fallback === "string"
+        ? fallback
+        : "";
   return {
     id: doc.id,
     customerName: d.customer?.displayName || "Trusted Customer",
@@ -50,7 +65,7 @@ function mapReviewDoc(
     bookingType: d.tags?.bookingType || "",
     region: d.tags?.region || "",
     loyalty: d.tags?.loyalty || "",
-    date: d.dates?.created || "",
+    date,
     media: Array.isArray(d.media) ? d.media : [],
   };
 }
@@ -69,7 +84,7 @@ const EMPTY_FILTER_OPTIONS: FilterOptions = {
 // Sort
 // ---------------------------------------------------------------------------
 
-type SortOption = "newest" | "oldest" | "highest" | "lowest";
+type SortOption = "newest" | "oldest";
 
 function sortReviews(reviews: ReviewData[], sort: SortOption): ReviewData[] {
   const sorted = [...reviews];
@@ -78,10 +93,6 @@ function sortReviews(reviews: ReviewData[], sort: SortOption): ReviewData[] {
       return sorted.sort((a, b) => b.date.localeCompare(a.date));
     case "oldest":
       return sorted.sort((a, b) => a.date.localeCompare(b.date));
-    case "highest":
-      return sorted.sort((a, b) => b.rating - a.rating || b.date.localeCompare(a.date));
-    case "lowest":
-      return sorted.sort((a, b) => a.rating - b.rating || b.date.localeCompare(a.date));
   }
 }
 
@@ -109,7 +120,8 @@ function paramsToFilters(searchParams: URLSearchParams): {
   sort: SortOption;
 } {
   const search = searchParams.get("q") || "";
-  const sort = (searchParams.get("sort") as SortOption) || "newest";
+  const rawSort = searchParams.get("sort");
+  const sort: SortOption = rawSort === "oldest" ? "oldest" : "newest";
 
   const parseArray = (key: string) => {
     const val = searchParams.get(key);
@@ -140,17 +152,19 @@ function buildServerConstraints(
   brand: string,
   dateStart: string,
   dateEnd: string,
-  filters: Filters
+  filters: Filters,
+  dateField: DateField
 ): QueryConstraint[] {
   const constraints: QueryConstraint[] = [];
+  const path = dateFieldPath(dateField);
 
   if (brand !== "combined") {
     constraints.push(where("brand", "==", brand));
   }
 
   // Date range
-  constraints.push(where("dates.created", ">=", dateStart));
-  constraints.push(where("dates.created", "<=", dateEnd));
+  constraints.push(where(path, ">=", dateStart));
+  constraints.push(where(path, "<=", dateEnd));
 
   // Single-value equality filters (Firestore supports these alongside orderBy)
   // We can only use ONE array-contains or "in" per query, so we pick the most
@@ -186,7 +200,7 @@ function buildServerConstraints(
     constraints.push(where("tags.tour", "in", filters.itinerary));
   }
 
-  constraints.push(orderBy("dates.created", "desc"));
+  constraints.push(orderBy(path, "desc"));
 
   return constraints;
 }
@@ -254,7 +268,7 @@ const DISPLAY_PAGE_SIZE = 10;
 function ReviewsContent() {
   const searchParams = useSearchParams();
   const { merchantQueryId: brand } = useBrand();
-  const { dateRange, dataVersion } = useDashboard();
+  const { dateRange, dateField, dataVersion } = useDashboard();
 
   // Parse initial state from URL
   const initial = paramsToFilters(searchParams);
@@ -282,8 +296,10 @@ function ReviewsContent() {
 
   // Load filter options scoped to the selected date range
   useEffect(() => {
-    getFilterOptions(brand, dateStart, dateEnd).then(setFilterOptions).catch(() => {});
-  }, [brand, dateStart, dateEnd, dataVersion]);
+    getFilterOptions(brand, dateStart, dateEnd, dateField)
+      .then(setFilterOptions)
+      .catch(() => {});
+  }, [brand, dateStart, dateEnd, dateField, dataVersion]);
 
   // Main query — re-fetch when brand, date range, or server-side filters change
   useEffect(() => {
@@ -297,13 +313,13 @@ function ReviewsContent() {
 
     const db = getClientDb();
     const ref = collection(db, "reviews");
-    const constraints = buildServerConstraints(brand, dateStart, dateEnd, filters);
+    const constraints = buildServerConstraints(brand, dateStart, dateEnd, filters, dateField);
     constraints.push(limit(PAGE_SIZE));
     const q = query(ref, ...constraints);
 
     Promise.all([getDocs(q), getParentNameLookup(brand)]).then(([snap, parentLookup]) => {
       if (cancelled) return;
-      const reviews = snap.docs.map((d) => mapReviewDoc(d, parentLookup));
+      const reviews = snap.docs.map((d) => mapReviewDoc(d, dateField, parentLookup));
       setAllReviews(reviews);
       setLastDoc(snap.docs[snap.docs.length - 1] || null);
       setHasMoreFirestore(snap.docs.length === PAGE_SIZE);
@@ -321,7 +337,7 @@ function ReviewsContent() {
 
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [brand, dateStart, dateEnd, srvFilterKey, dataVersion]);
+  }, [brand, dateStart, dateEnd, dateField, srvFilterKey, dataVersion]);
 
   // Load more from Firestore
   const loadMoreFromFirestore = useCallback(async () => {
@@ -330,14 +346,14 @@ function ReviewsContent() {
 
     const db = getClientDb();
     const ref = collection(db, "reviews");
-    const constraints = buildServerConstraints(brand, dateStart, dateEnd, filters);
+    const constraints = buildServerConstraints(brand, dateStart, dateEnd, filters, dateField);
     constraints.push(startAfter(lastDoc), limit(PAGE_SIZE));
     const q = query(ref, ...constraints);
     try {
       const snap = await getDocs(q);
 
       const parentLookup = await getParentNameLookup(brand);
-      const newReviews = snap.docs.map((d) => mapReviewDoc(d, parentLookup));
+      const newReviews = snap.docs.map((d) => mapReviewDoc(d, dateField, parentLookup));
       setAllReviews((prev) => [...prev, ...newReviews]);
       setLastDoc(snap.docs[snap.docs.length - 1] || null);
       setHasMoreFirestore(snap.docs.length === PAGE_SIZE);
@@ -351,7 +367,7 @@ function ReviewsContent() {
       setLoadingMore(false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [lastDoc, hasMoreFirestore, loadingMore, brand, dateStart, dateEnd, srvFilterKey]);
+  }, [lastDoc, hasMoreFirestore, loadingMore, brand, dateStart, dateEnd, dateField, srvFilterKey]);
 
   // Sync state to URL using history API directly to avoid Next.js router re-render cycles
   useEffect(() => {
@@ -476,21 +492,31 @@ function ReviewsContent() {
             </span>
           )}
         </button>
-        <div className="flex items-center gap-2 ml-auto">
-          <label htmlFor="sort-select" className="text-sm text-text-secondary">
-            Sort:
-          </label>
-          <select
-            id="sort-select"
-            value={sort}
-            onChange={(e) => setSort(e.target.value as SortOption)}
-            className="rounded-lg border border-input-border bg-surface px-3 py-1.5 text-sm text-text-primary focus:outline-none focus:ring-2 focus:ring-brand-accent/30"
+        <div className="flex items-center ml-auto" role="group" aria-label="Sort order">
+          <button
+            type="button"
+            onClick={() => setSort("newest")}
+            aria-pressed={sort === "newest"}
+            className={`cursor-pointer rounded-l-lg border px-4 py-1.5 text-sm font-medium transition-colors ${
+              sort === "newest"
+                ? "border-brand-accent bg-brand-accent text-brand-accent-foreground"
+                : "border-input-border bg-surface text-text-primary hover:bg-surface-hover"
+            }`}
           >
-            <option value="newest">Newest</option>
-            <option value="oldest">Oldest</option>
-            <option value="highest">Highest Rating</option>
-            <option value="lowest">Lowest Rating</option>
-          </select>
+            Newest
+          </button>
+          <button
+            type="button"
+            onClick={() => setSort("oldest")}
+            aria-pressed={sort === "oldest"}
+            className={`cursor-pointer -ml-px rounded-r-lg border px-4 py-1.5 text-sm font-medium transition-colors ${
+              sort === "oldest"
+                ? "border-brand-accent bg-brand-accent text-brand-accent-foreground"
+                : "border-input-border bg-surface text-text-primary hover:bg-surface-hover"
+            }`}
+          >
+            Oldest
+          </button>
         </div>
       </div>
 

--- a/app/src/app/ships/page.tsx
+++ b/app/src/app/ships/page.tsx
@@ -41,7 +41,7 @@ function ShipsContent() {
 
 function ShipList() {
   const { merchantQueryId: brand } = useBrand();
-  const { dateRange, dataVersion } = useDashboard();
+  const { dateRange, dateField, dataVersion } = useDashboard();
   const [ships, setShips] = useState<ShipSummary[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -56,7 +56,7 @@ function ShipList() {
       setLoading(true);
       setError(null);
     });
-    getShips(brand, dateRange).then((data) => {
+    getShips(brand, dateRange, dateField).then((data) => {
       if (cancelled) return;
       setShips(data);
       setLoading(false);
@@ -67,7 +67,7 @@ function ShipList() {
       setLoading(false);
     });
     return () => { cancelled = true; };
-  }, [brand, dateRange, dataVersion]);
+  }, [brand, dateRange, dateField, dataVersion]);
 
   const filtered = useMemo(() => {
     const result = ships.filter((s) =>

--- a/app/src/components/itineraries/ItineraryDetail.tsx
+++ b/app/src/components/itineraries/ItineraryDetail.tsx
@@ -20,7 +20,7 @@ import {
 
 export default function ItineraryDetail({ slug }: { slug: string }) {
   const { merchantQueryId: brand } = useBrand();
-  const { dateRange, dataVersion } = useDashboard();
+  const { dateRange, dateField, dataVersion } = useDashboard();
   const [itinerary, setItinerary] = useState<ItinerarySummary | null>(null);
   const [quotes, setQuotes] = useState<{ positive: Quote[]; negative: Quote[] }>({
     positive: [],
@@ -38,7 +38,7 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    getItineraryBySlug(slug, brand, dateRange).then(async (data) => {
+    getItineraryBySlug(slug, brand, dateRange, dateField).then(async (data) => {
       if (cancelled) return;
       setItinerary(data);
       if (data) {
@@ -47,7 +47,8 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
           data.childItineraries,
           data.ships[0],
           brand,
-          dateRange
+          dateRange,
+          dateField
         );
         if (!cancelled) setQuotes(q);
       }
@@ -59,7 +60,7 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
       setLoading(false);
     });
     return () => { cancelled = true; };
-  }, [slug, brand, dateRange, dataVersion]);
+  }, [slug, brand, dateRange, dateField, dataVersion]);
 
   const openPanel = useCallback(async (theme: string, type: "positive" | "negative") => {
     setPanelTheme(theme);
@@ -67,7 +68,7 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
     setPanelOpen(true);
     setPanelLoading(true);
     try {
-      const reviews = await getReviewsByTheme(brand, theme, type, dateRange.start, dateRange.end);
+      const reviews = await getReviewsByTheme(brand, theme, type, dateField, dateRange.start, dateRange.end);
       setPanelReviews(reviews);
     } catch (err) {
       console.error("Failed to load theme reviews", err);
@@ -75,7 +76,7 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
     } finally {
       setPanelLoading(false);
     }
-  }, [brand, dateRange]);
+  }, [brand, dateRange, dateField]);
 
   const closePanel = useCallback(() => {
     setPanelOpen(false);

--- a/app/src/components/layout/DateFieldSelector.tsx
+++ b/app/src/components/layout/DateFieldSelector.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+/**
+ * DateFieldSelector — toggles which date field on a review document drives
+ * the date-range filter across the app.
+ *
+ * Mirrors Feefo's hub UI, which lets users filter by either "Review Updated
+ * Date" (default) or "Review Created Date". The selection is persisted in
+ * localStorage via `pref:dateField` and read by `useDashboard()`.
+ */
+
+import { useState, useRef, useEffect } from "react";
+import {
+  useDashboard,
+  DATE_FIELD_LABELS,
+  type DateField,
+} from "@/contexts/DashboardContext";
+
+const options: DateField[] = ["lastUpdated", "created"];
+
+type DateFieldSelectorProps = {
+  tone?: "inverse" | "neutral";
+};
+
+export default function DateFieldSelector({
+  tone = "inverse",
+}: DateFieldSelectorProps) {
+  const { dateField, setDateField } = useDashboard();
+  const [open, setOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const isNeutral = tone === "neutral";
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node)
+      ) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("click", handleClickOutside);
+    return () => document.removeEventListener("click", handleClickOutside);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen(!open);
+        }}
+        title="Date field used to filter reviews"
+        className={`cursor-pointer flex w-full items-center justify-between gap-2 rounded-full px-3.5 py-2 text-sm font-medium shadow-sm transition-colors sm:w-auto ${
+          isNeutral
+            ? "border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 dark:border-white/15 dark:bg-white/5 dark:text-white dark:hover:bg-white/10"
+            : "border border-white/20 bg-white/10 text-white hover:bg-white/20"
+        }`}
+      >
+        <svg
+          className={`h-4 w-4 shrink-0 ${
+            isNeutral ? "text-slate-500 dark:text-white/70" : "text-white/70"
+          }`}
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M3 6h18M6 12h12M10 18h4"
+          />
+        </svg>
+        <span className="truncate">{DATE_FIELD_LABELS[dateField]}</span>
+        <svg
+          className={`h-4 w-4 shrink-0 transition-transform ${
+            isNeutral ? "text-slate-400 dark:text-white/50" : "text-white/50"
+          } ${open ? "rotate-180" : ""}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+          />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          className="absolute right-0 z-50 mt-2 w-56 rounded-2xl border border-border bg-surface py-1 shadow-xl"
+        >
+          {options.map((option) => (
+            <button
+              key={option}
+              onClick={() => {
+                setDateField(option);
+                setOpen(false);
+              }}
+              className={`cursor-pointer w-full px-4 py-2 text-left text-sm transition-colors ${
+                dateField === option
+                  ? "bg-brand-accent/10 text-text-primary font-semibold"
+                  : "text-text-secondary hover:bg-surface-hover hover:text-text-primary"
+              }`}
+            >
+              {DATE_FIELD_LABELS[option]}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/layout/Header.tsx
+++ b/app/src/components/layout/Header.tsx
@@ -27,6 +27,7 @@ import NavTabs from "./NavTabs";
 import MerchantSwitcher from "./MerchantSwitcher";
 import MobileDrawer from "./MobileDrawer";
 import DateRangePicker from "./DateRangePicker";
+import DateFieldSelector from "./DateFieldSelector";
 import RefreshButton from "./RefreshButton";
 import ThemeToggle from "./ThemeToggle";
 import AuthButton from "./AuthButton";
@@ -106,6 +107,7 @@ export default function Header() {
           >
             <MerchantSwitcher tone="inverse" />
             <DateRangePicker tone="inverse" />
+            <DateFieldSelector tone="inverse" />
             {showAuthControls && (
               <RefreshButton tone="inverse" showSyncLabel />
             )}

--- a/app/src/components/layout/MobileDrawer.tsx
+++ b/app/src/components/layout/MobileDrawer.tsx
@@ -24,6 +24,7 @@ import { getClientAuth, hasFirebaseWebConfig } from "@/lib/firebase";
 import { getCurrentAdminAccess } from "@/lib/firestore/admin-queries";
 import MerchantSwitcher from "./MerchantSwitcher";
 import DateRangePicker from "./DateRangePicker";
+import DateFieldSelector from "./DateFieldSelector";
 import RefreshButton from "./RefreshButton";
 import ThemeToggle from "./ThemeToggle";
 import AuthButton from "./AuthButton";
@@ -201,6 +202,14 @@ export default function MobileDrawer({ open, onClose }: MobileDrawerProps) {
               Date Range
             </p>
             <DateRangePicker tone="neutral" />
+          </div>
+
+          {/* Date field */}
+          <div className="space-y-1.5">
+            <p className="px-1 text-xs font-medium text-text-tertiary uppercase tracking-wide">
+              Date Field
+            </p>
+            <DateFieldSelector tone="neutral" />
           </div>
 
           {/* Refresh */}

--- a/app/src/components/ships/ShipDetail.tsx
+++ b/app/src/components/ships/ShipDetail.tsx
@@ -21,7 +21,7 @@ import {
 
 export default function ShipDetail({ slug }: { slug: string }) {
   const { merchantQueryId: brand } = useBrand();
-  const { dateRange, dataVersion } = useDashboard();
+  const { dateRange, dateField, dataVersion } = useDashboard();
   const [ship, setShip] = useState<ShipSummary | null>(null);
   const [quotes, setQuotes] = useState<{ positive: Quote[]; negative: Quote[] }>({
     positive: [],
@@ -39,11 +39,11 @@ export default function ShipDetail({ slug }: { slug: string }) {
     let cancelled = false;
     setLoading(true);
     setError(null);
-    getShipBySlug(slug, brand, dateRange).then(async (data) => {
+    getShipBySlug(slug, brand, dateRange, dateField).then(async (data) => {
       if (cancelled) return;
       setShip(data);
       if (data) {
-        const q = await getShipQuotes(data.name, brand, dateRange);
+        const q = await getShipQuotes(data.name, brand, dateRange, dateField);
         if (!cancelled) setQuotes(q);
       }
       setLoading(false);
@@ -54,7 +54,7 @@ export default function ShipDetail({ slug }: { slug: string }) {
       setLoading(false);
     });
     return () => { cancelled = true; };
-  }, [slug, brand, dateRange, dataVersion]);
+  }, [slug, brand, dateRange, dateField, dataVersion]);
 
   const openPanel = useCallback(async (theme: string, type: "positive" | "negative") => {
     setPanelTheme(theme);
@@ -62,7 +62,7 @@ export default function ShipDetail({ slug }: { slug: string }) {
     setPanelOpen(true);
     setPanelLoading(true);
     try {
-      const reviews = await getReviewsByTheme(brand, theme, type, dateRange.start, dateRange.end);
+      const reviews = await getReviewsByTheme(brand, theme, type, dateField, dateRange.start, dateRange.end);
       setPanelReviews(reviews);
     } catch (err) {
       console.error("Failed to load theme reviews", err);
@@ -70,7 +70,7 @@ export default function ShipDetail({ slug }: { slug: string }) {
     } finally {
       setPanelLoading(false);
     }
-  }, [brand, dateRange]);
+  }, [brand, dateRange, dateField]);
 
   const closePanel = useCallback(() => {
     setPanelOpen(false);

--- a/app/src/contexts/DashboardContext.tsx
+++ b/app/src/contexts/DashboardContext.tsx
@@ -16,6 +16,14 @@ import {
   type ReactNode,
 } from "react";
 import { subMonths, subYears, startOfMonth, startOfYear, startOfWeek } from "date-fns";
+import { usePersistedState } from "@/hooks/usePersistedState";
+
+export type DateField = "lastUpdated" | "created";
+
+export const DATE_FIELD_LABELS: Record<DateField, string> = {
+  lastUpdated: "Review Updated Date",
+  created: "Review Created Date",
+};
 
 export type DatePreset =
   | "This Week"
@@ -39,6 +47,8 @@ export interface DateRange {
 interface DashboardContextValue {
   dateRange: DateRange;
   setDateRange: (range: DateRange) => void;
+  dateField: DateField;
+  setDateField: (field: DateField) => void;
   lastSynced: string | null;
   setLastSynced: (value: string | null) => void;
   dataVersion: number;
@@ -111,6 +121,10 @@ function getInitialDateRange(): DateRange {
 
 export function DashboardProvider({ children }: { children: ReactNode }) {
   const [dateRange, setDateRangeState] = useState<DateRange>(getInitialDateRange);
+  const [dateField, setDateField] = usePersistedState<DateField>(
+    "pref:dateField",
+    "created"
+  );
   const [lastSynced, setLastSynced] = useState<string | null>(null);
   const [dataVersion, setDataVersion] = useState(0);
 
@@ -140,6 +154,8 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       value={{
         dateRange,
         setDateRange: handleSetDateRange,
+        dateField,
+        setDateField,
         lastSynced,
         setLastSynced: handleSetLastSynced,
         dataVersion,

--- a/app/src/contexts/DashboardContext.tsx
+++ b/app/src/contexts/DashboardContext.tsx
@@ -11,6 +11,7 @@
 import {
   createContext,
   useContext,
+  useEffect,
   useState,
   useCallback,
   type ReactNode,
@@ -24,6 +25,12 @@ export const DATE_FIELD_LABELS: Record<DateField, string> = {
   lastUpdated: "Review Updated Date",
   created: "Review Created Date",
 };
+
+const VALID_DATE_FIELDS: readonly DateField[] = ["lastUpdated", "created"];
+
+function isDateField(value: unknown): value is DateField {
+  return typeof value === "string" && (VALID_DATE_FIELDS as readonly string[]).includes(value);
+}
 
 export type DatePreset =
   | "This Week"
@@ -121,9 +128,27 @@ function getInitialDateRange(): DateRange {
 
 export function DashboardProvider({ children }: { children: ReactNode }) {
   const [dateRange, setDateRangeState] = useState<DateRange>(getInitialDateRange);
-  const [dateField, setDateField] = usePersistedState<DateField>(
+  const [storedDateField, setStoredDateField] = usePersistedState<DateField>(
     "pref:dateField",
     "created"
+  );
+  // Guard against a corrupted localStorage value: anything outside our enum
+  // gets coerced back to "created" and the bad value is wiped from storage.
+  const dateField: DateField = isDateField(storedDateField) ? storedDateField : "created";
+
+  useEffect(() => {
+    if (!isDateField(storedDateField)) {
+      setStoredDateField("created");
+    }
+  }, [storedDateField, setStoredDateField]);
+
+  const setDateField = useCallback(
+    (next: DateField) => {
+      if (isDateField(next)) {
+        setStoredDateField(next);
+      }
+    },
+    [setStoredDateField]
   );
   const [lastSynced, setLastSynced] = useState<string | null>(null);
   const [dataVersion, setDataVersion] = useState(0);

--- a/app/src/lib/firestore/itinerary-queries.ts
+++ b/app/src/lib/firestore/itinerary-queries.ts
@@ -1,8 +1,8 @@
 "use client";
 
 import { getClientDb } from "@/lib/firebase";
-import type { DateRange } from "@/contexts/DashboardContext";
-import { getFleetSummaryByDateRange } from "@/lib/firestore/queries";
+import type { DateField, DateRange } from "@/contexts/DashboardContext";
+import { dateFieldPath, getFleetSummaryByDateRange } from "@/lib/firestore/queries";
 import {
   collection,
   query,
@@ -56,12 +56,14 @@ function getReviewRating(data: Record<string, unknown>): number {
 function buildDateRangeConstraints(
   brand: string,
   startDate: Date,
-  endDate: Date
+  endDate: Date,
+  dateField: DateField
 ) {
+  const path = dateFieldPath(dateField);
   const constraints = [
-    where("dates.created", ">=", startDate.toISOString()),
-    where("dates.created", "<=", endDate.toISOString()),
-    orderBy("dates.created", "desc"),
+    where(path, ">=", startDate.toISOString()),
+    where(path, "<=", endDate.toISOString()),
+    orderBy(path, "desc"),
   ];
 
   if (brand !== "combined") {
@@ -90,14 +92,15 @@ async function getParentNameLookup(brand: string): Promise<Map<string, string>> 
 
 async function getItinerariesByDateRange(
   brand: string,
-  dateRange: SummaryDateRange
+  dateRange: SummaryDateRange,
+  dateField: DateField
 ): Promise<ItinerarySummary[]> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
   const [snap, parentLookup, fleet] = await Promise.all([
-    getDocs(query(ref, ...buildDateRangeConstraints(brand, dateRange.start, dateRange.end))),
+    getDocs(query(ref, ...buildDateRangeConstraints(brand, dateRange.start, dateRange.end, dateField))),
     getParentNameLookup(brand),
-    getFleetSummaryByDateRange(brand, dateRange.start, dateRange.end),
+    getFleetSummaryByDateRange(brand, dateRange.start, dateRange.end, dateField),
   ]);
 
   if (snap.empty) return [];
@@ -220,10 +223,11 @@ async function getFleetAverages(brand: string): Promise<{ avgRating: number; avg
 
 export async function getItineraries(
   brand: string = "combined",
-  dateRange?: SummaryDateRange
+  dateRange?: SummaryDateRange,
+  dateField: DateField = "created"
 ): Promise<ItinerarySummary[]> {
   if (dateRange && !usesAllTimeSummaries(dateRange)) {
-    return getItinerariesByDateRange(brand, dateRange);
+    return getItinerariesByDateRange(brand, dateRange, dateField);
   }
 
   const db = getClientDb();
@@ -315,9 +319,10 @@ export async function getItineraries(
 export async function getItineraryBySlug(
   slug: string,
   brand: string = "combined",
-  dateRange?: SummaryDateRange
+  dateRange?: SummaryDateRange,
+  dateField: DateField = "created"
 ): Promise<ItinerarySummary | null> {
-  const itineraries = await getItineraries(brand, dateRange);
+  const itineraries = await getItineraries(brand, dateRange, dateField);
   return itineraries.find((it) => it.slug === slug) ?? null;
 }
 
@@ -326,16 +331,18 @@ export async function getItineraryQuotes(
   childItineraries: string[],
   _ship: string,
   brand: string = "combined",
-  dateRange?: SummaryDateRange
+  dateRange?: SummaryDateRange,
+  dateField: DateField = "created"
 ): Promise<{ positive: Quote[]; negative: Quote[] }> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
+  const path = dateFieldPath(dateField);
   // Use childItineraries to match all variant tour names; Firestore "in" supports up to 30
   const tourNames = childItineraries.length > 0 ? childItineraries.slice(0, 30) : [itineraryName];
   const reviewLimit = dateRange && !usesAllTimeSummaries(dateRange) ? 100 : 20;
   const baseConstraints = [
     where("tags.tour", "in", tourNames),
-    orderBy("dates.created", "desc"),
+    orderBy(path, "desc"),
     limit(reviewLimit),
   ];
   if (brand !== "combined") {
@@ -351,11 +358,13 @@ export async function getItineraryQuotes(
 
   for (const d of snap.docs) {
     const data = d.data();
-    const created = data.dates?.created;
+    const dates = data.dates as { created?: unknown; lastUpdated?: unknown } | undefined;
+    const rawValue = dateField === "lastUpdated" ? dates?.lastUpdated : dates?.created;
+    const value = typeof rawValue === "string" ? rawValue : "";
     if (
       startIso &&
       endIso &&
-      (typeof created !== "string" || created < startIso || created > endIso)
+      (!value || value < startIso || value > endIso)
     ) {
       continue;
     }
@@ -371,7 +380,7 @@ export async function getItineraryQuotes(
       ship: data.tags?.ship || "",
       itinerary: data.tags?.tour || data.product?.title || itineraryName,
       text,
-      date: data.dates?.created || "",
+      date: value,
     };
 
     if (rating >= 4 && positive.length < 5) {

--- a/app/src/lib/firestore/queries.ts
+++ b/app/src/lib/firestore/queries.ts
@@ -267,10 +267,36 @@ export async function getTrendSeries(
     rangeDays <= 45 ? "day" : rangeDays <= 366 ? "week" : "month";
 
   if (granularity === "month") {
-    const monthly = await getMonthlySummaries(brand);
+    // The pre-aggregated monthly_summaries collection is keyed off `dates.created`,
+    // so it can only serve the created-date trend. For lastUpdated we live-query
+    // the reviews collection and bucket by month off the chosen field — that keeps
+    // the trend chart consistent with the KPI counts on the same page.
+    if (dateField === "created") {
+      const monthly = await getMonthlySummaries(brand);
+      return {
+        granularity,
+        points: buildMonthlyTrendPoints(monthly, startDate, endDate),
+      };
+    }
+
+    const dbForMonth = getClientDb();
+    const refForMonth = collection(dbForMonth, "reviews");
+    const monthConstraints = buildDateRangeConstraints(
+      brand,
+      startDate.toISOString(),
+      endDate.toISOString(),
+      "<=",
+      dateField
+    );
+    const monthSnap = await getDocs(query(refForMonth, ...monthConstraints));
     return {
       granularity,
-      points: buildMonthlyTrendPoints(monthly, startDate, endDate),
+      points: buildMonthlyTrendPointsFromDocs(
+        monthSnap.docs.map((docSnap) => docSnap.data()),
+        startDate,
+        endDate,
+        dateField
+      ),
     };
   }
 
@@ -357,7 +383,7 @@ export async function getFleetSummaryByDateRange(
     where(path, "<=", endDate.toISOString()),
   ];
   if (brand !== "combined") {
-    constraints.push(where("brand", "==", brand));
+    constraints.unshift(where("brand", "==", brand));
   }
   constraints.push(orderBy(path, "desc"));
   const q = query(ref, ...constraints);
@@ -860,6 +886,58 @@ function buildAdaptiveTrendPoints(
     });
 
     bucketKey = nextBucketKey;
+  }
+
+  return points;
+}
+
+function buildMonthlyTrendPointsFromDocs(
+  docs: DocumentData[],
+  startDate: Date,
+  endDate: Date,
+  dateField: DateField
+): TrendPoint[] {
+  const bucketStats = new Map<string, { ratingSum: number; ratingCount: number; reviewCount: number }>();
+
+  for (const data of docs) {
+    const value = readDateFieldValue(data, dateField);
+    if (!value) continue;
+
+    const bucketKey = toUtcMonthKey(value);
+    const current = bucketStats.get(bucketKey) ?? { ratingSum: 0, ratingCount: 0, reviewCount: 0 };
+    const rating = data.ratings?.product ?? data.ratings?.service ?? null;
+
+    current.reviewCount += 1;
+    if (typeof rating === "number" && Number.isFinite(rating)) {
+      current.ratingSum += rating;
+      current.ratingCount += 1;
+    }
+    bucketStats.set(bucketKey, current);
+  }
+
+  const points: TrendPoint[] = [];
+  let monthKey = toUtcMonthKey(startDate);
+  const endMonthKey = toUtcMonthKey(endDate);
+
+  while (monthKey <= endMonthKey) {
+    const stats = bucketStats.get(monthKey) ?? { ratingSum: 0, ratingCount: 0, reviewCount: 0 };
+    const nextMonthKey = addUtcMonths(monthKey, 1);
+    const labels = formatPeriodLabel("month", monthKey, nextMonthKey);
+
+    points.push({
+      key: monthKey,
+      label: labels.label,
+      fullLabel: labels.fullLabel,
+      averageRating:
+        stats.ratingCount > 0
+          ? Math.round((stats.ratingSum / stats.ratingCount) * 100) / 100
+          : null,
+      reviewCount: stats.reviewCount,
+      periodStart: `${monthKey}-01T00:00:00.000Z`,
+      periodEnd: `${nextMonthKey}-01T00:00:00.000Z`,
+    });
+
+    monthKey = nextMonthKey;
   }
 
   return points;

--- a/app/src/lib/firestore/queries.ts
+++ b/app/src/lib/firestore/queries.ts
@@ -2,6 +2,7 @@
 
 import { format } from "date-fns";
 import { getClientDb } from "@/lib/firebase";
+import type { DateField } from "@/contexts/DashboardContext";
 import {
   collection,
   doc,
@@ -81,6 +82,10 @@ const PANEL_REVIEW_LIMIT = 100;
 const PANEL_REVIEW_BATCH_SIZE = 200;
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
+
+export function dateFieldPath(field: DateField): "dates.created" | "dates.lastUpdated" {
+  return field === "lastUpdated" ? "dates.lastUpdated" : "dates.created";
+}
 
 function slugify(text: string): string {
   return text
@@ -254,7 +259,8 @@ export async function getMonthlySummaries(brand: string): Promise<MonthlySummary
 export async function getTrendSeries(
   brand: string,
   startDate: Date,
-  endDate: Date
+  endDate: Date,
+  dateField: DateField
 ): Promise<{ granularity: TrendGranularity; points: TrendPoint[] }> {
   const rangeDays = getRangeLengthInDays(startDate, endDate);
   const granularity: TrendGranularity =
@@ -271,13 +277,13 @@ export async function getTrendSeries(
   const db = getClientDb();
   const ref = collection(db, "reviews");
   const constraints = [
-    ...buildDateRangeConstraints(brand, startDate.toISOString(), endDate.toISOString()),
+    ...buildDateRangeConstraints(brand, startDate.toISOString(), endDate.toISOString(), "<=", dateField),
   ];
   const snap = await getDocs(query(ref, ...constraints));
 
   return {
     granularity,
-    points: buildAdaptiveTrendPoints(snap.docs.map((docSnap) => docSnap.data()), startDate, endDate, granularity),
+    points: buildAdaptiveTrendPoints(snap.docs.map((docSnap) => docSnap.data()), startDate, endDate, granularity, dateField),
   };
 }
 
@@ -340,18 +346,20 @@ export async function getEntitySummaries(
 export async function getFleetSummaryByDateRange(
   brand: string,
   startDate: Date,
-  endDate: Date
+  endDate: Date,
+  dateField: DateField
 ): Promise<FleetSummary> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
+  const path = dateFieldPath(dateField);
   const constraints: QueryConstraint[] = [
-    where("dates.created", ">=", startDate.toISOString()),
-    where("dates.created", "<=", endDate.toISOString()),
+    where(path, ">=", startDate.toISOString()),
+    where(path, "<=", endDate.toISOString()),
   ];
   if (brand !== "combined") {
     constraints.push(where("brand", "==", brand));
   }
-  constraints.push(orderBy("dates.created", "desc"));
+  constraints.push(orderBy(path, "desc"));
   const q = query(ref, ...constraints);
   const snap = await getDocs(q);
 
@@ -441,14 +449,16 @@ export async function getEntitySummariesByDateRange(
   brand: string,
   startDate: Date,
   endDate: Date,
+  dateField: DateField,
   scope: "ship" | "itinerary" = "itinerary"
 ): Promise<EntitySummary[]> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
+  const path = dateFieldPath(dateField);
   const constraints: QueryConstraint[] = [
-    where("dates.created", ">=", startDate.toISOString()),
-    where("dates.created", "<=", endDate.toISOString()),
-    orderBy("dates.created", "desc"),
+    where(path, ">=", startDate.toISOString()),
+    where(path, "<=", endDate.toISOString()),
+    orderBy(path, "desc"),
   ];
   if (brand !== "combined") {
     constraints.unshift(where("brand", "==", brand));
@@ -517,14 +527,16 @@ export interface FilterOptions {
 export async function getFilterOptions(
   brand: string,
   startDate: string,
-  endDate: string
+  endDate: string,
+  dateField: DateField
 ): Promise<FilterOptions> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
+  const path = dateFieldPath(dateField);
   const constraints: QueryConstraint[] = [
-    where("dates.created", ">=", startDate),
-    where("dates.created", "<=", endDate),
-    orderBy("dates.created", "desc"),
+    where(path, ">=", startDate),
+    where(path, "<=", endDate),
+    orderBy(path, "desc"),
   ];
   if (brand !== "combined") {
     constraints.unshift(where("brand", "==", brand));
@@ -578,15 +590,17 @@ export async function getReviewsByTheme(
   brand: string,
   theme: string,
   type: "positive" | "negative",
+  dateField: DateField,
   startDate?: Date,
   endDate?: Date
 ): Promise<ThemeReview[]> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
+  const path = dateFieldPath(dateField);
   const fetchLimit = startDate && endDate ? 100 : 20;
   const constraints = [
     where(`themes.${type}`, "array-contains", theme),
-    orderBy("dates.created", "desc"),
+    orderBy(path, "desc"),
     limit(fetchLimit),
   ];
   if (brand !== "combined") {
@@ -600,17 +614,17 @@ export async function getReviewsByTheme(
   const filteredDocs =
     startDate && endDate
       ? snap.docs.filter((docSnap) => {
-          const created = docSnap.data().dates?.created;
+          const value = readDateFieldValue(docSnap.data(), dateField);
           return (
-            typeof created === "string" &&
-            created >= startDate.toISOString() &&
-            created <= endDate.toISOString()
+            typeof value === "string" &&
+            value >= startDate.toISOString() &&
+            value <= endDate.toISOString()
           );
         })
       : snap.docs;
 
   return filteredDocs.slice(0, 20).map((docSnap) =>
-    mapReviewDoc({ id: docSnap.id, data: docSnap.data() })
+    mapReviewDoc({ id: docSnap.id, data: docSnap.data() }, dateField)
   );
 }
 
@@ -618,25 +632,36 @@ export async function getReviewsForOverviewSelection(
   brand: string,
   startDate: Date,
   endDate: Date,
-  filter: OverviewSelectionFilter
+  filter: OverviewSelectionFilter,
+  dateField: DateField
 ): Promise<ThemeReview[]> {
   if (filter.kind === "theme") {
-    return getThemeSelectionReviews(brand, startDate, endDate, filter);
+    return getThemeSelectionReviews(brand, startDate, endDate, filter, dateField);
   }
 
   if (filter.kind === "period") {
-    return getPeriodSelectionReviews(brand, filter.start, filter.end);
+    return getPeriodSelectionReviews(brand, filter.start, filter.end, dateField);
   }
 
   if (filter.kind === "month") {
-    return getMonthSelectionReviews(brand, filter.month);
+    return getMonthSelectionReviews(brand, filter.month, dateField);
   }
 
-  return getRatingSelectionReviews(brand, startDate, endDate, filter.star);
+  return getRatingSelectionReviews(brand, startDate, endDate, filter.star, dateField);
+}
+
+function readDateFieldValue(data: DocumentData, dateField: DateField): string {
+  const dates = data.dates as { created?: unknown; lastUpdated?: unknown } | undefined;
+  const primary = dateField === "lastUpdated" ? dates?.lastUpdated : dates?.created;
+  if (typeof primary === "string") return primary;
+  // Fallback so older reviews missing one field still render a date label.
+  const fallback = dateField === "lastUpdated" ? dates?.created : dates?.lastUpdated;
+  return typeof fallback === "string" ? fallback : "";
 }
 
 function mapReviewDoc(
-  review: { id: string; data: DocumentData }
+  review: { id: string; data: DocumentData },
+  dateField: DateField
 ): ThemeReview {
   const data = review.data;
   return {
@@ -646,12 +671,16 @@ function mapReviewDoc(
     itinerary: data.tags?.tour || data.product?.title || "",
     ship: data.tags?.ship || "",
     text: data.reviews?.productText || data.reviews?.serviceText || "",
-    date: data.dates?.created || "",
+    date: readDateFieldValue(data, dateField),
     media: Array.isArray(data.media) ? data.media : [],
   };
 }
 
-function matchesOverviewSelection(data: DocumentData, filter: OverviewSelectionFilter): boolean {
+function matchesOverviewSelection(
+  data: DocumentData,
+  filter: OverviewSelectionFilter,
+  dateField: DateField
+): boolean {
   if (filter.kind === "theme") {
     const values = data.themes?.[filter.sentiment] || [];
     return Array.isArray(values) && values.includes(filter.theme);
@@ -662,11 +691,11 @@ function matchesOverviewSelection(data: DocumentData, filter: OverviewSelectionF
     return rating !== null && Math.round(rating) === filter.star;
   }
 
-  const created = typeof data.dates?.created === "string" ? data.dates.created : "";
+  const value = readDateFieldValue(data, dateField);
   if (filter.kind === "period") {
-    return created >= filter.start && created < filter.end;
+    return value >= filter.start && value < filter.end;
   }
-  return created.startsWith(filter.month);
+  return value.startsWith(filter.month);
 }
 
 function getMonthBounds(month: string): { start: string; end: string } {
@@ -777,7 +806,8 @@ function buildAdaptiveTrendPoints(
   docs: DocumentData[],
   startDate: Date,
   endDate: Date,
-  granularity: Extract<TrendGranularity, "day" | "week">
+  granularity: Extract<TrendGranularity, "day" | "week">,
+  dateField: DateField
 ): TrendPoint[] {
   const bucketStats = new Map<string, { ratingSum: number; ratingCount: number; reviewCount: number }>();
   const rangeStartKey = granularity === "day" ? toUtcDayKey(startDate) : getUtcWeekStartKey(startDate);
@@ -786,10 +816,10 @@ function buildAdaptiveTrendPoints(
   const selectedEndExclusiveIso = `${addUtcDays(toUtcDayKey(endDate), 1)}T00:00:00.000Z`;
 
   for (const data of docs) {
-    const created = typeof data.dates?.created === "string" ? data.dates.created : null;
-    if (!created) continue;
+    const value = readDateFieldValue(data, dateField);
+    if (!value) continue;
 
-    const bucketKey = granularity === "day" ? toUtcDayKey(created) : getUtcWeekStartKey(created);
+    const bucketKey = granularity === "day" ? toUtcDayKey(value) : getUtcWeekStartKey(value);
     const current = bucketStats.get(bucketKey) ?? { ratingSum: 0, ratingCount: 0, reviewCount: 0 };
     const rating = data.ratings?.product ?? data.ratings?.service ?? null;
 
@@ -870,18 +900,20 @@ function buildDateRangeConstraints(
   brand: string,
   start: string,
   end: string,
-  endOperator: "<" | "<=" = "<="
+  endOperator: "<" | "<=" = "<=",
+  dateField: DateField = "created"
 ): QueryConstraint[] {
+  const path = dateFieldPath(dateField);
   const constraints: QueryConstraint[] = [
-    where("dates.created", ">=", start),
-    where("dates.created", endOperator, end),
+    where(path, ">=", start),
+    where(path, endOperator, end),
   ];
 
   if (brand !== "combined") {
     constraints.push(where("brand", "==", brand));
   }
 
-  constraints.push(orderBy("dates.created", "desc"));
+  constraints.push(orderBy(path, "desc"));
   return constraints;
 }
 
@@ -889,12 +921,13 @@ async function getThemeSelectionReviews(
   brand: string,
   startDate: Date,
   endDate: Date,
-  filter: Extract<OverviewSelectionFilter, { kind: "theme" }>
+  filter: Extract<OverviewSelectionFilter, { kind: "theme" }>,
+  dateField: DateField
 ): Promise<ThemeReview[]> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
   const constraints = [
-    ...buildDateRangeConstraints(brand, startDate.toISOString(), endDate.toISOString()),
+    ...buildDateRangeConstraints(brand, startDate.toISOString(), endDate.toISOString(), "<=", dateField),
     where(`themes.${filter.sentiment}`, "array-contains", filter.theme),
     limit(PANEL_REVIEW_LIMIT),
   ];
@@ -902,33 +935,38 @@ async function getThemeSelectionReviews(
   try {
     const snap = await getDocs(query(ref, ...constraints));
     return snap.docs.map((docSnap) =>
-      mapReviewDoc({ id: docSnap.id, data: docSnap.data() })
+      mapReviewDoc({ id: docSnap.id, data: docSnap.data() }, dateField)
     );
   } catch (error) {
     console.warn("Falling back to paged theme filtering for overview selection", error);
-    return getFilteredPagedReviews(brand, startDate, endDate, filter);
+    return getFilteredPagedReviews(brand, startDate, endDate, filter, dateField);
   }
 }
 
-async function getMonthSelectionReviews(brand: string, month: string): Promise<ThemeReview[]> {
+async function getMonthSelectionReviews(
+  brand: string,
+  month: string,
+  dateField: DateField
+): Promise<ThemeReview[]> {
   const bounds = getMonthBounds(month);
-  return getPeriodSelectionReviews(brand, bounds.start, bounds.end);
+  return getPeriodSelectionReviews(brand, bounds.start, bounds.end, dateField);
 }
 
 async function getPeriodSelectionReviews(
   brand: string,
   periodStart: string,
-  periodEnd: string
+  periodEnd: string,
+  dateField: DateField
 ): Promise<ThemeReview[]> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
   const constraints = [
-    ...buildDateRangeConstraints(brand, periodStart, periodEnd, "<"),
+    ...buildDateRangeConstraints(brand, periodStart, periodEnd, "<", dateField),
     limit(PANEL_REVIEW_LIMIT),
   ];
   const snap = await getDocs(query(ref, ...constraints));
   return snap.docs.map((docSnap) =>
-    mapReviewDoc({ id: docSnap.id, data: docSnap.data() })
+    mapReviewDoc({ id: docSnap.id, data: docSnap.data() }, dateField)
   );
 }
 
@@ -936,26 +974,33 @@ async function getRatingSelectionReviews(
   brand: string,
   startDate: Date,
   endDate: Date,
-  star: number
+  star: number,
+  dateField: DateField
 ): Promise<ThemeReview[]> {
-  return getFilteredPagedReviews(brand, startDate, endDate, {
-    kind: "rating",
-    star,
-  });
+  return getFilteredPagedReviews(
+    brand,
+    startDate,
+    endDate,
+    { kind: "rating", star },
+    dateField
+  );
 }
 
 async function getFilteredPagedReviews(
   brand: string,
   startDate: Date,
   endDate: Date,
-  filter: OverviewSelectionFilter
+  filter: OverviewSelectionFilter,
+  dateField: DateField
 ): Promise<ThemeReview[]> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
   const constraints = buildDateRangeConstraints(
     brand,
     startDate.toISOString(),
-    endDate.toISOString()
+    endDate.toISOString(),
+    "<=",
+    dateField
   );
   const reviews: ThemeReview[] = [];
   let lastDoc: QueryDocumentSnapshot<DocumentData> | null = null;
@@ -973,8 +1018,8 @@ async function getFilteredPagedReviews(
 
     for (const docSnap of snap.docs) {
       const data = docSnap.data();
-      if (matchesOverviewSelection(data, filter)) {
-        reviews.push(mapReviewDoc({ id: docSnap.id, data }));
+      if (matchesOverviewSelection(data, filter, dateField)) {
+        reviews.push(mapReviewDoc({ id: docSnap.id, data }, dateField));
         if (reviews.length >= PANEL_REVIEW_LIMIT) {
           break;
         }

--- a/app/src/lib/firestore/ship-queries.ts
+++ b/app/src/lib/firestore/ship-queries.ts
@@ -1,8 +1,8 @@
 "use client";
 
 import { getClientDb } from "@/lib/firebase";
-import type { DateRange } from "@/contexts/DashboardContext";
-import { getFleetSummaryByDateRange } from "@/lib/firestore/queries";
+import type { DateField, DateRange } from "@/contexts/DashboardContext";
+import { dateFieldPath, getFleetSummaryByDateRange } from "@/lib/firestore/queries";
 import {
   collection,
   query,
@@ -64,12 +64,14 @@ function getReviewRating(data: Record<string, unknown>): number {
 function buildDateRangeConstraints(
   brand: string,
   startDate: Date,
-  endDate: Date
+  endDate: Date,
+  dateField: DateField
 ) {
+  const path = dateFieldPath(dateField);
   const constraints = [
-    where("dates.created", ">=", startDate.toISOString()),
-    where("dates.created", "<=", endDate.toISOString()),
-    orderBy("dates.created", "desc"),
+    where(path, ">=", startDate.toISOString()),
+    where(path, "<=", endDate.toISOString()),
+    orderBy(path, "desc"),
   ];
 
   if (brand !== "combined") {
@@ -98,14 +100,15 @@ async function getParentNameLookup(brand: string): Promise<Map<string, string>> 
 
 async function getShipsByDateRange(
   brand: string,
-  dateRange: SummaryDateRange
+  dateRange: SummaryDateRange,
+  dateField: DateField
 ): Promise<ShipSummary[]> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
   const [snap, parentLookup, fleet] = await Promise.all([
-    getDocs(query(ref, ...buildDateRangeConstraints(brand, dateRange.start, dateRange.end))),
+    getDocs(query(ref, ...buildDateRangeConstraints(brand, dateRange.start, dateRange.end, dateField))),
     getParentNameLookup(brand),
-    getFleetSummaryByDateRange(brand, dateRange.start, dateRange.end),
+    getFleetSummaryByDateRange(brand, dateRange.start, dateRange.end, dateField),
   ]);
 
   if (snap.empty) return [];
@@ -324,10 +327,11 @@ async function getFleetAverages(brand: string): Promise<{ avgRating: number; avg
 
 export async function getShips(
   brand: string = "combined",
-  dateRange?: SummaryDateRange
+  dateRange?: SummaryDateRange,
+  dateField: DateField = "created"
 ): Promise<ShipSummary[]> {
   if (dateRange && !usesAllTimeSummaries(dateRange)) {
-    return getShipsByDateRange(brand, dateRange);
+    return getShipsByDateRange(brand, dateRange, dateField);
   }
 
   const db = getClientDb();
@@ -352,23 +356,26 @@ export async function getShips(
 export async function getShipBySlug(
   slug: string,
   brand: string = "combined",
-  dateRange?: SummaryDateRange
+  dateRange?: SummaryDateRange,
+  dateField: DateField = "created"
 ): Promise<ShipSummary | null> {
-  const ships = await getShips(brand, dateRange);
+  const ships = await getShips(brand, dateRange, dateField);
   return ships.find((s) => s.slug === slug) ?? null;
 }
 
 export async function getShipQuotes(
   shipName: string,
   brand: string = "combined",
-  dateRange?: SummaryDateRange
+  dateRange?: SummaryDateRange,
+  dateField: DateField = "created"
 ): Promise<{ positive: Quote[]; negative: Quote[] }> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
+  const path = dateFieldPath(dateField);
   const reviewLimit = dateRange && !usesAllTimeSummaries(dateRange) ? 100 : 20;
   const baseConstraints = [
     where("tags.ship", "==", shipName),
-    orderBy("dates.created", "desc"),
+    orderBy(path, "desc"),
   ];
   if (brand !== "combined") {
     baseConstraints.unshift(where("brand", "==", brand));
@@ -386,11 +393,13 @@ export async function getShipQuotes(
 
   for (const d of snap.docs) {
     const data = d.data();
-    const created = data.dates?.created;
+    const dates = data.dates as { created?: unknown; lastUpdated?: unknown } | undefined;
+    const rawValue = dateField === "lastUpdated" ? dates?.lastUpdated : dates?.created;
+    const value = typeof rawValue === "string" ? rawValue : "";
     if (
       startIso &&
       endIso &&
-      (typeof created !== "string" || created < startIso || created > endIso)
+      (!value || value < startIso || value > endIso)
     ) {
       continue;
     }
@@ -406,7 +415,7 @@ export async function getShipQuotes(
       ship: data.tags?.ship || shipName,
       itinerary: data.tags?.tour || data.product?.title || "",
       text,
-      date: data.dates?.created || "",
+      date: value,
     };
 
     if (rating >= 4 && positive.length < 5) {

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -13,6 +13,14 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "brand", "order": "ASCENDING" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "brand", "order": "ASCENDING" },
         { "fieldPath": "themes.positive", "arrayConfig": "CONTAINS" }
       ]
     },
@@ -31,6 +39,15 @@
         { "fieldPath": "brand", "order": "ASCENDING" },
         { "fieldPath": "ratings.product", "order": "ASCENDING" },
         { "fieldPath": "dates.created", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "brand", "order": "ASCENDING" },
+        { "fieldPath": "ratings.product", "order": "ASCENDING" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
       ]
     },
     {
@@ -61,6 +78,14 @@
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
+        { "fieldPath": "tags.tour", "order": "ASCENDING" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
         { "fieldPath": "brand", "order": "ASCENDING" },
         { "fieldPath": "tags.tour", "order": "ASCENDING" },
         { "fieldPath": "dates.created", "order": "DESCENDING" }
@@ -70,6 +95,32 @@
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
+        { "fieldPath": "brand", "order": "ASCENDING" },
+        { "fieldPath": "tags.tour", "order": "ASCENDING" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ship", "order": "ASCENDING" },
+        { "fieldPath": "dates.created", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "ship", "order": "ASCENDING" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "brand", "order": "ASCENDING" },
         { "fieldPath": "ship", "order": "ASCENDING" },
         { "fieldPath": "dates.created", "order": "DESCENDING" }
       ]
@@ -80,7 +131,7 @@
       "fields": [
         { "fieldPath": "brand", "order": "ASCENDING" },
         { "fieldPath": "ship", "order": "ASCENDING" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
       ]
     },
     {
@@ -97,8 +148,26 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "brand", "order": "ASCENDING" },
+        { "fieldPath": "tags.ship", "order": "ASCENDING" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "brand", "order": "ASCENDING" },
         { "fieldPath": "tags.region", "order": "ASCENDING" },
         { "fieldPath": "dates.created", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "brand", "order": "ASCENDING" },
+        { "fieldPath": "tags.region", "order": "ASCENDING" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
       ]
     },
     {
@@ -115,8 +184,26 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "brand", "order": "ASCENDING" },
+        { "fieldPath": "tags.bookingType", "order": "ASCENDING" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "brand", "order": "ASCENDING" },
         { "fieldPath": "tags.loyalty", "order": "ASCENDING" },
         { "fieldPath": "dates.created", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "brand", "order": "ASCENDING" },
+        { "fieldPath": "tags.loyalty", "order": "ASCENDING" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
       ]
     },
     {
@@ -133,8 +220,26 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "brand", "order": "ASCENDING" },
+        { "fieldPath": "themes.positive", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "brand", "order": "ASCENDING" },
         { "fieldPath": "themes.negative", "arrayConfig": "CONTAINS" },
         { "fieldPath": "dates.created", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "brand", "order": "ASCENDING" },
+        { "fieldPath": "themes.negative", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
       ]
     }
   ],


### PR DESCRIPTION
## Summary

- Adds a global **Review Updated Date / Review Created Date** selector in the header that drives every date-filtered query (Overview, Reviews, Admin, Itineraries, Ships). Persisted in localStorage; default is **Review Created Date**.
- Restructures the header so BrandSwitcher sits next to the title, freeing space for the new selector next to the date range picker.
- Replaces the Reviews Explorer Sort dropdown with a **Newest / Oldest** segmented toggle to match Feefo's UI. Drops the rarely used highest/lowest rating sorts (Star Rating sidebar filter covers that).
- Duplicates the 14 Firestore composite indexes for `dates.lastUpdated` alongside the existing `dates.created` ones.
- Updates `.github/workflows/firebase-deploy.yml` to include `firestore:indexes` so new indexes deploy automatically with `main`.

## Why

Comparing Luxury Gold reviews for Apr 21–28 between Feefo's hub UI (14 results) and our app (9 results) revealed that Feefo's hub defaults to "Review Updated Date" while our app filtered by `dates.created`. Switching the date-type used by our queries fully reconciles the counts, and exposing it as a user-controllable filter matches the affordance Feefo provides.

## Test plan

- [ ] Pull the branch, verify build passes (`npm --prefix app run build`)
- [ ] Open the app, confirm the new "Review Created Date" dropdown appears next to the date picker and BrandSwitcher sits next to "Feefo Reviews"
- [ ] On Reviews Explorer, set Luxury Gold + Apr 21 – Apr 28, 2026 + **Review Created Date** → expect ~8 reviews (matches Feefo with same filter)
- [ ] Switch the dropdown to **Review Updated Date** → expect ~14 reviews (matches Feefo's default)
- [ ] Refresh the page; selection persists
- [ ] Verify Overview KPIs, Itineraries list, Ships list, and Admin "Tour Mappings" all respect the dropdown
- [ ] Verify the Newest/Oldest toggle on Reviews Explorer flips order correctly
- [ ] After merge, confirm the `Deploy Firebase` workflow runs `firebase deploy --only functions,hosting,firestore:indexes` and that new indexes show up in the Firebase Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)