### PR TITLE
Fix unreadable Newest/Oldest toggle on Reviews Explorer

### DIFF
--- a/app/src/app/reviews/page.tsx
+++ b/app/src/app/reviews/page.tsx
@@ -499,7 +499,7 @@ function ReviewsContent() {
             aria-pressed={sort === "newest"}
             className={`cursor-pointer rounded-l-lg border px-4 py-1.5 text-sm font-medium transition-colors ${
               sort === "newest"
-                ? "border-brand-accent bg-brand-accent text-brand-accent-foreground"
+                ? "border-brand-accent bg-brand-accent text-accent-foreground font-semibold"
                 : "border-input-border bg-surface text-text-primary hover:bg-surface-hover"
             }`}
           >
@@ -511,7 +511,7 @@ function ReviewsContent() {
             aria-pressed={sort === "oldest"}
             className={`cursor-pointer -ml-px rounded-r-lg border px-4 py-1.5 text-sm font-medium transition-colors ${
               sort === "oldest"
-                ? "border-brand-accent bg-brand-accent text-brand-accent-foreground"
+                ? "border-brand-accent bg-brand-accent text-accent-foreground font-semibold"
                 : "border-input-border bg-surface text-text-primary hover:bg-surface-hover"
             }`}
           >


### PR DESCRIPTION
## Summary

Same bug as the one fixed on PR #42 for the audit button: the selected Newest/Oldest segmented toggle on the Reviews Explorer used \`text-brand-accent-foreground\`, which is not a defined CSS variable. Only \`--accent-foreground\` exists (set to dark slate \`#1e293b\` for contrast on the gold accent). The class silently fell through to the inherited white, leaving the active button white-on-gold and unreadable.

This shipped as part of #39 and didn't get caught in review because the unselected state renders fine and the issue only appears once you click an option.

## Change

\`app/src/app/reviews/page.tsx\` — both selected-state class strings:

\`\`\`diff
- border-brand-accent bg-brand-accent text-brand-accent-foreground
+ border-brand-accent bg-brand-accent text-accent-foreground font-semibold
\`\`\`

\`font-semibold\` added to match the weight used elsewhere on accent-coloured buttons (DateRangePicker's Apply button, MerchantSwitcher's selected pill).

## Test plan

- [ ] Open Reviews Explorer → click Newest, then Oldest
- [ ] In both light and dark mode, the active button reads as dark text on gold (not white-on-gold)
- [ ] Inactive button still renders as text-text-primary on surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)