### PR TITLE
Fix itinerary/ship panel filters; add paginated reviews and localized dates

### DIFF
--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -159,6 +159,12 @@ export default function OverviewPage() {
     setPanelHasMore(false);
   }, []);
 
+  // Panel cursor and selection are tied to the current filters; close on
+  // filter change so Show more never resumes against a stale selection.
+  useEffect(() => {
+    closePanel();
+  }, [brand, dateField, dateRange, closePanel]);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useBrand } from "@/contexts/BrandContext";
 import KpiCard from "@/components/dashboard/KpiCard";
@@ -19,6 +19,7 @@ import {
   type OverviewSelectionFilter,
   type FleetSummary,
   type EntitySummary,
+  type ReviewPageCursor,
   type ThemeReview,
   type TrendPoint,
   type TrendGranularity,
@@ -42,6 +43,10 @@ export default function OverviewPage() {
   const [panelAccent, setPanelAccent] = useState<"positive" | "negative" | "neutral">("neutral");
   const [panelReviews, setPanelReviews] = useState<ThemeReview[]>([]);
   const [panelLoading, setPanelLoading] = useState(false);
+  const [panelLoadingMore, setPanelLoadingMore] = useState(false);
+  const [panelHasMore, setPanelHasMore] = useState(false);
+  const panelCursorRef = useRef<ReviewPageCursor>(null);
+  const panelFilterRef = useRef<OverviewSelectionFilter | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -100,18 +105,22 @@ export default function OverviewPage() {
       setPanelOpen(true);
       setPanelReviews([]);
       setPanelLoading(true);
+      setPanelHasMore(false);
+      panelCursorRef.current = null;
+      panelFilterRef.current = selection.filter;
       try {
-        const reviews = await getReviewsForOverviewSelection(
+        const page = await getReviewsForOverviewSelection(
           brand,
           dateRange.start,
           dateRange.end,
           selection.filter,
           dateField
         );
-        setPanelReviews(reviews);
+        setPanelReviews(page.reviews);
+        panelCursorRef.current = page.cursor;
+        setPanelHasMore(page.hasMore);
       } catch (err) {
         console.error("Failed to load overview panel reviews", err);
-        setPanelReviews([]);
       } finally {
         setPanelLoading(false);
       }
@@ -119,9 +128,35 @@ export default function OverviewPage() {
     [brand, dateRange.end, dateRange.start, dateField]
   );
 
+  const loadMorePanel = useCallback(async () => {
+    if (panelLoadingMore || !panelFilterRef.current) return;
+    setPanelLoadingMore(true);
+    try {
+      const page = await getReviewsForOverviewSelection(
+        brand,
+        dateRange.start,
+        dateRange.end,
+        panelFilterRef.current,
+        dateField,
+        undefined,
+        panelCursorRef.current
+      );
+      setPanelReviews((prev) => [...prev, ...page.reviews]);
+      panelCursorRef.current = page.cursor;
+      setPanelHasMore(page.hasMore);
+    } catch (err) {
+      console.error("Failed to load more overview panel reviews", err);
+    } finally {
+      setPanelLoadingMore(false);
+    }
+  }, [brand, dateRange.end, dateRange.start, dateField, panelLoadingMore]);
+
   const closePanel = useCallback(() => {
     setPanelOpen(false);
     setPanelReviews([]);
+    panelCursorRef.current = null;
+    panelFilterRef.current = null;
+    setPanelHasMore(false);
   }, []);
 
   if (loading) {
@@ -277,6 +312,9 @@ export default function OverviewPage() {
           reviews={panelReviews}
           loading={panelLoading}
           onClose={closePanel}
+          onLoadMore={loadMorePanel}
+          hasMore={panelHasMore}
+          loadingMore={panelLoadingMore}
         />
       )}
     </div>

--- a/app/src/components/dashboard/QuotesSection.tsx
+++ b/app/src/components/dashboard/QuotesSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { formatReviewDate } from "@/lib/format/date";
 
 export interface Quote {
   id: string;
@@ -58,6 +59,7 @@ function QuoteCard({
       </div>
       <p className="mb-2 text-xs text-text-secondary">
         {quote.itinerary} · {quote.ship}
+        {quote.date && ` · ${formatReviewDate(quote.date)}`}
       </p>
       <p
         ref={textRef}

--- a/app/src/components/dashboard/ReviewPanel.tsx
+++ b/app/src/components/dashboard/ReviewPanel.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import type { ThemeReview } from "@/lib/firestore/queries";
 import MediaThumbnails from "@/components/reviews/MediaThumbnails";
+import { formatReviewDate } from "@/lib/format/date";
 
 interface ReviewPanelProps {
   title: string;
@@ -11,6 +12,9 @@ interface ReviewPanelProps {
   reviews: ThemeReview[];
   loading: boolean;
   onClose: () => void;
+  onLoadMore?: () => void;
+  hasMore?: boolean;
+  loadingMore?: boolean;
 }
 
 function StarRating({ rating }: { rating: number }) {
@@ -52,6 +56,7 @@ function QuoteCard({
       </div>
       <p className="mb-2 text-xs text-text-secondary">
         {review.itinerary} · {review.ship}
+        {review.date && ` · ${formatReviewDate(review.date)}`}
       </p>
       <p className="text-sm leading-relaxed text-text-primary">
         {expanded || review.text.length <= 150
@@ -82,6 +87,9 @@ export default function ReviewPanel({
   reviews,
   loading,
   onClose,
+  onLoadMore,
+  hasMore = false,
+  loadingMore = false,
 }: ReviewPanelProps) {
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -111,7 +119,9 @@ export default function ReviewPanel({
           <div>
             <h2 className="text-lg font-semibold text-text-primary">{title}</h2>
             <p className="mt-0.5 text-sm text-text-secondary">
-              {reviews.length} review{reviews.length !== 1 ? "s" : ""}
+              {hasMore
+                ? `Showing ${reviews.length}+ reviews`
+                : `${reviews.length} review${reviews.length !== 1 ? "s" : ""}`}
             </p>
             <p className="mt-1 text-xs text-text-tertiary">{subtitle}</p>
           </div>
@@ -147,9 +157,29 @@ export default function ReviewPanel({
               No matching reviews were found.
             </p>
           ) : (
-            reviews.map((review) => (
-              <QuoteCard key={review.id} review={review} accent={accent} />
-            ))
+            <>
+              {reviews.map((review) => (
+                <QuoteCard key={review.id} review={review} accent={accent} />
+              ))}
+              {hasMore && onLoadMore && (
+                <div className="pt-2 text-center">
+                  <button
+                    onClick={onLoadMore}
+                    disabled={loadingMore}
+                    className="inline-flex items-center gap-2 rounded-lg bg-header-bg px-6 py-2.5 text-sm font-medium text-header-text shadow-sm transition-colors hover:opacity-90 disabled:opacity-50 cursor-pointer"
+                  >
+                    {loadingMore ? (
+                      <>
+                        <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                        Loading...
+                      </>
+                    ) : (
+                      "Show more"
+                    )}
+                  </button>
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/app/src/components/itineraries/ItineraryDetail.tsx
+++ b/app/src/components/itineraries/ItineraryDetail.tsx
@@ -142,6 +142,12 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
     setPanelHasMore(false);
   }, []);
 
+  // Panel cursor is tied to the current filters; close on filter change so
+  // Show more never resumes against a stale selection.
+  useEffect(() => {
+    closePanel();
+  }, [brand, dateField, dateRange, closePanel]);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">

--- a/app/src/components/itineraries/ItineraryDetail.tsx
+++ b/app/src/components/itineraries/ItineraryDetail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import Link from "next/link";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useBrand } from "@/contexts/BrandContext";
@@ -10,13 +10,18 @@ import ThemeChart from "@/components/dashboard/ThemeChart";
 import ReviewPanel from "@/components/dashboard/ReviewPanel";
 import QuotesSection from "@/components/dashboard/QuotesSection";
 import type { Quote } from "@/components/dashboard/QuotesSection";
-import { getReviewsByTheme } from "@/lib/firestore/queries";
-import type { ThemeReview } from "@/lib/firestore/queries";
+import type { ReviewPageCursor, ThemeReview } from "@/lib/firestore/queries";
 import {
   getItineraryBySlug,
   getItineraryQuotes,
+  getItineraryReviewsByStar,
+  getItineraryReviewsByTheme,
   type ItinerarySummary,
 } from "@/lib/firestore/itinerary-queries";
+
+type PanelState =
+  | { kind: "theme"; theme: string; type: "positive" | "negative" }
+  | { kind: "rating"; star: number };
 
 export default function ItineraryDetail({ slug }: { slug: string }) {
   const { merchantQueryId: brand } = useBrand();
@@ -28,11 +33,13 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [panelOpen, setPanelOpen] = useState(false);
-  const [panelTheme, setPanelTheme] = useState("");
-  const [panelType, setPanelType] = useState<"positive" | "negative">("positive");
+
+  const [panelState, setPanelState] = useState<PanelState | null>(null);
   const [panelReviews, setPanelReviews] = useState<ThemeReview[]>([]);
   const [panelLoading, setPanelLoading] = useState(false);
+  const [panelLoadingMore, setPanelLoadingMore] = useState(false);
+  const [panelHasMore, setPanelHasMore] = useState(false);
+  const panelCursorRef = useRef<ReviewPageCursor>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -62,25 +69,77 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
     return () => { cancelled = true; };
   }, [slug, brand, dateRange, dateField, dataVersion]);
 
-  const openPanel = useCallback(async (theme: string, type: "positive" | "negative") => {
-    setPanelTheme(theme);
-    setPanelType(type);
-    setPanelOpen(true);
-    setPanelLoading(true);
-    try {
-      const reviews = await getReviewsByTheme(brand, theme, type, dateField, dateRange.start, dateRange.end);
-      setPanelReviews(reviews);
-    } catch (err) {
-      console.error("Failed to load theme reviews", err);
+  const fetchPanelPage = useCallback(
+    async (state: PanelState, cursor: ReviewPageCursor) => {
+      if (!itinerary) {
+        return { reviews: [], cursor: null, hasMore: false };
+      }
+      if (state.kind === "theme") {
+        return getItineraryReviewsByTheme(
+          brand,
+          itinerary.childItineraries,
+          state.theme,
+          state.type,
+          dateField,
+          dateRange,
+          undefined,
+          cursor
+        );
+      }
+      return getItineraryReviewsByStar(
+        brand,
+        itinerary.childItineraries,
+        state.star,
+        dateField,
+        dateRange,
+        undefined,
+        cursor
+      );
+    },
+    [itinerary, brand, dateField, dateRange]
+  );
+
+  const openPanel = useCallback(
+    async (state: PanelState) => {
+      setPanelState(state);
       setPanelReviews([]);
+      setPanelLoading(true);
+      setPanelHasMore(false);
+      panelCursorRef.current = null;
+      try {
+        const page = await fetchPanelPage(state, null);
+        setPanelReviews(page.reviews);
+        panelCursorRef.current = page.cursor;
+        setPanelHasMore(page.hasMore);
+      } catch (err) {
+        console.error("Failed to load panel reviews", err);
+      } finally {
+        setPanelLoading(false);
+      }
+    },
+    [fetchPanelPage]
+  );
+
+  const loadMorePanel = useCallback(async () => {
+    if (!panelState || panelLoadingMore) return;
+    setPanelLoadingMore(true);
+    try {
+      const page = await fetchPanelPage(panelState, panelCursorRef.current);
+      setPanelReviews((prev) => [...prev, ...page.reviews]);
+      panelCursorRef.current = page.cursor;
+      setPanelHasMore(page.hasMore);
+    } catch (err) {
+      console.error("Failed to load more panel reviews", err);
     } finally {
-      setPanelLoading(false);
+      setPanelLoadingMore(false);
     }
-  }, [brand, dateRange, dateField]);
+  }, [panelState, panelLoadingMore, fetchPanelPage]);
 
   const closePanel = useCallback(() => {
-    setPanelOpen(false);
+    setPanelState(null);
     setPanelReviews([]);
+    panelCursorRef.current = null;
+    setPanelHasMore(false);
   }, []);
 
   if (loading) {
@@ -111,6 +170,21 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
   const ratingDelta = itinerary.averageRating - itinerary.fleetAvgRating;
   const fiveStarDelta = itinerary.fiveStarPercent - itinerary.fleetAvgFiveStar;
 
+  const panelTitle =
+    panelState?.kind === "theme"
+      ? panelState.theme
+      : panelState
+        ? `${panelState.star}-Star Reviews`
+        : "";
+  const panelSubtitle =
+    panelState?.kind === "theme"
+      ? `Reviews for ${itinerary.name} matching the selected ${panelState.type} theme`
+      : panelState
+        ? `${panelState.star}-star reviews for ${itinerary.name}`
+        : "";
+  const panelAccent: "positive" | "negative" | "neutral" =
+    panelState?.kind === "theme" ? panelState.type : "neutral";
+
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-2 text-sm text-text-secondary">
@@ -125,10 +199,13 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
         <KpiCard title="5-Star %" value={`${itinerary.fiveStarPercent.toFixed(1)}%`} trendUp={fiveStarDelta >= 0} delta={`${fiveStarDelta >= 0 ? "+" : ""}${fiveStarDelta.toFixed(1)}% vs fleet avg`} />
         <KpiCard title="4+ Star %" value={`${itinerary.fourPlusPercent.toFixed(1)}%`} />
       </div>
-      <RatingDistributionChart data={itinerary.ratingDistribution} />
+      <RatingDistributionChart
+        data={itinerary.ratingDistribution}
+        onBarClick={(star) => openPanel({ kind: "rating", star })}
+      />
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <ThemeChart title="Positive Themes" data={itinerary.positiveThemes} type="positive" onBarClick={(theme) => openPanel(theme, "positive")} />
-        <ThemeChart title="Negative Themes" data={itinerary.negativeThemes} type="negative" onBarClick={(theme) => openPanel(theme, "negative")} />
+        <ThemeChart title="Positive Themes" data={itinerary.positiveThemes} type="positive" onBarClick={(theme) => openPanel({ kind: "theme", theme, type: "positive" })} />
+        <ThemeChart title="Negative Themes" data={itinerary.negativeThemes} type="negative" onBarClick={(theme) => openPanel({ kind: "theme", theme, type: "negative" })} />
       </div>
       <div className="bg-surface rounded-lg shadow-sm p-6">
         <h3 className="text-lg font-semibold text-text-primary mb-4">Ships Operating This Itinerary</h3>
@@ -142,14 +219,17 @@ export default function ItineraryDetail({ slug }: { slug: string }) {
         </div>
       </div>
       <QuotesSection positiveQuotes={quotes.positive} negativeQuotes={quotes.negative} />
-      {panelOpen && (
+      {panelState && (
         <ReviewPanel
-          title={panelTheme}
-          subtitle={`Reviews matching the selected ${panelType} theme`}
-          accent={panelType}
+          title={panelTitle}
+          subtitle={panelSubtitle}
+          accent={panelAccent}
           reviews={panelReviews}
           loading={panelLoading}
           onClose={closePanel}
+          onLoadMore={loadMorePanel}
+          hasMore={panelHasMore}
+          loadingMore={panelLoadingMore}
         />
       )}
     </div>

--- a/app/src/components/ships/ShipDetail.tsx
+++ b/app/src/components/ships/ShipDetail.tsx
@@ -136,6 +136,12 @@ export default function ShipDetail({ slug }: { slug: string }) {
     setPanelHasMore(false);
   }, []);
 
+  // Panel cursor is tied to the current filters; close on filter change so
+  // Show more never resumes against a stale selection.
+  useEffect(() => {
+    closePanel();
+  }, [brand, dateField, dateRange, closePanel]);
+
   if (loading) {
     return (
       <div className="flex items-center justify-center py-24">

--- a/app/src/components/ships/ShipDetail.tsx
+++ b/app/src/components/ships/ShipDetail.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import Link from "next/link";
 import { useDashboard } from "@/contexts/DashboardContext";
 import { useBrand } from "@/contexts/BrandContext";
@@ -11,13 +11,18 @@ import ThemeChart from "@/components/dashboard/ThemeChart";
 import ReviewPanel from "@/components/dashboard/ReviewPanel";
 import QuotesSection from "@/components/dashboard/QuotesSection";
 import type { Quote } from "@/components/dashboard/QuotesSection";
-import { getReviewsByTheme } from "@/lib/firestore/queries";
-import type { ThemeReview } from "@/lib/firestore/queries";
+import type { ReviewPageCursor, ThemeReview } from "@/lib/firestore/queries";
 import {
   getShipBySlug,
   getShipQuotes,
+  getShipReviewsByStar,
+  getShipReviewsByTheme,
   type ShipSummary,
 } from "@/lib/firestore/ship-queries";
+
+type PanelState =
+  | { kind: "theme"; theme: string; type: "positive" | "negative" }
+  | { kind: "rating"; star: number };
 
 export default function ShipDetail({ slug }: { slug: string }) {
   const { merchantQueryId: brand } = useBrand();
@@ -29,11 +34,13 @@ export default function ShipDetail({ slug }: { slug: string }) {
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [panelOpen, setPanelOpen] = useState(false);
-  const [panelTheme, setPanelTheme] = useState("");
-  const [panelType, setPanelType] = useState<"positive" | "negative">("positive");
+
+  const [panelState, setPanelState] = useState<PanelState | null>(null);
   const [panelReviews, setPanelReviews] = useState<ThemeReview[]>([]);
   const [panelLoading, setPanelLoading] = useState(false);
+  const [panelLoadingMore, setPanelLoadingMore] = useState(false);
+  const [panelHasMore, setPanelHasMore] = useState(false);
+  const panelCursorRef = useRef<ReviewPageCursor>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -56,25 +63,77 @@ export default function ShipDetail({ slug }: { slug: string }) {
     return () => { cancelled = true; };
   }, [slug, brand, dateRange, dateField, dataVersion]);
 
-  const openPanel = useCallback(async (theme: string, type: "positive" | "negative") => {
-    setPanelTheme(theme);
-    setPanelType(type);
-    setPanelOpen(true);
-    setPanelLoading(true);
-    try {
-      const reviews = await getReviewsByTheme(brand, theme, type, dateField, dateRange.start, dateRange.end);
-      setPanelReviews(reviews);
-    } catch (err) {
-      console.error("Failed to load theme reviews", err);
+  const fetchPanelPage = useCallback(
+    async (state: PanelState, cursor: ReviewPageCursor) => {
+      if (!ship) {
+        return { reviews: [], cursor: null, hasMore: false };
+      }
+      if (state.kind === "theme") {
+        return getShipReviewsByTheme(
+          brand,
+          ship.name,
+          state.theme,
+          state.type,
+          dateField,
+          dateRange,
+          undefined,
+          cursor
+        );
+      }
+      return getShipReviewsByStar(
+        brand,
+        ship.name,
+        state.star,
+        dateField,
+        dateRange,
+        undefined,
+        cursor
+      );
+    },
+    [ship, brand, dateField, dateRange]
+  );
+
+  const openPanel = useCallback(
+    async (state: PanelState) => {
+      setPanelState(state);
       setPanelReviews([]);
+      setPanelLoading(true);
+      setPanelHasMore(false);
+      panelCursorRef.current = null;
+      try {
+        const page = await fetchPanelPage(state, null);
+        setPanelReviews(page.reviews);
+        panelCursorRef.current = page.cursor;
+        setPanelHasMore(page.hasMore);
+      } catch (err) {
+        console.error("Failed to load panel reviews", err);
+      } finally {
+        setPanelLoading(false);
+      }
+    },
+    [fetchPanelPage]
+  );
+
+  const loadMorePanel = useCallback(async () => {
+    if (!panelState || panelLoadingMore) return;
+    setPanelLoadingMore(true);
+    try {
+      const page = await fetchPanelPage(panelState, panelCursorRef.current);
+      setPanelReviews((prev) => [...prev, ...page.reviews]);
+      panelCursorRef.current = page.cursor;
+      setPanelHasMore(page.hasMore);
+    } catch (err) {
+      console.error("Failed to load more panel reviews", err);
     } finally {
-      setPanelLoading(false);
+      setPanelLoadingMore(false);
     }
-  }, [brand, dateRange, dateField]);
+  }, [panelState, panelLoadingMore, fetchPanelPage]);
 
   const closePanel = useCallback(() => {
-    setPanelOpen(false);
+    setPanelState(null);
     setPanelReviews([]);
+    panelCursorRef.current = null;
+    setPanelHasMore(false);
   }, []);
 
   if (loading) {
@@ -105,6 +164,21 @@ export default function ShipDetail({ slug }: { slug: string }) {
   const ratingDelta = ship.averageRating - ship.fleetAvgRating;
   const fiveStarDelta = ship.fiveStarPercent - ship.fleetAvgFiveStar;
 
+  const panelTitle =
+    panelState?.kind === "theme"
+      ? panelState.theme
+      : panelState
+        ? `${panelState.star}-Star Reviews`
+        : "";
+  const panelSubtitle =
+    panelState?.kind === "theme"
+      ? `Reviews for ${ship.name} matching the selected ${panelState.type} theme`
+      : panelState
+        ? `${panelState.star}-star reviews for ${ship.name}`
+        : "";
+  const panelAccent: "positive" | "negative" | "neutral" =
+    panelState?.kind === "theme" ? panelState.type : "neutral";
+
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-2 text-sm text-text-secondary">
@@ -119,10 +193,13 @@ export default function ShipDetail({ slug }: { slug: string }) {
         <KpiCard title="5-Star %" value={`${ship.fiveStarPercent.toFixed(1)}%`} trendUp={fiveStarDelta >= 0} delta={`${fiveStarDelta >= 0 ? "+" : ""}${fiveStarDelta.toFixed(1)}% vs fleet avg`} />
         <KpiCard title="4+ Star %" value={`${ship.fourPlusPercent.toFixed(1)}%`} />
       </div>
-      <RatingDistributionChart data={ship.ratingDistribution} />
+      <RatingDistributionChart
+        data={ship.ratingDistribution}
+        onBarClick={(star) => openPanel({ kind: "rating", star })}
+      />
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <ThemeChart title="Positive Themes" data={ship.positiveThemes} type="positive" onBarClick={(theme) => openPanel(theme, "positive")} />
-        <ThemeChart title="Negative Themes" data={ship.negativeThemes} type="negative" onBarClick={(theme) => openPanel(theme, "negative")} />
+        <ThemeChart title="Positive Themes" data={ship.positiveThemes} type="positive" onBarClick={(theme) => openPanel({ kind: "theme", theme, type: "positive" })} />
+        <ThemeChart title="Negative Themes" data={ship.negativeThemes} type="negative" onBarClick={(theme) => openPanel({ kind: "theme", theme, type: "negative" })} />
       </div>
       <div className="bg-surface rounded-lg shadow-sm p-6">
         <h3 className="text-lg font-semibold text-text-primary mb-4">Itineraries on This Ship</h3>
@@ -141,14 +218,17 @@ export default function ShipDetail({ slug }: { slug: string }) {
         </div>
       </div>
       <QuotesSection positiveQuotes={quotes.positive} negativeQuotes={quotes.negative} />
-      {panelOpen && (
+      {panelState && (
         <ReviewPanel
-          title={panelTheme}
-          subtitle={`Reviews matching the selected ${panelType} theme`}
-          accent={panelType}
+          title={panelTitle}
+          subtitle={panelSubtitle}
+          accent={panelAccent}
           reviews={panelReviews}
           loading={panelLoading}
           onClose={closePanel}
+          onLoadMore={loadMorePanel}
+          hasMore={panelHasMore}
+          loadingMore={panelLoadingMore}
         />
       )}
     </div>

--- a/app/src/lib/firestore/itinerary-queries.ts
+++ b/app/src/lib/firestore/itinerary-queries.ts
@@ -393,42 +393,42 @@ async function getItineraryReviewsFiltered(
   if (dateRange?.end) constraints.push(where(path, "<=", dateRange.end.toISOString()));
   constraints.push(orderBy(path, "desc"));
 
+  const targetSize = pageSize + 1;
   const reviews: ThemeReview[] = [];
-  let lastDoc: QueryDocumentSnapshot<DocumentData> | null = cursor;
-  let scanExhausted = false;
+  const matchDocs: QueryDocumentSnapshot<DocumentData>[] = [];
+  let scanCursor: QueryDocumentSnapshot<DocumentData> | null = cursor;
 
-  while (reviews.length < pageSize) {
+  outer: while (reviews.length < targetSize) {
     const pageConstraints: QueryConstraint[] = [
       ...constraints,
       limit(ITINERARY_REVIEW_BATCH_SIZE),
     ];
-    if (lastDoc) pageConstraints.push(startAfter(lastDoc));
+    if (scanCursor) pageConstraints.push(startAfter(scanCursor));
 
     const snap = await getDocs(query(ref, ...pageConstraints));
-    if (snap.empty) {
-      scanExhausted = true;
-      break;
-    }
+    if (snap.empty) break;
 
     for (const docSnap of snap.docs) {
+      scanCursor = docSnap;
       const data = docSnap.data();
-      lastDoc = docSnap;
       if (matcher(data)) {
         reviews.push(mapItineraryReviewDoc(docSnap.id, data, dateField));
-        if (reviews.length >= pageSize) break;
+        matchDocs.push(docSnap);
+        if (reviews.length >= targetSize) break outer;
       }
     }
 
-    if (snap.docs.length < ITINERARY_REVIEW_BATCH_SIZE) {
-      scanExhausted = true;
-      break;
-    }
+    if (snap.docs.length < ITINERARY_REVIEW_BATCH_SIZE) break;
   }
 
+  const hasMore = reviews.length > pageSize;
+  const pageReviews = reviews.slice(0, pageSize);
+  const pageMatchDocs = matchDocs.slice(0, pageSize);
+
   return {
-    reviews,
-    cursor: lastDoc,
-    hasMore: !scanExhausted,
+    reviews: pageReviews,
+    cursor: pageMatchDocs[pageMatchDocs.length - 1] ?? scanCursor,
+    hasMore,
   };
 }
 

--- a/app/src/lib/firestore/itinerary-queries.ts
+++ b/app/src/lib/firestore/itinerary-queries.ts
@@ -2,7 +2,14 @@
 
 import { getClientDb } from "@/lib/firebase";
 import type { DateField, DateRange } from "@/contexts/DashboardContext";
-import { dateFieldPath, getFleetSummaryByDateRange } from "@/lib/firestore/queries";
+import {
+  dateFieldPath,
+  getFleetSummaryByDateRange,
+  REVIEW_PANEL_PAGE_SIZE,
+  type ReviewPage,
+  type ReviewPageCursor,
+  type ThemeReview,
+} from "@/lib/firestore/queries";
 import {
   collection,
   query,
@@ -10,8 +17,15 @@ import {
   getDocs,
   orderBy,
   limit,
+  startAfter,
+  type DocumentData,
+  type QueryConstraint,
+  type QueryDocumentSnapshot,
 } from "firebase/firestore";
 import type { Quote } from "@/components/dashboard/QuotesSection";
+
+const ITINERARY_REVIEW_BATCH_SIZE = 200;
+const TOUR_IN_LIMIT = 30;
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -324,6 +338,145 @@ export async function getItineraryBySlug(
 ): Promise<ItinerarySummary | null> {
   const itineraries = await getItineraries(brand, dateRange, dateField);
   return itineraries.find((it) => it.slug === slug) ?? null;
+}
+
+function mapItineraryReviewDoc(
+  id: string,
+  data: DocumentData,
+  dateField: DateField
+): ThemeReview {
+  const dates = data.dates as { created?: unknown; lastUpdated?: unknown } | undefined;
+  const rawValue = dateField === "lastUpdated" ? dates?.lastUpdated : dates?.created;
+  const fallback = dateField === "lastUpdated" ? dates?.created : dates?.lastUpdated;
+  const date = typeof rawValue === "string" ? rawValue : typeof fallback === "string" ? fallback : "";
+
+  return {
+    id,
+    guestName: data.customer?.displayName || data.customer?.name || "Trusted Customer",
+    rating: data.ratings?.product ?? data.ratings?.service ?? 0,
+    itinerary: data.tags?.tour || data.product?.title || "",
+    ship: data.tags?.ship || "",
+    text: data.reviews?.productText || data.reviews?.serviceText || "",
+    date,
+    media: Array.isArray(data.media) ? data.media : [],
+  };
+}
+
+/**
+ * Scan reviews scoped to a specific itinerary's child tour names, applying an
+ * in-memory predicate (theme membership or star rating). Firestore disallows
+ * combining `in` with `array-contains` in one query, so we filter pages
+ * client-side.
+ */
+async function getItineraryReviewsFiltered(
+  brand: string,
+  childItineraries: string[],
+  matcher: (data: DocumentData) => boolean,
+  dateField: DateField,
+  dateRange: SummaryDateRange | undefined,
+  pageSize: number,
+  cursor: ReviewPageCursor
+): Promise<ReviewPage> {
+  const tourNames = (childItineraries.length > 0 ? childItineraries : [])
+    .slice(0, TOUR_IN_LIMIT);
+  if (tourNames.length === 0) {
+    return { reviews: [], cursor: null, hasMore: false };
+  }
+
+  const db = getClientDb();
+  const ref = collection(db, "reviews");
+  const path = dateFieldPath(dateField);
+  const constraints: QueryConstraint[] = [];
+  if (brand !== "combined") constraints.push(where("brand", "==", brand));
+  constraints.push(where("tags.tour", "in", tourNames));
+  if (dateRange?.start) constraints.push(where(path, ">=", dateRange.start.toISOString()));
+  if (dateRange?.end) constraints.push(where(path, "<=", dateRange.end.toISOString()));
+  constraints.push(orderBy(path, "desc"));
+
+  const reviews: ThemeReview[] = [];
+  let lastDoc: QueryDocumentSnapshot<DocumentData> | null = cursor;
+  let scanExhausted = false;
+
+  while (reviews.length < pageSize) {
+    const pageConstraints: QueryConstraint[] = [
+      ...constraints,
+      limit(ITINERARY_REVIEW_BATCH_SIZE),
+    ];
+    if (lastDoc) pageConstraints.push(startAfter(lastDoc));
+
+    const snap = await getDocs(query(ref, ...pageConstraints));
+    if (snap.empty) {
+      scanExhausted = true;
+      break;
+    }
+
+    for (const docSnap of snap.docs) {
+      const data = docSnap.data();
+      lastDoc = docSnap;
+      if (matcher(data)) {
+        reviews.push(mapItineraryReviewDoc(docSnap.id, data, dateField));
+        if (reviews.length >= pageSize) break;
+      }
+    }
+
+    if (snap.docs.length < ITINERARY_REVIEW_BATCH_SIZE) {
+      scanExhausted = true;
+      break;
+    }
+  }
+
+  return {
+    reviews,
+    cursor: lastDoc,
+    hasMore: !scanExhausted,
+  };
+}
+
+export async function getItineraryReviewsByTheme(
+  brand: string,
+  childItineraries: string[],
+  theme: string,
+  type: "positive" | "negative",
+  dateField: DateField,
+  dateRange: SummaryDateRange | undefined,
+  pageSize: number = REVIEW_PANEL_PAGE_SIZE,
+  cursor: ReviewPageCursor = null
+): Promise<ReviewPage> {
+  return getItineraryReviewsFiltered(
+    brand,
+    childItineraries,
+    (data) => {
+      const themes = data.themes?.[type];
+      return Array.isArray(themes) && themes.includes(theme);
+    },
+    dateField,
+    dateRange,
+    pageSize,
+    cursor
+  );
+}
+
+export async function getItineraryReviewsByStar(
+  brand: string,
+  childItineraries: string[],
+  star: number,
+  dateField: DateField,
+  dateRange: SummaryDateRange | undefined,
+  pageSize: number = REVIEW_PANEL_PAGE_SIZE,
+  cursor: ReviewPageCursor = null
+): Promise<ReviewPage> {
+  return getItineraryReviewsFiltered(
+    brand,
+    childItineraries,
+    (data) => {
+      const rating = data.ratings?.product ?? data.ratings?.service ?? null;
+      return typeof rating === "number" && Math.round(rating) === star;
+    },
+    dateField,
+    dateRange,
+    pageSize,
+    cursor
+  );
 }
 
 export async function getItineraryQuotes(

--- a/app/src/lib/firestore/queries.ts
+++ b/app/src/lib/firestore/queries.ts
@@ -72,13 +72,23 @@ export interface ThemeReview {
   media: { type: string; url: string }[];
 }
 
+/** Cursor for paged theme/rating panels. Opaque to callers. */
+export type ReviewPageCursor = QueryDocumentSnapshot<DocumentData> | null;
+
+export interface ReviewPage {
+  reviews: ThemeReview[];
+  cursor: ReviewPageCursor;
+  hasMore: boolean;
+}
+
+export const REVIEW_PANEL_PAGE_SIZE = 50;
+
 export type OverviewSelectionFilter =
   | { kind: "theme"; theme: string; sentiment: "positive" | "negative" }
   | { kind: "rating"; star: number }
   | { kind: "month"; month: string }
   | { kind: "period"; start: string; end: string; label: string };
 
-const PANEL_REVIEW_LIMIT = 100;
 const PANEL_REVIEW_BATCH_SIZE = 200;
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
@@ -612,46 +622,41 @@ export async function getFilterOptions(
   };
 }
 
+/**
+ * Fetch a page of reviews matching a theme. Pass the previous page's `cursor`
+ * to load the next page; pass `null` to start from the beginning.
+ */
 export async function getReviewsByTheme(
   brand: string,
   theme: string,
   type: "positive" | "negative",
   dateField: DateField,
-  startDate?: Date,
-  endDate?: Date
-): Promise<ThemeReview[]> {
+  startDate: Date | undefined,
+  endDate: Date | undefined,
+  pageSize: number = REVIEW_PANEL_PAGE_SIZE,
+  cursor: ReviewPageCursor = null
+): Promise<ReviewPage> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
   const path = dateFieldPath(dateField);
-  const fetchLimit = startDate && endDate ? 100 : 20;
-  const constraints = [
-    where(`themes.${type}`, "array-contains", theme),
-    orderBy(path, "desc"),
-    limit(fetchLimit),
-  ];
-  if (brand !== "combined") {
-    constraints.unshift(where("brand", "==", brand));
-  }
-  const q = query(ref, ...constraints);
-  const snap = await getDocs(q);
+  const constraints: QueryConstraint[] = [];
+  if (brand !== "combined") constraints.push(where("brand", "==", brand));
+  if (startDate) constraints.push(where(path, ">=", startDate.toISOString()));
+  if (endDate) constraints.push(where(path, "<=", endDate.toISOString()));
+  constraints.push(where(`themes.${type}`, "array-contains", theme));
+  constraints.push(orderBy(path, "desc"));
+  if (cursor) constraints.push(startAfter(cursor));
+  constraints.push(limit(pageSize));
 
-  if (snap.empty) return [];
-
-  const filteredDocs =
-    startDate && endDate
-      ? snap.docs.filter((docSnap) => {
-          const value = readDateFieldValue(docSnap.data(), dateField);
-          return (
-            typeof value === "string" &&
-            value >= startDate.toISOString() &&
-            value <= endDate.toISOString()
-          );
-        })
-      : snap.docs;
-
-  return filteredDocs.slice(0, 20).map((docSnap) =>
+  const snap = await getDocs(query(ref, ...constraints));
+  const reviews = snap.docs.map((docSnap) =>
     mapReviewDoc({ id: docSnap.id, data: docSnap.data() }, dateField)
   );
+  return {
+    reviews,
+    cursor: snap.docs[snap.docs.length - 1] ?? cursor,
+    hasMore: snap.docs.length === pageSize,
+  };
 }
 
 export async function getReviewsForOverviewSelection(
@@ -659,21 +664,47 @@ export async function getReviewsForOverviewSelection(
   startDate: Date,
   endDate: Date,
   filter: OverviewSelectionFilter,
-  dateField: DateField
-): Promise<ThemeReview[]> {
+  dateField: DateField,
+  pageSize: number = REVIEW_PANEL_PAGE_SIZE,
+  cursor: ReviewPageCursor = null
+): Promise<ReviewPage> {
   if (filter.kind === "theme") {
-    return getThemeSelectionReviews(brand, startDate, endDate, filter, dateField);
+    return getReviewsByTheme(
+      brand,
+      filter.theme,
+      filter.sentiment,
+      dateField,
+      startDate,
+      endDate,
+      pageSize,
+      cursor
+    );
   }
 
   if (filter.kind === "period") {
-    return getPeriodSelectionReviews(brand, filter.start, filter.end, dateField);
+    return getPeriodSelectionReviews(
+      brand,
+      filter.start,
+      filter.end,
+      dateField,
+      pageSize,
+      cursor
+    );
   }
 
   if (filter.kind === "month") {
-    return getMonthSelectionReviews(brand, filter.month, dateField);
+    return getMonthSelectionReviews(brand, filter.month, dateField, pageSize, cursor);
   }
 
-  return getRatingSelectionReviews(brand, startDate, endDate, filter.star, dateField);
+  return getRatingSelectionReviews(
+    brand,
+    startDate,
+    endDate,
+    filter.star,
+    dateField,
+    pageSize,
+    cursor
+  );
 }
 
 function readDateFieldValue(data: DocumentData, dateField: DateField): string {
@@ -995,57 +1026,49 @@ function buildDateRangeConstraints(
   return constraints;
 }
 
-async function getThemeSelectionReviews(
-  brand: string,
-  startDate: Date,
-  endDate: Date,
-  filter: Extract<OverviewSelectionFilter, { kind: "theme" }>,
-  dateField: DateField
-): Promise<ThemeReview[]> {
-  const db = getClientDb();
-  const ref = collection(db, "reviews");
-  const constraints = [
-    ...buildDateRangeConstraints(brand, startDate.toISOString(), endDate.toISOString(), "<=", dateField),
-    where(`themes.${filter.sentiment}`, "array-contains", filter.theme),
-    limit(PANEL_REVIEW_LIMIT),
-  ];
-
-  try {
-    const snap = await getDocs(query(ref, ...constraints));
-    return snap.docs.map((docSnap) =>
-      mapReviewDoc({ id: docSnap.id, data: docSnap.data() }, dateField)
-    );
-  } catch (error) {
-    console.warn("Falling back to paged theme filtering for overview selection", error);
-    return getFilteredPagedReviews(brand, startDate, endDate, filter, dateField);
-  }
-}
-
 async function getMonthSelectionReviews(
   brand: string,
   month: string,
-  dateField: DateField
-): Promise<ThemeReview[]> {
+  dateField: DateField,
+  pageSize: number,
+  cursor: ReviewPageCursor
+): Promise<ReviewPage> {
   const bounds = getMonthBounds(month);
-  return getPeriodSelectionReviews(brand, bounds.start, bounds.end, dateField);
+  return getPeriodSelectionReviews(
+    brand,
+    bounds.start,
+    bounds.end,
+    dateField,
+    pageSize,
+    cursor
+  );
 }
 
 async function getPeriodSelectionReviews(
   brand: string,
   periodStart: string,
   periodEnd: string,
-  dateField: DateField
-): Promise<ThemeReview[]> {
+  dateField: DateField,
+  pageSize: number,
+  cursor: ReviewPageCursor
+): Promise<ReviewPage> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
-  const constraints = [
+  const constraints: QueryConstraint[] = [
     ...buildDateRangeConstraints(brand, periodStart, periodEnd, "<", dateField),
-    limit(PANEL_REVIEW_LIMIT),
   ];
+  if (cursor) constraints.push(startAfter(cursor));
+  constraints.push(limit(pageSize));
+
   const snap = await getDocs(query(ref, ...constraints));
-  return snap.docs.map((docSnap) =>
+  const reviews = snap.docs.map((docSnap) =>
     mapReviewDoc({ id: docSnap.id, data: docSnap.data() }, dateField)
   );
+  return {
+    reviews,
+    cursor: snap.docs[snap.docs.length - 1] ?? cursor,
+    hasMore: snap.docs.length === pageSize,
+  };
 }
 
 async function getRatingSelectionReviews(
@@ -1053,14 +1076,18 @@ async function getRatingSelectionReviews(
   startDate: Date,
   endDate: Date,
   star: number,
-  dateField: DateField
-): Promise<ThemeReview[]> {
+  dateField: DateField,
+  pageSize: number,
+  cursor: ReviewPageCursor
+): Promise<ReviewPage> {
   return getFilteredPagedReviews(
     brand,
     startDate,
     endDate,
     { kind: "rating", star },
-    dateField
+    dateField,
+    pageSize,
+    cursor
   );
 }
 
@@ -1069,8 +1096,10 @@ async function getFilteredPagedReviews(
   startDate: Date,
   endDate: Date,
   filter: OverviewSelectionFilter,
-  dateField: DateField
-): Promise<ThemeReview[]> {
+  dateField: DateField,
+  pageSize: number,
+  cursor: ReviewPageCursor
+): Promise<ReviewPage> {
   const db = getClientDb();
   const ref = collection(db, "reviews");
   const constraints = buildDateRangeConstraints(
@@ -1081,16 +1110,18 @@ async function getFilteredPagedReviews(
     dateField
   );
   const reviews: ThemeReview[] = [];
-  let lastDoc: QueryDocumentSnapshot<DocumentData> | null = null;
+  let lastDoc: QueryDocumentSnapshot<DocumentData> | null = cursor;
+  let scanExhausted = false;
 
-  while (reviews.length < PANEL_REVIEW_LIMIT) {
-    const pageConstraints = [...constraints, limit(PANEL_REVIEW_BATCH_SIZE)];
+  while (reviews.length < pageSize) {
+    const pageConstraints: QueryConstraint[] = [...constraints, limit(PANEL_REVIEW_BATCH_SIZE)];
     if (lastDoc) {
       pageConstraints.push(startAfter(lastDoc));
     }
 
     const snap = await getDocs(query(ref, ...pageConstraints));
     if (snap.empty) {
+      scanExhausted = true;
       break;
     }
 
@@ -1098,18 +1129,22 @@ async function getFilteredPagedReviews(
       const data = docSnap.data();
       if (matchesOverviewSelection(data, filter, dateField)) {
         reviews.push(mapReviewDoc({ id: docSnap.id, data }, dateField));
-        if (reviews.length >= PANEL_REVIEW_LIMIT) {
-          break;
-        }
+        lastDoc = docSnap;
+        if (reviews.length >= pageSize) break;
+      } else {
+        lastDoc = docSnap;
       }
     }
 
     if (snap.docs.length < PANEL_REVIEW_BATCH_SIZE) {
+      scanExhausted = true;
       break;
     }
-
-    lastDoc = snap.docs[snap.docs.length - 1];
   }
 
-  return reviews;
+  return {
+    reviews,
+    cursor: lastDoc,
+    hasMore: !scanExhausted,
+  };
 }

--- a/app/src/lib/firestore/queries.ts
+++ b/app/src/lib/firestore/queries.ts
@@ -646,16 +646,20 @@ export async function getReviewsByTheme(
   constraints.push(where(`themes.${type}`, "array-contains", theme));
   constraints.push(orderBy(path, "desc"));
   if (cursor) constraints.push(startAfter(cursor));
-  constraints.push(limit(pageSize));
+  // Fetch one extra row to know if a next page exists without lying when
+  // the result count exactly equals pageSize.
+  constraints.push(limit(pageSize + 1));
 
   const snap = await getDocs(query(ref, ...constraints));
-  const reviews = snap.docs.map((docSnap) =>
+  const hasMore = snap.docs.length > pageSize;
+  const pageDocs = snap.docs.slice(0, pageSize);
+  const reviews = pageDocs.map((docSnap) =>
     mapReviewDoc({ id: docSnap.id, data: docSnap.data() }, dateField)
   );
   return {
     reviews,
-    cursor: snap.docs[snap.docs.length - 1] ?? cursor,
-    hasMore: snap.docs.length === pageSize,
+    cursor: pageDocs[pageDocs.length - 1] ?? cursor,
+    hasMore,
   };
 }
 
@@ -1058,16 +1062,18 @@ async function getPeriodSelectionReviews(
     ...buildDateRangeConstraints(brand, periodStart, periodEnd, "<", dateField),
   ];
   if (cursor) constraints.push(startAfter(cursor));
-  constraints.push(limit(pageSize));
+  constraints.push(limit(pageSize + 1));
 
   const snap = await getDocs(query(ref, ...constraints));
-  const reviews = snap.docs.map((docSnap) =>
+  const hasMore = snap.docs.length > pageSize;
+  const pageDocs = snap.docs.slice(0, pageSize);
+  const reviews = pageDocs.map((docSnap) =>
     mapReviewDoc({ id: docSnap.id, data: docSnap.data() }, dateField)
   );
   return {
     reviews,
-    cursor: snap.docs[snap.docs.length - 1] ?? cursor,
-    hasMore: snap.docs.length === pageSize,
+    cursor: pageDocs[pageDocs.length - 1] ?? cursor,
+    hasMore,
   };
 }
 
@@ -1109,42 +1115,41 @@ async function getFilteredPagedReviews(
     "<=",
     dateField
   );
+  // Fetch one extra match so hasMore reflects whether a real next page exists.
+  const targetSize = pageSize + 1;
   const reviews: ThemeReview[] = [];
-  let lastDoc: QueryDocumentSnapshot<DocumentData> | null = cursor;
-  let scanExhausted = false;
+  const matchDocs: QueryDocumentSnapshot<DocumentData>[] = [];
+  let scanCursor: QueryDocumentSnapshot<DocumentData> | null = cursor;
 
-  while (reviews.length < pageSize) {
+  outer: while (reviews.length < targetSize) {
     const pageConstraints: QueryConstraint[] = [...constraints, limit(PANEL_REVIEW_BATCH_SIZE)];
-    if (lastDoc) {
-      pageConstraints.push(startAfter(lastDoc));
+    if (scanCursor) {
+      pageConstraints.push(startAfter(scanCursor));
     }
 
     const snap = await getDocs(query(ref, ...pageConstraints));
-    if (snap.empty) {
-      scanExhausted = true;
-      break;
-    }
+    if (snap.empty) break;
 
     for (const docSnap of snap.docs) {
+      scanCursor = docSnap;
       const data = docSnap.data();
       if (matchesOverviewSelection(data, filter, dateField)) {
         reviews.push(mapReviewDoc({ id: docSnap.id, data }, dateField));
-        lastDoc = docSnap;
-        if (reviews.length >= pageSize) break;
-      } else {
-        lastDoc = docSnap;
+        matchDocs.push(docSnap);
+        if (reviews.length >= targetSize) break outer;
       }
     }
 
-    if (snap.docs.length < PANEL_REVIEW_BATCH_SIZE) {
-      scanExhausted = true;
-      break;
-    }
+    if (snap.docs.length < PANEL_REVIEW_BATCH_SIZE) break;
   }
 
+  const hasMore = reviews.length > pageSize;
+  const pageReviews = reviews.slice(0, pageSize);
+  const pageMatchDocs = matchDocs.slice(0, pageSize);
+
   return {
-    reviews,
-    cursor: lastDoc,
-    hasMore: !scanExhausted,
+    reviews: pageReviews,
+    cursor: pageMatchDocs[pageMatchDocs.length - 1] ?? scanCursor,
+    hasMore,
   };
 }

--- a/app/src/lib/firestore/ship-queries.ts
+++ b/app/src/lib/firestore/ship-queries.ts
@@ -2,7 +2,14 @@
 
 import { getClientDb } from "@/lib/firebase";
 import type { DateField, DateRange } from "@/contexts/DashboardContext";
-import { dateFieldPath, getFleetSummaryByDateRange } from "@/lib/firestore/queries";
+import {
+  dateFieldPath,
+  getFleetSummaryByDateRange,
+  REVIEW_PANEL_PAGE_SIZE,
+  type ReviewPage,
+  type ReviewPageCursor,
+  type ThemeReview,
+} from "@/lib/firestore/queries";
 import {
   collection,
   query,
@@ -10,8 +17,14 @@ import {
   getDocs,
   orderBy,
   limit,
+  startAfter,
+  type DocumentData,
+  type QueryConstraint,
+  type QueryDocumentSnapshot,
 } from "firebase/firestore";
 import type { Quote } from "@/components/dashboard/QuotesSection";
+
+const SHIP_REVIEW_BATCH_SIZE = 200;
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -361,6 +374,142 @@ export async function getShipBySlug(
 ): Promise<ShipSummary | null> {
   const ships = await getShips(brand, dateRange, dateField);
   return ships.find((s) => s.slug === slug) ?? null;
+}
+
+function mapShipReviewDoc(
+  id: string,
+  data: DocumentData,
+  dateField: DateField
+): ThemeReview {
+  const dates = data.dates as { created?: unknown; lastUpdated?: unknown } | undefined;
+  const rawValue = dateField === "lastUpdated" ? dates?.lastUpdated : dates?.created;
+  const fallback = dateField === "lastUpdated" ? dates?.created : dates?.lastUpdated;
+  const date = typeof rawValue === "string" ? rawValue : typeof fallback === "string" ? fallback : "";
+
+  return {
+    id,
+    guestName: data.customer?.displayName || data.customer?.name || "Trusted Customer",
+    rating: data.ratings?.product ?? data.ratings?.service ?? 0,
+    itinerary: data.tags?.tour || data.product?.title || "",
+    ship: data.tags?.ship || "",
+    text: data.reviews?.productText || data.reviews?.serviceText || "",
+    date,
+    media: Array.isArray(data.media) ? data.media : [],
+  };
+}
+
+/**
+ * Scan reviews scoped to a single ship with an in-memory predicate (theme
+ * membership or star rating). Mirrors the itinerary-queries pattern so theme
+ * and rating panels filter to the ship in view.
+ */
+async function getShipReviewsFiltered(
+  brand: string,
+  shipName: string,
+  matcher: (data: DocumentData) => boolean,
+  dateField: DateField,
+  dateRange: SummaryDateRange | undefined,
+  pageSize: number,
+  cursor: ReviewPageCursor
+): Promise<ReviewPage> {
+  if (!shipName) {
+    return { reviews: [], cursor: null, hasMore: false };
+  }
+
+  const db = getClientDb();
+  const ref = collection(db, "reviews");
+  const path = dateFieldPath(dateField);
+  const constraints: QueryConstraint[] = [];
+  if (brand !== "combined") constraints.push(where("brand", "==", brand));
+  constraints.push(where("tags.ship", "==", shipName));
+  if (dateRange?.start) constraints.push(where(path, ">=", dateRange.start.toISOString()));
+  if (dateRange?.end) constraints.push(where(path, "<=", dateRange.end.toISOString()));
+  constraints.push(orderBy(path, "desc"));
+
+  const reviews: ThemeReview[] = [];
+  let lastDoc: QueryDocumentSnapshot<DocumentData> | null = cursor;
+  let scanExhausted = false;
+
+  while (reviews.length < pageSize) {
+    const pageConstraints: QueryConstraint[] = [
+      ...constraints,
+      limit(SHIP_REVIEW_BATCH_SIZE),
+    ];
+    if (lastDoc) pageConstraints.push(startAfter(lastDoc));
+
+    const snap = await getDocs(query(ref, ...pageConstraints));
+    if (snap.empty) {
+      scanExhausted = true;
+      break;
+    }
+
+    for (const docSnap of snap.docs) {
+      const data = docSnap.data();
+      lastDoc = docSnap;
+      if (matcher(data)) {
+        reviews.push(mapShipReviewDoc(docSnap.id, data, dateField));
+        if (reviews.length >= pageSize) break;
+      }
+    }
+
+    if (snap.docs.length < SHIP_REVIEW_BATCH_SIZE) {
+      scanExhausted = true;
+      break;
+    }
+  }
+
+  return {
+    reviews,
+    cursor: lastDoc,
+    hasMore: !scanExhausted,
+  };
+}
+
+export async function getShipReviewsByTheme(
+  brand: string,
+  shipName: string,
+  theme: string,
+  type: "positive" | "negative",
+  dateField: DateField,
+  dateRange: SummaryDateRange | undefined,
+  pageSize: number = REVIEW_PANEL_PAGE_SIZE,
+  cursor: ReviewPageCursor = null
+): Promise<ReviewPage> {
+  return getShipReviewsFiltered(
+    brand,
+    shipName,
+    (data) => {
+      const themes = data.themes?.[type];
+      return Array.isArray(themes) && themes.includes(theme);
+    },
+    dateField,
+    dateRange,
+    pageSize,
+    cursor
+  );
+}
+
+export async function getShipReviewsByStar(
+  brand: string,
+  shipName: string,
+  star: number,
+  dateField: DateField,
+  dateRange: SummaryDateRange | undefined,
+  pageSize: number = REVIEW_PANEL_PAGE_SIZE,
+  cursor: ReviewPageCursor = null
+): Promise<ReviewPage> {
+  return getShipReviewsFiltered(
+    brand,
+    shipName,
+    (data) => {
+      const rating = data.ratings?.product ?? data.ratings?.service ?? null;
+      return typeof rating === "number" && Math.round(rating) === star;
+    },
+    dateField,
+    dateRange,
+    pageSize,
+    cursor
+  );
 }
 
 export async function getShipQuotes(

--- a/app/src/lib/firestore/ship-queries.ts
+++ b/app/src/lib/firestore/ship-queries.ts
@@ -426,42 +426,42 @@ async function getShipReviewsFiltered(
   if (dateRange?.end) constraints.push(where(path, "<=", dateRange.end.toISOString()));
   constraints.push(orderBy(path, "desc"));
 
+  const targetSize = pageSize + 1;
   const reviews: ThemeReview[] = [];
-  let lastDoc: QueryDocumentSnapshot<DocumentData> | null = cursor;
-  let scanExhausted = false;
+  const matchDocs: QueryDocumentSnapshot<DocumentData>[] = [];
+  let scanCursor: QueryDocumentSnapshot<DocumentData> | null = cursor;
 
-  while (reviews.length < pageSize) {
+  outer: while (reviews.length < targetSize) {
     const pageConstraints: QueryConstraint[] = [
       ...constraints,
       limit(SHIP_REVIEW_BATCH_SIZE),
     ];
-    if (lastDoc) pageConstraints.push(startAfter(lastDoc));
+    if (scanCursor) pageConstraints.push(startAfter(scanCursor));
 
     const snap = await getDocs(query(ref, ...pageConstraints));
-    if (snap.empty) {
-      scanExhausted = true;
-      break;
-    }
+    if (snap.empty) break;
 
     for (const docSnap of snap.docs) {
+      scanCursor = docSnap;
       const data = docSnap.data();
-      lastDoc = docSnap;
       if (matcher(data)) {
         reviews.push(mapShipReviewDoc(docSnap.id, data, dateField));
-        if (reviews.length >= pageSize) break;
+        matchDocs.push(docSnap);
+        if (reviews.length >= targetSize) break outer;
       }
     }
 
-    if (snap.docs.length < SHIP_REVIEW_BATCH_SIZE) {
-      scanExhausted = true;
-      break;
-    }
+    if (snap.docs.length < SHIP_REVIEW_BATCH_SIZE) break;
   }
 
+  const hasMore = reviews.length > pageSize;
+  const pageReviews = reviews.slice(0, pageSize);
+  const pageMatchDocs = matchDocs.slice(0, pageSize);
+
   return {
-    reviews,
-    cursor: lastDoc,
-    hasMore: !scanExhausted,
+    reviews: pageReviews,
+    cursor: pageMatchDocs[pageMatchDocs.length - 1] ?? scanCursor,
+    hasMore,
   };
 }
 

--- a/app/src/lib/format/date.ts
+++ b/app/src/lib/format/date.ts
@@ -1,0 +1,21 @@
+/**
+ * Locale-aware date formatting for review timestamps.
+ * Falls back gracefully if `navigator` is unavailable (SSR) or the value
+ * isn't a parseable ISO date.
+ */
+export function formatReviewDate(iso: string): string {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+
+  const locale =
+    typeof navigator !== "undefined" && navigator.language
+      ? navigator.language
+      : undefined;
+
+  return new Intl.DateTimeFormat(locale, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(date);
+}

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -138,6 +138,22 @@
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
+        { "fieldPath": "tags.ship", "order": "ASCENDING" },
+        { "fieldPath": "dates.created", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "tags.ship", "order": "ASCENDING" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
         { "fieldPath": "brand", "order": "ASCENDING" },
         { "fieldPath": "tags.ship", "order": "ASCENDING" },
         { "fieldPath": "dates.created", "order": "DESCENDING" }
@@ -238,6 +254,38 @@
       "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "brand", "order": "ASCENDING" },
+        { "fieldPath": "themes.negative", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "themes.positive", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "dates.created", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "themes.positive", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "themes.negative", "arrayConfig": "CONTAINS" },
+        { "fieldPath": "dates.created", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
         { "fieldPath": "themes.negative", "arrayConfig": "CONTAINS" },
         { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
       ]


### PR DESCRIPTION
## Summary

- Rating-distribution and theme bars on the itinerary and ship detail pages now open a side panel scoped to that itinerary/ship (previously theme clicks pulled reviews from every itinerary, and rating bars did nothing).
- Side panels are paginated 50 reviews per page with a **Show more** button. Cursor-based pagination, applied across overview, itinerary, and ship panels.
- Review dates render in the user's locale (`Intl.DateTimeFormat(navigator.language, …)`) in both the side panel and the Guest Quotes section.
- Added missing Firestore composite indexes (`tags.ship + dates.{created,lastUpdated}` and `themes.{positive,negative} + dates.{created,lastUpdated}`) so cross-brand "All" queries work. Indexes already deployed to production.

## Files of note

- `app/src/lib/firestore/queries.ts` — `getReviewsByTheme` and `getReviewsForOverviewSelection` now return `{ reviews, cursor, hasMore }` with a 50-default page size.
- `app/src/lib/firestore/itinerary-queries.ts` — new `getItineraryReviewsByTheme` and `getItineraryReviewsByStar` (filter by `tags.tour IN childItineraries`).
- `app/src/lib/firestore/ship-queries.ts` — new `getShipReviewsByTheme` and `getShipReviewsByStar` (filter by `tags.ship == shipName`).
- `app/src/components/dashboard/ReviewPanel.tsx` — `onLoadMore` / `hasMore` / `loadingMore` props plus localized date metadata.
- `app/src/lib/format/date.ts` — locale-aware date helper.
- `firestore.indexes.json` — 6 new composite indexes.

## Test plan

- [ ] Itinerary detail (e.g. `/itineraries?slug=splendors-of-egypt-the-nile`): click any rating bar → panel opens with N-star reviews scoped to that itinerary, dates localized.
- [ ] Itinerary detail: click a positive/negative theme bar → panel reviews are scoped to this itinerary only (verify itinerary column on each card).
- [ ] Ship detail (e.g. `/ships?slug=s-s-joie-de-vivre`): same flow — rating bar and theme bar clicks open ship-scoped panels.
- [ ] When a panel has more than 50 matching reviews, **Show more** appends the next 50.
- [ ] Guest Quotes cards show localized dates next to itinerary · ship.
- [ ] Overview page theme/rating/period/month bar clicks still work and now support **Show more**.
- [ ] Switch merchant header to "All" and confirm the Ships and Itineraries pages load (depends on the new indexes — already deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)