### PR TITLE
Add read-only audit for duplicate review documents

### DIFF
--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -15,6 +15,7 @@ import {
   listKnownUsers,
   listOperationalLogs,
   removeAdminUser,
+  runDuplicateReviewAudit,
   getItineraryMappings,
   upsertAdminUser,
   saveManualMapping,
@@ -23,6 +24,7 @@ import {
   type AdminRole,
   type CurrentAdminAccess,
   type AdminUserAccess,
+  type DuplicateAuditReport,
   type ItineraryMapping,
   type KnownUser,
   type OperationLogEntry,
@@ -117,6 +119,10 @@ export default function AdminPage() {
   const [renameValue, setRenameValue] = useState("");
   const [saving, setSaving] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
+  const [duplicateReport, setDuplicateReport] = useState<DuplicateAuditReport | null>(null);
+  const [duplicateLoading, setDuplicateLoading] = useState(false);
+  const [duplicateBrand, setDuplicateBrand] = useState<"" | "uniworld" | "luxury-gold">("");
+  const [duplicatesExpanded, setDuplicatesExpanded] = useState(false);
 
   const dateStart = dateRange.start.toISOString();
   const dateEnd = dateRange.end.toISOString();
@@ -156,6 +162,18 @@ export default function AdminPage() {
     }
     setLogsLoading(false);
   }, [logsRangeHours]);
+
+  const runDuplicateAudit = useCallback(async () => {
+    setDuplicateLoading(true);
+    setDuplicatesExpanded(true);
+    try {
+      const report = await runDuplicateReviewAudit(duplicateBrand || null);
+      setDuplicateReport(report);
+    } catch (err) {
+      setToast(err instanceof Error ? err.message : "Failed to run duplicate audit");
+    }
+    setDuplicateLoading(false);
+  }, [duplicateBrand]);
 
   const loadMappings = useCallback(async () => {
     setLoading(true);
@@ -803,6 +821,135 @@ export default function AdminPage() {
                 loading={logsLoading}
                 emptyMessage={`No operational logs were recorded in the ${getLogsRangeLabel(logsRangeHours).toLowerCase()}.`}
               />
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+
+      {canViewLogs ? (
+        <div className="mb-8 rounded-lg border border-border bg-surface shadow-sm">
+          <div className="px-6 py-4 border-b border-border">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-text-primary">Duplicate Review Audit</h2>
+                <p className="mt-1 text-sm text-text-secondary">
+                  Read-only check that groups review documents by their stable Feefo URL and lists any URL with more than one document. Useful for finding duplicates created when a review&apos;s service/product IDs shift over its lifecycle.
+                </p>
+              </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <select
+                  value={duplicateBrand}
+                  onChange={(event) =>
+                    setDuplicateBrand(event.target.value as "" | "uniworld" | "luxury-gold")
+                  }
+                  className="rounded-lg border border-input-border bg-surface px-3 py-2 text-sm text-text-primary"
+                >
+                  <option value="">All brands</option>
+                  <option value="uniworld">Uniworld</option>
+                  <option value="luxury-gold">Luxury Gold</option>
+                </select>
+                <button
+                  type="button"
+                  onClick={runDuplicateAudit}
+                  disabled={duplicateLoading}
+                  className="inline-flex items-center rounded-lg bg-brand-accent px-4 py-2 text-sm font-medium text-brand-accent-foreground shadow-sm hover:opacity-90 disabled:opacity-50"
+                >
+                  {duplicateLoading ? "Running…" : "Run audit"}
+                </button>
+                {duplicateReport ? (
+                  <button
+                    type="button"
+                    onClick={() => setDuplicatesExpanded((value) => !value)}
+                    aria-expanded={duplicatesExpanded}
+                    className={`inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-input-border bg-surface text-text-secondary shadow-sm transition-transform hover:bg-surface-hover ${
+                      duplicatesExpanded ? "rotate-180" : ""
+                    }`}
+                  >
+                    <svg className="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                      <path
+                        fillRule="evenodd"
+                        d="M5.23 7.21a.75.75 0 011.06.02L10 11.17l3.71-3.94a.75.75 0 011.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          </div>
+          {duplicateReport && duplicatesExpanded ? (
+            <div className="px-6 py-5">
+              <div className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+                <div className="rounded-lg border border-border bg-surface p-3">
+                  <div className="text-2xl font-bold text-text-primary">{duplicateReport.scannedDocs}</div>
+                  <div className="text-xs text-text-secondary">Scanned docs</div>
+                </div>
+                <div className="rounded-lg border border-border bg-surface p-3">
+                  <div className="text-2xl font-bold text-text-primary">{duplicateReport.duplicateGroups}</div>
+                  <div className="text-xs text-text-secondary">Duplicate groups</div>
+                </div>
+                <div className="rounded-lg border border-border bg-surface p-3">
+                  <div className="text-2xl font-bold text-text-primary">{duplicateReport.extraDocs}</div>
+                  <div className="text-xs text-text-secondary">Extra docs</div>
+                </div>
+                <div className="rounded-lg border border-border bg-surface p-3">
+                  <div className="text-sm font-medium text-text-primary">
+                    {duplicateReport.scannedBrand ?? "All brands"}
+                  </div>
+                  <div className="text-xs text-text-secondary">Scope</div>
+                </div>
+              </div>
+              {duplicateReport.groups.length === 0 ? (
+                <p className="text-sm text-text-secondary">
+                  No duplicates found. Every review document has a unique Feefo URL.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {duplicateReport.groups.map((group) => (
+                    <details
+                      key={group.feedbackUrl}
+                      className="rounded-lg border border-border bg-surface-alt"
+                    >
+                      <summary className="cursor-pointer px-4 py-3 text-sm">
+                        <span className="font-medium text-text-primary">
+                          {group.members.length} docs
+                        </span>
+                        <span className="ml-2 text-text-secondary break-all">
+                          {group.feedbackUrl}
+                        </span>
+                      </summary>
+                      <div className="px-4 pb-3">
+                        <table className="w-full text-xs">
+                          <thead>
+                            <tr className="text-left text-text-tertiary">
+                              <th className="py-1 pr-3">Doc ID</th>
+                              <th className="py-1 pr-3">Brand</th>
+                              <th className="py-1 pr-3">Service ID</th>
+                              <th className="py-1 pr-3">Product ID</th>
+                              <th className="py-1 pr-3">Order Ref</th>
+                              <th className="py-1 pr-3">Created</th>
+                              <th className="py-1 pr-3">Last Updated</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {group.members.map((member) => (
+                              <tr key={member.id} className="border-t border-border/50 text-text-primary">
+                                <td className="py-1 pr-3 font-mono">{member.id}</td>
+                                <td className="py-1 pr-3">{member.brand ?? "—"}</td>
+                                <td className="py-1 pr-3 font-mono">{member.serviceId ?? "—"}</td>
+                                <td className="py-1 pr-3 font-mono">{member.productId ?? "—"}</td>
+                                <td className="py-1 pr-3">{member.orderRef ?? "—"}</td>
+                                <td className="py-1 pr-3">{member.created ?? "—"}</td>
+                                <td className="py-1 pr-3">{member.lastUpdated ?? "—"}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    </details>
+                  ))}
+                </div>
+              )}
             </div>
           ) : null}
         </div>

--- a/app/src/lib/firestore/admin-queries.ts
+++ b/app/src/lib/firestore/admin-queries.ts
@@ -161,3 +161,37 @@ export async function listOperationalLogs(
   });
   return response.logs ?? [];
 }
+
+export interface DuplicateMember {
+  id: string;
+  brand: string | null;
+  serviceId: string | null;
+  productId: string | null;
+  orderRef: string | null;
+  created: string | null;
+  lastUpdated: string | null;
+  productTitle: string | null;
+}
+
+export interface DuplicateGroup {
+  feedbackUrl: string;
+  members: DuplicateMember[];
+}
+
+export interface DuplicateAuditReport {
+  scannedDocs: number;
+  duplicateGroups: number;
+  extraDocs: number;
+  scannedBrand: string | null;
+  groups: DuplicateGroup[];
+}
+
+export async function runDuplicateReviewAudit(
+  brand?: string | null
+): Promise<DuplicateAuditReport> {
+  const response = await postFunction<{ report: DuplicateAuditReport }>(
+    "auditDuplicateReviews",
+    brand ? { brand } : {}
+  );
+  return response.report;
+}

--- a/functions/src/audit/find-duplicate-reviews.ts
+++ b/functions/src/audit/find-duplicate-reviews.ts
@@ -1,0 +1,112 @@
+import { getFirestore } from "firebase-admin/firestore";
+
+/**
+ * Read-only audit: find reviews stored as multiple Firestore documents.
+ *
+ * `transformReview` picks the document ID from `service.id ?? product.id ??
+ * url-extracted hash`. If a Feefo review starts product-only and later gains
+ * a service feedback, the chosen ID changes and the next sync writes a new
+ * document — leaving the old one orphaned. This script groups reviews by
+ * their stable `feedbackUrl` and surfaces every group with more than one doc.
+ *
+ * The audit changes nothing. It returns enough metadata for a human to decide
+ * which duplicate to keep and run a manual cleanup separately.
+ */
+
+export interface DuplicateMember {
+  id: string;
+  brand: string | null;
+  serviceId: string | null;
+  productId: string | null;
+  orderRef: string | null;
+  created: string | null;
+  lastUpdated: string | null;
+  productTitle: string | null;
+}
+
+export interface DuplicateGroup {
+  feedbackUrl: string;
+  members: DuplicateMember[];
+}
+
+export interface DuplicateAuditReport {
+  scannedDocs: number;
+  duplicateGroups: number;
+  extraDocs: number; // members beyond one per feedbackUrl
+  scannedBrand: string | null;
+  groups: DuplicateGroup[];
+}
+
+const MAX_GROUPS_RETURNED = 200;
+
+export async function findDuplicateReviews(
+  filterBrand: string | null = null
+): Promise<DuplicateAuditReport> {
+  const db = getFirestore();
+  let query: FirebaseFirestore.Query = db.collection("reviews");
+  if (filterBrand) {
+    query = query.where("brand", "==", filterBrand);
+  }
+  const snap = await query.get();
+
+  const byUrl = new Map<string, DuplicateMember[]>();
+
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    const url = typeof data.feedbackUrl === "string" ? data.feedbackUrl : null;
+    if (!url) continue; // older docs without a feedbackUrl can't be deduped this way
+
+    const member: DuplicateMember = {
+      id: doc.id,
+      brand: typeof data.brand === "string" ? data.brand : null,
+      serviceId:
+        typeof data.service?.id === "string"
+          ? data.service.id
+          : null,
+      productId:
+        typeof data.product?.id === "string" ? data.product.id : null,
+      orderRef:
+        typeof data.customer?.orderRef === "string"
+          ? data.customer.orderRef
+          : null,
+      created:
+        typeof data.dates?.created === "string" ? data.dates.created : null,
+      lastUpdated:
+        typeof data.dates?.lastUpdated === "string"
+          ? data.dates.lastUpdated
+          : null,
+      productTitle:
+        typeof data.product?.title === "string" ? data.product.title : null,
+    };
+
+    const existing = byUrl.get(url);
+    if (existing) {
+      existing.push(member);
+    } else {
+      byUrl.set(url, [member]);
+    }
+  }
+
+  const groups: DuplicateGroup[] = [];
+  let extraDocs = 0;
+  for (const [feedbackUrl, members] of byUrl) {
+    if (members.length > 1) {
+      // Newest first so it's easy to spot which doc to keep.
+      members.sort((a, b) =>
+        (b.lastUpdated ?? "").localeCompare(a.lastUpdated ?? "")
+      );
+      groups.push({ feedbackUrl, members });
+      extraDocs += members.length - 1;
+    }
+  }
+
+  groups.sort((a, b) => b.members.length - a.members.length);
+
+  return {
+    scannedDocs: snap.size,
+    duplicateGroups: groups.length,
+    extraDocs,
+    scannedBrand: filterBrand,
+    groups: groups.slice(0, MAX_GROUPS_RETURNED),
+  };
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -24,6 +24,7 @@ import {
   rebuildMappings as rebuildItineraryMappings,
   updateMapping as updateItineraryMapping,
 } from "./sync/itinerary-mappings";
+import { findDuplicateReviews } from "./audit/find-duplicate-reviews";
 import {
   listOperationLogs,
   writeOperationLog,
@@ -543,6 +544,23 @@ export const itineraryMappings = onRequest(
     }
 
     res.status(400).json({ error: "Invalid action. Use 'rebuild', 'update', or 'recompute'." });
+  }
+);
+
+// Read-only audit: groups review docs by their stable feedbackUrl and reports
+// any that have more than one document. See functions/src/audit/find-duplicate-reviews.ts
+// for the rationale (transformReview's ID picker is unstable across review lifecycle).
+export const auditDuplicateReviews = onRequest(
+  { timeoutSeconds: 300, memory: "1GiB", invoker: "public", cors: ALLOWED_ORIGINS },
+  async (req, res) => {
+    if (!ensurePost(req, res)) return;
+    const caller = await authorizeRequest(req, res, "sync");
+    if (!caller) return;
+
+    const rawBrand = typeof req.body?.brand === "string" ? req.body.brand : null;
+    const brand = rawBrand && isValidBrand(rawBrand) ? rawBrand : null;
+    const report = await findDuplicateReviews(brand);
+    res.json({ report });
   }
 );
 


### PR DESCRIPTION
## Why

While comparing review counts to Feefo's hub UI we noticed our app sometimes returns **more** reviews than Feefo for the same brand + date window. The leading hypothesis: \`transformReview\` picks each review's Firestore doc ID with \`raw.service?.id ?? product?.id ?? extractIdFromUrl(raw.url)\`. That choice is **not stable** across a review's lifecycle:

- Feefo first publishes a product-only review → we store doc ID = \`product.id\`
- Customer later adds service feedback → \`raw.service?.id\` is now populated → next sync writes doc ID = \`service.id\`
- Result: same logical Feefo review, two Firestore documents

This PR is **read-only**. It adds tooling to confirm the hypothesis and size the cleanup before designing a real fix.

## What's in the PR

1. **\`functions/src/audit/find-duplicate-reviews.ts\`** — groups every \`reviews\` doc by its stable \`feedbackUrl\` (the Feefo review URL never changes) and emits any group with > 1 member. Each member carries enough metadata (\`service.id\`, \`product.id\`, \`orderRef\`, \`dates.created\`, \`dates.lastUpdated\`, etc.) to decide which doc to keep. Output is capped at 200 groups per call.

2. **\`auditDuplicateReviews\` HTTPS function** — POST endpoint, requires \`sync\` permission, accepts an optional \`{ brand: \"uniworld\" | \"luxury-gold\" }\` body to scope the scan.

3. **Admin page panel** — gated on \`canViewLogs\` (same gate as the Operations Log section), with a brand selector, Run audit button, summary stats (scanned docs / duplicate groups / extra docs), and an expandable table per group.

## How to use after deploy

1. Open **/admin**
2. Scroll to the new **Duplicate Review Audit** card
3. Pick a brand (or leave \"All brands\")
4. Click **Run audit** — depending on collection size this can take 10-30s
5. Inspect groups. For each group, the rows tell you which doc is keyed on \`service.id\` vs \`product.id\` and which has the most recent \`lastUpdated\`

If the hypothesis holds, expect to see groups where one row has \`Service ID = —\` (the orphan) and another has both \`Service ID\` and \`Product ID\` populated.

## What's intentionally NOT in this PR

- **No deletes**, no writes, no schema changes
- **No fix to \`transformReview\`** — that's a separate PR once we've confirmed the cause and decided whether to migrate to a stable ID like \`extractIdFromUrl(raw.url)\` or \`order_ref + brand\`
- **No backfill** to merge existing duplicates — likewise separate

## Test plan

- [ ] CI builds clean (functions + app TypeScript both compile)
- [ ] Deploy preview / staging: log in as admin, open /admin, run audit with no brand filter — endpoint returns within 30s
- [ ] Run audit with \`luxury-gold\` filter — groups (if any) only contain Luxury Gold docs
- [ ] Verify report's \`scannedDocs\` matches the actual Firestore collection size for the chosen brand
- [ ] Verify a known multi-product review (if any) appears or doesn't, depending on whether its \`feedbackUrl\` collides

🤖 Generated with [Claude Code](https://claude.com/claude-code)