### PR TITLE
Restore themes-on-insert fix to prevent unclassified reviews

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -7,6 +7,7 @@ import { timingSafeEqual } from "crypto";
 import { syncAll } from "./sync/sync-reviews";
 import { computeSummaries } from "./sync/compute-summaries";
 import { submitClassificationBatch, processBatchResults } from "./sync/batch-classify";
+import { backfillMissingThemes } from "./sync/backfill-themes";
 import {
   deleteAdminUser,
   getAdminUserByEmail,
@@ -464,6 +465,38 @@ export const batchClassify = onRequest(
     }
 
     res.status(400).json({ error: "Invalid action. Use 'submit' or 'results'." });
+  }
+);
+
+// One-shot repair: re-seed the default `themes` map on review documents that
+// are missing it. Whenever the sync regresses and writes new reviews without
+// `themes`, the classifier silently skips them (its `themes.classifiedAt ==
+// null` query does not match documents where the field is absent). After
+// fixing the sync, call this endpoint once to recover the affected docs.
+// Paginate by passing `since` (ISO timestamp) and `maxDocs`; the response
+// returns `done`, `repaired`, and `lastScannedId` so you can call again.
+export const backfillThemes = onRequest(
+  { timeoutSeconds: 540, memory: "1GiB", invoker: "public", cors: ALLOWED_ORIGINS },
+  async (req, res) => {
+    if (!ensurePost(req, res)) return;
+    const caller = await authorizeRequest(req, res, "batchClassify");
+    if (!caller) return;
+
+    const since = typeof req.body?.since === "string" ? req.body.since : null;
+    const maxDocs =
+      typeof req.body?.maxDocs === "number" && req.body.maxDocs > 0
+        ? Math.min(req.body.maxDocs, 20000)
+        : undefined;
+
+    const result = await backfillMissingThemes({
+      since,
+      maxDocs,
+      source: "manual",
+      actorEmail: caller.email,
+      actorUid: caller.uid,
+    });
+    console.log(`backfillThemes by ${caller.source}:${caller.email ?? caller.uid}`, result);
+    res.json(result);
   }
 );
 

--- a/functions/src/sync/backfill-themes.ts
+++ b/functions/src/sync/backfill-themes.ts
@@ -1,0 +1,143 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { writeOperationLog, type OperationLogSource } from "../ops/operation-logs";
+
+interface BackfillThemesResult {
+  scanned: number;
+  repaired: number;
+  alreadyOk: number;
+  errors: number;
+  done: boolean;
+  lastScannedId: string | null;
+}
+
+interface BackfillThemesOptions {
+  since?: string | null;
+  maxDocs?: number;
+  source?: OperationLogSource;
+  actorEmail?: string | null;
+  actorUid?: string | null;
+}
+
+const DEFAULT_MAX_DOCS = 5000;
+const PAGE_SIZE = 500;
+
+/**
+ * Re-add the default `themes` map to review documents that are missing it.
+ *
+ * Between the 2026-03-28 sync change and the follow-up fix, new reviews were
+ * written without a `themes` field. The classifier query
+ * `where("themes.classifiedAt", "==", null)` does not match documents where
+ * the field is absent, so those reviews never reached the classifier and
+ * never received theme tags.
+ *
+ * This backfill walks reviews in sync order and re-seeds the default themes
+ * map (`{ positive: [], negative: [], classifiedAt: null }`) wherever it is
+ * missing, so the next classifier run will pick them up.
+ */
+export async function backfillMissingThemes(
+  options: BackfillThemesOptions = {}
+): Promise<BackfillThemesResult> {
+  const db = getFirestore();
+  const maxDocs = options.maxDocs ?? DEFAULT_MAX_DOCS;
+  const since = options.since ?? null;
+
+  const result: BackfillThemesResult = {
+    scanned: 0,
+    repaired: 0,
+    alreadyOk: 0,
+    errors: 0,
+    done: false,
+    lastScannedId: null,
+  };
+
+  let cursor: FirebaseFirestore.QueryDocumentSnapshot | null = null;
+
+  while (result.scanned < maxDocs) {
+    let q = db
+      .collection("reviews")
+      .orderBy("dates.synced", "desc")
+      .limit(PAGE_SIZE);
+
+    if (since) {
+      q = q.where("dates.synced", ">=", since) as typeof q;
+    }
+    if (cursor) {
+      q = q.startAfter(cursor);
+    }
+
+    const snapshot = await q.get();
+    if (snapshot.empty) {
+      result.done = true;
+      break;
+    }
+
+    const writer = db.bulkWriter();
+    writer.onWriteError((err) => {
+      if (err.failedAttempts < 3) return true;
+      result.errors += 1;
+      return false;
+    });
+
+    for (const doc of snapshot.docs) {
+      result.scanned += 1;
+      result.lastScannedId = doc.id;
+
+      const data = doc.data() as Record<string, unknown>;
+      const themes = data.themes as
+        | {
+            positive?: unknown;
+            negative?: unknown;
+            classifiedAt?: unknown;
+          }
+        | undefined;
+
+      const positiveOk = Array.isArray(themes?.positive);
+      const negativeOk = Array.isArray(themes?.negative);
+      const classifiedAtOk =
+        themes !== undefined && "classifiedAt" in themes;
+
+      if (themes && positiveOk && negativeOk && classifiedAtOk) {
+        result.alreadyOk += 1;
+        continue;
+      }
+
+      const repaired = {
+        positive: positiveOk ? (themes!.positive as string[]) : [],
+        negative: negativeOk ? (themes!.negative as string[]) : [],
+        classifiedAt: classifiedAtOk ? themes!.classifiedAt : null,
+      };
+
+      writer.set(doc.ref, { themes: repaired }, { merge: true });
+      result.repaired += 1;
+    }
+
+    await writer.close();
+
+    if (snapshot.docs.length < PAGE_SIZE) {
+      result.done = true;
+      break;
+    }
+
+    cursor = snapshot.docs[snapshot.docs.length - 1];
+  }
+
+  await writeOperationLog({
+    type: "sync",
+    level: result.errors > 0 ? "error" : "success",
+    action: "themes_backfill",
+    message: `Backfilled missing themes on ${result.repaired} review(s)`,
+    source: options.source ?? "manual",
+    actorEmail: options.actorEmail ?? null,
+    actorUid: options.actorUid ?? null,
+    details: {
+      scanned: result.scanned,
+      repaired: result.repaired,
+      alreadyOk: result.alreadyOk,
+      errors: result.errors,
+      done: result.done,
+      since,
+    },
+  });
+
+  return result;
+}

--- a/functions/src/sync/sync-reviews.ts
+++ b/functions/src/sync/sync-reviews.ts
@@ -129,9 +129,24 @@ export async function syncBrand(
       }
 
       // Write this page to Firestore immediately.
-      // We intentionally strip `themes` and only merge the remaining fields
-      // so that any existing theme/classification data on a review is preserved
-      // and managed by the batch-classify pipeline, not overwritten by sync.
+      //
+      // Themes handling — DO NOT "simplify" by always stripping themes.
+      // The batch classifier finds work via
+      //   .where("themes.classifiedAt", "==", null)
+      // and Firestore's `== null` does NOT match documents where the field
+      // is missing. So:
+      //
+      //   * For brand-new reviews we MUST write the default themes map
+      //     ({ positive: [], negative: [], classifiedAt: null }) so the
+      //     classifier can see them on the next pass.
+      //   * For existing reviews we strip themes from the merge payload
+      //     so the classifier's previous output (positive/negative arrays
+      //     and classifiedAt timestamp) is preserved across re-syncs.
+      //
+      // A previous regression silently dropped the new-review branch and
+      // left ~11 days of reviews permanently unclassified — see the
+      // `backfillThemes` HTTP endpoint and the operation logs around
+      // 2026-05-04 for the recovery procedure.
       const reviewRefs = pageReviews.map((doc) => db.collection("reviews").doc(doc.id));
       const existingSnapshots =
         reviewRefs.length > 0 ? await db.getAll(...reviewRefs) : [];
@@ -147,7 +162,8 @@ export async function syncBrand(
             ? existingData.dates.lastUpdated
             : null;
 
-        if (!existingSnapshot?.exists) {
+        const isNew = !existingSnapshot?.exists;
+        if (isNew) {
           result.newReviews += 1;
         } else if (isIncomingReviewNewer(existingLastUpdated, doc.dates.lastUpdated)) {
           result.updatedReviews += 1;
@@ -156,7 +172,12 @@ export async function syncBrand(
         }
 
         result.writtenReviews += 1;
-        writer.set(db.collection("reviews").doc(doc.id), docWithoutThemes, { merge: true });
+        // See the comment above this loop: include themes only on new
+        // inserts; preserve existing themes by stripping them on update.
+        const payload = isNew
+          ? { ...docWithoutThemes, themes }
+          : docWithoutThemes;
+        writer.set(db.collection("reviews").doc(doc.id), payload, { merge: true });
       }
       await writer.close();
 


### PR DESCRIPTION
## Summary

- Re-applies the fix that ensures the default `themes` map is written on brand-new review inserts. Without it, the batch classifier's `themes.classifiedAt == null` query never matches new docs (Firestore `== null` excludes missing fields), so they remain unclassified forever.
- Adds a `backfillThemes` HTTP endpoint that re-seeds the default themes map on docs missing it. Idempotent and paginated.

## Why this PR exists

This is the same fix that was deployed manually on **2026-04-23**, but it was never committed to git. PR #44 (`Stable doc IDs`, commit `21c0b4a`, merged 2026-04-28) refactored the same loop in `sync-reviews.ts` without the new-review branch. CI auto-deployed from `main` on Apr 28 and **silently reverted the production fix**. Roughly 11 days of new reviews then accumulated without themes. The Overview's _This Week_ / _This Month_ theme charts were empty as a result.

The `sync-reviews.ts` comment now explicitly references the regression so a future "simplification" pass doesn't drop the new-insert branch again.

## Recovery already executed against production

- Manual deploy from this branch on 2026-05-04.
- `backfillThemes` with `since: 2026-04-24` → repaired 127 reviews (369 already-OK).
- `batchClassify` submitted: batch `msgbatch_01JynmnGRKjdjx2NrTw3HcGS`, 96 reviews queued. Polling for results.

Merging this PR makes the recovery permanent — without it, the next CI deploy from `main` would re-introduce the bug.

## Test plan

- [x] Local `tsc` build passes
- [x] Production deploy succeeded (`backfillThemes` created, all other functions updated)
- [x] Backfill endpoint repaired the expected number of docs (127)
- [x] Classification batch accepted 96 reviews
- [ ] Batch reaches `complete` status and Overview _This Month_ shows populated theme charts (in progress at PR open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)