### PR TITLE
Ship missing audit follow-ups: gold-button fix and Remove duplicates

### DIFF
--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -15,6 +15,7 @@ import {
   listKnownUsers,
   listOperationalLogs,
   removeAdminUser,
+  resolveDuplicateReviews,
   runDuplicateReviewAudit,
   getItineraryMappings,
   upsertAdminUser,
@@ -121,6 +122,7 @@ export default function AdminPage() {
   const [toast, setToast] = useState<string | null>(null);
   const [duplicateReport, setDuplicateReport] = useState<DuplicateAuditReport | null>(null);
   const [duplicateLoading, setDuplicateLoading] = useState(false);
+  const [duplicateResolving, setDuplicateResolving] = useState(false);
   const [duplicateBrand, setDuplicateBrand] = useState<"" | "uniworld" | "luxury-gold">("");
   const [duplicatesExpanded, setDuplicatesExpanded] = useState(false);
 
@@ -174,6 +176,30 @@ export default function AdminPage() {
     }
     setDuplicateLoading(false);
   }, [duplicateBrand]);
+
+  const removeDuplicates = useCallback(async () => {
+    if (!duplicateReport || duplicateReport.duplicateGroups === 0) return;
+    const summary =
+      `${duplicateReport.duplicateGroups} duplicate group(s) (${duplicateReport.extraDocs} extra doc(s))`;
+    const confirmed = window.confirm(
+      `Remove duplicates?\n\nThis will delete ${duplicateReport.extraDocs} document(s) across ${summary}, keeping the document with the most recent Last Updated timestamp in each group. This cannot be undone.`
+    );
+    if (!confirmed) return;
+
+    setDuplicateResolving(true);
+    try {
+      const result = await resolveDuplicateReviews(duplicateBrand || null);
+      setToast(
+        `Removed ${result.docsDeleted} duplicate doc(s) across ${result.groupsResolved} group(s).`
+      );
+      // Re-run the audit so the table reflects the new state.
+      const report = await runDuplicateReviewAudit(duplicateBrand || null);
+      setDuplicateReport(report);
+    } catch (err) {
+      setToast(err instanceof Error ? err.message : "Failed to remove duplicates");
+    }
+    setDuplicateResolving(false);
+  }, [duplicateBrand, duplicateReport]);
 
   const loadMappings = useCallback(async () => {
     setLoading(true);
@@ -851,11 +877,23 @@ export default function AdminPage() {
                 <button
                   type="button"
                   onClick={runDuplicateAudit}
-                  disabled={duplicateLoading}
+                  disabled={duplicateLoading || duplicateResolving}
                   className="inline-flex items-center rounded-lg bg-brand-accent px-4 py-2 text-sm font-semibold text-accent-foreground shadow-sm hover:opacity-90 disabled:opacity-50"
                 >
                   {duplicateLoading ? "Running…" : "Run audit"}
                 </button>
+                {duplicateReport && duplicateReport.duplicateGroups > 0 ? (
+                  <button
+                    type="button"
+                    onClick={removeDuplicates}
+                    disabled={duplicateResolving || duplicateLoading}
+                    className="inline-flex items-center rounded-lg border border-red-500 bg-red-500 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-600 disabled:opacity-50"
+                  >
+                    {duplicateResolving
+                      ? "Removing…"
+                      : `Remove duplicates (${duplicateReport.extraDocs})`}
+                  </button>
+                ) : null}
                 {duplicateReport ? (
                   <button
                     type="button"

--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -863,17 +863,22 @@ export default function AdminPage() {
                 </p>
               </div>
               <div className="flex flex-wrap items-center gap-2">
-                <select
-                  value={duplicateBrand}
-                  onChange={(event) =>
-                    setDuplicateBrand(event.target.value as "" | "uniworld" | "luxury-gold")
-                  }
-                  className="rounded-lg border border-input-border bg-surface px-3 py-2 text-sm text-text-primary"
-                >
-                  <option value="">All brands</option>
-                  <option value="uniworld">Uniworld</option>
-                  <option value="luxury-gold">Luxury Gold</option>
-                </select>
+                <label className="inline-flex items-center gap-2 rounded-lg border border-input-border bg-surface px-3 py-2 text-sm text-text-primary shadow-sm">
+                  <span className="text-xs font-medium uppercase tracking-wide text-text-secondary">
+                    Brand
+                  </span>
+                  <select
+                    value={duplicateBrand}
+                    onChange={(event) =>
+                      setDuplicateBrand(event.target.value as "" | "uniworld" | "luxury-gold")
+                    }
+                    className="bg-transparent text-sm font-medium text-text-primary focus:outline-none"
+                  >
+                    <option value="">All brands</option>
+                    <option value="uniworld">Uniworld</option>
+                    <option value="luxury-gold">Luxury Gold</option>
+                  </select>
+                </label>
                 <button
                   type="button"
                   onClick={runDuplicateAudit}

--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -852,7 +852,7 @@ export default function AdminPage() {
                   type="button"
                   onClick={runDuplicateAudit}
                   disabled={duplicateLoading}
-                  className="inline-flex items-center rounded-lg bg-brand-accent px-4 py-2 text-sm font-medium text-brand-accent-foreground shadow-sm hover:opacity-90 disabled:opacity-50"
+                  className="inline-flex items-center rounded-lg bg-brand-accent px-4 py-2 text-sm font-semibold text-accent-foreground shadow-sm hover:opacity-90 disabled:opacity-50"
                 >
                   {duplicateLoading ? "Running…" : "Run audit"}
                 </button>

--- a/app/src/lib/firestore/admin-queries.ts
+++ b/app/src/lib/firestore/admin-queries.ts
@@ -195,3 +195,19 @@ export async function runDuplicateReviewAudit(
   );
   return response.report;
 }
+
+export interface DuplicateResolutionResult {
+  groupsResolved: number;
+  docsDeleted: number;
+  scannedBrand: string | null;
+}
+
+export async function resolveDuplicateReviews(
+  brand?: string | null
+): Promise<DuplicateResolutionResult> {
+  const response = await postFunction<{ result: DuplicateResolutionResult }>(
+    "resolveDuplicateReviews",
+    brand ? { brand } : {}
+  );
+  return response.result;
+}

--- a/functions/src/audit/find-duplicate-reviews.ts
+++ b/functions/src/audit/find-duplicate-reviews.ts
@@ -110,3 +110,46 @@ export async function findDuplicateReviews(
     groups: groups.slice(0, MAX_GROUPS_RETURNED),
   };
 }
+
+export interface DuplicateResolutionResult {
+  groupsResolved: number;
+  docsDeleted: number;
+  scannedBrand: string | null;
+}
+
+/**
+ * Consolidates duplicates by keeping the document with the most recent
+ * `dates.lastUpdated` in each group and deleting the rest. Operates on the
+ * same group definition as `findDuplicateReviews` (same feedbackUrl with
+ * more than one document).
+ */
+export async function removeDuplicateReviews(
+  filterBrand: string | null = null
+): Promise<DuplicateResolutionResult> {
+  const report = await findDuplicateReviews(filterBrand);
+  const db = getFirestore();
+  const writer = db.bulkWriter();
+
+  let groupsResolved = 0;
+  let docsDeleted = 0;
+
+  for (const group of report.groups) {
+    if (group.members.length < 2) continue;
+    // findDuplicateReviews already sorts members by lastUpdated desc, so the
+    // first entry is the keeper and everything after it is a duplicate.
+    const [, ...toDelete] = group.members;
+    for (const member of toDelete) {
+      writer.delete(db.collection("reviews").doc(member.id));
+      docsDeleted += 1;
+    }
+    groupsResolved += 1;
+  }
+
+  await writer.close();
+
+  return {
+    groupsResolved,
+    docsDeleted,
+    scannedBrand: filterBrand,
+  };
+}

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -24,7 +24,10 @@ import {
   rebuildMappings as rebuildItineraryMappings,
   updateMapping as updateItineraryMapping,
 } from "./sync/itinerary-mappings";
-import { findDuplicateReviews } from "./audit/find-duplicate-reviews";
+import {
+  findDuplicateReviews,
+  removeDuplicateReviews,
+} from "./audit/find-duplicate-reviews";
 import {
   listOperationLogs,
   writeOperationLog,
@@ -561,6 +564,37 @@ export const auditDuplicateReviews = onRequest(
     const brand = rawBrand && isValidBrand(rawBrand) ? rawBrand : null;
     const report = await findDuplicateReviews(brand);
     res.json({ report });
+  }
+);
+
+// Resolve duplicate review documents by keeping the row with the most recent
+// `dates.lastUpdated` in each group and deleting the rest. Same authorization
+// gate as the audit; pairs with the audit panel's "Remove duplicates" button.
+export const resolveDuplicateReviews = onRequest(
+  { timeoutSeconds: 300, memory: "1GiB", invoker: "public", cors: ALLOWED_ORIGINS },
+  async (req, res) => {
+    if (!ensurePost(req, res)) return;
+    const caller = await authorizeRequest(req, res, "sync");
+    if (!caller) return;
+
+    const rawBrand = typeof req.body?.brand === "string" ? req.body.brand : null;
+    const brand = rawBrand && isValidBrand(rawBrand) ? rawBrand : null;
+    const result = await removeDuplicateReviews(brand);
+    await writeOperationLog({
+      type: "sync",
+      level: "success",
+      action: "duplicate_reviews_resolved",
+      message: `Resolved ${result.groupsResolved} duplicate review group(s)`,
+      brand: brand ?? null,
+      source: "manual",
+      actorEmail: caller.email,
+      actorUid: caller.uid,
+      details: {
+        groupsResolved: result.groupsResolved,
+        docsDeleted: result.docsDeleted,
+      },
+    });
+    res.json({ result });
   }
 );
 


### PR DESCRIPTION
## Why this exists

PR #42 (the duplicate-review audit) was merged after the initial commit but before two follow-up commits landed on its branch. Those follow-ups were:

1. **\`6b7bd04\` Use accent-foreground token on the audit button** — fixes the white-on-gold contrast issue on the \"Run audit\" button.
2. **\`2cefd9e\` Add Remove duplicates button to the audit panel** — adds the cleanup button + backend endpoint that was the entire point of the audit work.

Both ended up on the merged branch but neither made it onto \`main\`. This PR cherry-picks both so they actually ship.

## What you'll see after deploy

- The \"Run audit\" button is dark text on gold (legible) instead of white text on gold.
- A red **Remove duplicates (N)** button appears next to \"Run audit\" once the audit has run and found groups. Clicking it confirms, deletes all-but-newest in each group via Firestore bulkWriter, logs the resolution to Operational Logs, and re-runs the audit so the table updates.

## Backend additions (from cherry-pick of #2 above)

- \`functions/src/audit/find-duplicate-reviews.ts\` gains \`removeDuplicateReviews(brand?)\`.
- New \`resolveDuplicateReviews\` HTTPS endpoint, same \`sync\` permission as the audit.

## Test plan

- [ ] Open /admin → audit panel → \"Run audit\" button is dark-on-gold, readable
- [ ] Click Run audit, confirm 2 groups (4 docs total, 2 extra) appear as before
- [ ] Click \"Remove duplicates (2)\", confirm in dialog, verify toast says 2 docs deleted across 2 groups
- [ ] Audit auto-reruns showing 0 groups
- [ ] Operations Log shows a \`duplicate_reviews_resolved\` entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)