### PR TITLE
Move merchant switcher next to title in header

### DIFF
--- a/app/src/components/layout/Header.tsx
+++ b/app/src/components/layout/Header.tsx
@@ -4,10 +4,10 @@
  * Header — two-row sticky application bar.
  *
  * Row 1 — Brand + Auth (always visible on desktop, title-only on mobile):
- *   [App title] ················ [ThemeToggle | AuthButton]
+ *   [App title | MerchantSwitcher] ················ [ThemeToggle | AuthButton]
  *
  * Row 2 — Nav + Data controls (desktop/large-tablet only):
- *   [NavTabs — scrollable] ····· [MerchantSwitcher | DatePicker | Refresh]
+ *   [NavTabs — scrollable] ····· [DatePicker | DateFieldSelector | Refresh]
  *
  * Mobile / small-tablet (< lg / 1024px):
  *   [App title] ················ [Hamburger → MobileDrawer]
@@ -51,6 +51,12 @@ export default function Header() {
           <span className="shrink-0 text-base font-bold tracking-wide sm:text-lg">
             {brand.appTitle}
           </span>
+
+          {/* Merchant switcher — sits next to the title on desktop so it stops
+              competing with the date controls for the right edge. */}
+          <div className="hidden lg:block">
+            <MerchantSwitcher tone="inverse" />
+          </div>
 
           {/* Spacer */}
           <div className="flex-1" />
@@ -105,7 +111,6 @@ export default function Header() {
             className="shrink-0 flex items-center gap-2 pl-4"
             style={{ borderLeft: "1px solid rgba(255,255,255,0.12)" }}
           >
-            <MerchantSwitcher tone="inverse" />
             <DateRangePicker tone="inverse" />
             <DateFieldSelector tone="inverse" />
             {showAuthControls && (


### PR DESCRIPTION
## Summary

Follow-up to [#39](https://github.com/Uniworld-River-Cruises/reviews-dashboard/pull/39). The merchant switcher (All / Uniworld / Luxury Gold) was sharing Row 2 with the date controls, leaving the right edge crowded. This moves it next to the **Feefo Reviews** title — which had spare horizontal room — giving DatePicker, DateFieldSelector, and Refresh more breathing room.

**Before:**
```
Row 1: [Feefo Reviews] ········· [Theme | Auth]
Row 2: [Nav tabs] ········· [Merchant | DatePicker | DateField | Refresh]
```

**After:**
```
Row 1: [Feefo Reviews | Merchant] ········· [Theme | Auth]
Row 2: [Nav tabs] ········· [DatePicker | DateField | Refresh]
```

Mobile drawer is unchanged — `MerchantSwitcher` already has its own labeled "View" section there.

## Test plan

- [ ] At ≥ lg viewport, confirm `All / Uniworld / Luxury Gold` chips appear immediately right of the "Feefo Reviews" title
- [ ] Date picker, Date field selector, Refresh, Theme, and Auth all still render correctly on the right
- [ ] Below `lg` (mobile/tablet), the hamburger drawer still shows the merchant switcher in its "View" section
- [ ] Switching merchants still updates KPIs and review lists across pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)