### PR TITLE
Stop sync from creating duplicate review documents

### DIFF
--- a/functions/src/sync/sync-reviews.ts
+++ b/functions/src/sync/sync-reviews.ts
@@ -95,6 +95,39 @@ export async function syncBrand(
         }
       }
 
+      // Re-target each doc's ID to any existing doc that already represents
+      // the same Feefo review. Without this, a review whose service/product
+      // ID has shifted since the last sync would be written to a brand-new
+      // document, leaving the original behind as a duplicate. The lookup is
+      // by feedbackUrl, which is stable for the lifetime of the review.
+      const URL_CHUNK = 30; // Firestore "in" filter caps at 30 values.
+      const incomingUrls = pageReviews
+        .map((doc) => doc.feedbackUrl)
+        .filter((url): url is string => Boolean(url));
+      const urlToExistingId = new Map<string, string>();
+      for (let i = 0; i < incomingUrls.length; i += URL_CHUNK) {
+        const chunk = incomingUrls.slice(i, i + URL_CHUNK);
+        const lookup = await db
+          .collection("reviews")
+          .where("feedbackUrl", "in", chunk)
+          .get();
+        for (const docSnap of lookup.docs) {
+          const url = docSnap.get("feedbackUrl") as string | undefined;
+          // First match wins; if there are pre-existing duplicates for the
+          // same URL, the audit/cleanup tooling on the admin page handles
+          // them rather than this sync.
+          if (url && !urlToExistingId.has(url)) {
+            urlToExistingId.set(url, docSnap.id);
+          }
+        }
+      }
+      for (const doc of pageReviews) {
+        const existingId = urlToExistingId.get(doc.feedbackUrl);
+        if (existingId && existingId !== doc.id) {
+          doc.id = existingId;
+        }
+      }
+
       // Write this page to Firestore immediately.
       // We intentionally strip `themes` and only merge the remaining fields
       // so that any existing theme/classification data on a review is preserved

--- a/shared/src/feefo/transform.ts
+++ b/shared/src/feefo/transform.ts
@@ -8,8 +8,16 @@ export function transformReview(raw: FeefoReview): ReviewDocument {
   const product = raw.products[0];
   const tags = parseTags(raw.tags, product?.product?.tags);
 
-  // Use service.id (feedback ID) as primary ID, fall back to product.id
-  const id = raw.service?.id ?? product?.id ?? extractIdFromUrl(raw.url);
+  // Doc ID comes from the URL hash first, because the URL never changes for
+  // a given review; service.id and product.id can shift over a review's
+  // lifecycle and previously caused duplicate documents. URL hash falls back
+  // to service.id, then product.id, then a timestamp-only fallback as a
+  // last-resort so we never throw.
+  const id =
+    extractIdFromUrl(raw.url) ??
+    raw.service?.id ??
+    product?.id ??
+    `url-${Date.now()}`;
 
   const merchantId = raw.merchant.identifier;
   if (!VALID_BRANDS.has(merchantId)) {
@@ -71,8 +79,8 @@ export function transformReview(raw: FeefoReview): ReviewDocument {
   };
 }
 
-function extractIdFromUrl(url: string): string {
+function extractIdFromUrl(url: string): string | null {
   const parts = url.split("/");
   const hexPart = parts.find((p) => /^[0-9a-f]{24}$/.test(p));
-  return hexPart ?? `url-${Date.now()}`;
+  return hexPart ?? null;
 }


### PR DESCRIPTION
## Why

The duplicate audit (PR #42) revealed that when a Feefo review's \`service.id\` shifts between syncs, the sync writes a brand-new document instead of updating the existing one — leaving the original behind as a duplicate. Two such pairs are visible in the live data right now, and the rate is ~1 per ~10 days.

## What this changes

Two complementary fixes — neither requires a data migration.

**1. \`transformReview\` ID picker** — was \`service.id ?? product.id ?? extractIdFromUrl(url)\`, now \`extractIdFromUrl(url) ?? service.id ?? product.id ?? \"url-{Date.now()}\"\`. The URL hash never shifts for a given review, so brand-new reviews get a doc ID that's stable for the review's entire lifetime.

**2. \`syncBrand\` self-heals existing docs** — before writing each page, the sync looks up any existing review documents by \`feedbackUrl\` (in chunks of 30, the Firestore \`in\` limit). If a doc with that URL already exists at a different ID, the incoming write is re-targeted to the existing doc's ID. This keeps all 26k+ existing documents in place — no migration — while making future syncs idempotent regardless of which ID the Feefo response happens to populate.

If pre-existing duplicates already exist for a URL, the lookup just picks the first match and lets the audit/cleanup tooling on the admin page consolidate them; the sync's job is to stop *creating* new duplicates, not retroactively merge old ones.

## Why it doesn't need an index migration

The lookup is on a single field (\`feedbackUrl\`), and Firestore auto-creates single-field indexes. No \`firestore.indexes.json\` changes.

## Cost

One extra \`in\` query per chunk-of-30 reviews per page during sync. With pageSize=100 that's ~4 extra queries per page; for a typical incremental sync (last month of reviews) the overhead is in the low tens of queries.

## Test plan

- [ ] CI builds clean (functions + shared TypeScript both compile)
- [ ] Deploy preview / staging: trigger a manual sync, verify it completes with no errors and \`unchangedReviews\` count is non-zero (proving existing docs are being matched)
- [ ] Verify the live duplicate count from PR #42's audit doesn't grow after the next scheduled sync
- [ ] Spot check: pick a review that's been edited recently in Feefo, confirm there's still one doc for it after sync (not two)

## Related

Pairs with PR #42 (audit & cleanup tooling) — once that lands, an admin can run the audit, click \"Remove duplicates\" to consolidate the 2 existing pairs, and never see new duplicates form again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)