### PR TITLE
Align date-range presets with Feefo's filter set

### DIFF
--- a/app/src/components/layout/DateRangePicker.tsx
+++ b/app/src/components/layout/DateRangePicker.tsx
@@ -8,16 +8,21 @@ import {
   type DatePreset,
 } from "@/contexts/DashboardContext";
 
+// Order mirrors Feefo's date filter (Today first, calendar-aligned options
+// grouped together, All Time last). Keep this list in sync with the
+// `DatePreset` union in DashboardContext.
 const presets: DatePreset[] = [
-  "This Week",
-  "This Month",
-  "Last Quarter",
-  "Last 6 Months",
-  "YTD",
+  "Today",
+  "Yesterday",
+  "Last 7 Days",
+  "Last 30 Days",
   "Last 12 Months",
-  "Last 2 Years",
-  "Last 5 Years",
-  "Last 10 Years",
+  "Current Calendar Week",
+  "Current Calendar Month",
+  "Current Calendar Year",
+  "Last Calendar Week",
+  "Last Calendar Month",
+  "Last Calendar Year",
   "All Time",
   "Custom Range",
 ];

--- a/app/src/contexts/DashboardContext.tsx
+++ b/app/src/contexts/DashboardContext.tsx
@@ -16,7 +16,20 @@ import {
   useCallback,
   type ReactNode,
 } from "react";
-import { subMonths, subYears, startOfMonth, startOfYear, startOfWeek } from "date-fns";
+import {
+  endOfDay,
+  endOfMonth,
+  endOfWeek,
+  endOfYear,
+  startOfDay,
+  startOfMonth,
+  startOfWeek,
+  startOfYear,
+  subDays,
+  subMonths,
+  subWeeks,
+  subYears,
+} from "date-fns";
 import { usePersistedState } from "@/hooks/usePersistedState";
 
 export type DateField = "lastUpdated" | "created";
@@ -32,18 +45,57 @@ function isDateField(value: unknown): value is DateField {
   return typeof value === "string" && (VALID_DATE_FIELDS as readonly string[]).includes(value);
 }
 
+// Preset names mirror Feefo's date filter exactly so the dashboard's filter
+// vocabulary matches the source system reviewers are already used to.
 export type DatePreset =
-  | "This Week"
-  | "This Month"
-  | "Last Quarter"
-  | "Last 6 Months"
-  | "YTD"
+  | "Today"
+  | "Yesterday"
+  | "Last 7 Days"
+  | "Last 30 Days"
   | "Last 12 Months"
-  | "Last 2 Years"
-  | "Last 5 Years"
-  | "Last 10 Years"
+  | "Current Calendar Week"
+  | "Current Calendar Month"
+  | "Current Calendar Year"
+  | "Last Calendar Week"
+  | "Last Calendar Month"
+  | "Last Calendar Year"
   | "All Time"
   | "Custom Range";
+
+const VALID_PRESETS: readonly DatePreset[] = [
+  "Today",
+  "Yesterday",
+  "Last 7 Days",
+  "Last 30 Days",
+  "Last 12 Months",
+  "Current Calendar Week",
+  "Current Calendar Month",
+  "Current Calendar Year",
+  "Last Calendar Week",
+  "Last Calendar Month",
+  "Last Calendar Year",
+  "All Time",
+  "Custom Range",
+];
+
+function isDatePreset(value: unknown): value is DatePreset {
+  return typeof value === "string" && (VALID_PRESETS as readonly string[]).includes(value);
+}
+
+// Map old (pre-Feefo-alignment) preset names to their nearest equivalent so a
+// returning user keeps working without being thrown back to the default. The
+// removed presets (Last Quarter, Last 6 Months, Last 2/5/10 Years) collapse to
+// "Last 12 Months", which is the closest survivor on Feefo's list.
+const LEGACY_PRESET_MIGRATION: Record<string, DatePreset> = {
+  "This Week": "Current Calendar Week",
+  "This Month": "Current Calendar Month",
+  YTD: "Current Calendar Year",
+  "Last Quarter": "Last 12 Months",
+  "Last 6 Months": "Last 12 Months",
+  "Last 2 Years": "Last 12 Months",
+  "Last 5 Years": "Last 12 Months",
+  "Last 10 Years": "Last 12 Months",
+};
 
 export interface DateRange {
   start: Date;
@@ -68,33 +120,52 @@ const DEFAULT_PRESET: DatePreset = "Last 12 Months";
 
 export function getDateRangeForPreset(preset: DatePreset): { start: Date; end: Date } {
   const now = new Date();
-  const end = now;
 
   switch (preset) {
-    case "This Week":
-      return { start: startOfWeek(now, { weekStartsOn: 1 }), end };
-    case "This Month":
-      return { start: startOfMonth(now), end };
-    case "Last Quarter":
-      return { start: subMonths(startOfMonth(now), 3), end };
-    case "Last 6 Months":
-      return { start: subMonths(now, 6), end };
-    case "YTD":
-      return { start: startOfYear(now), end };
+    case "Today":
+      return { start: startOfDay(now), end: now };
+    case "Yesterday": {
+      const yesterday = subDays(now, 1);
+      return { start: startOfDay(yesterday), end: endOfDay(yesterday) };
+    }
+    case "Last 7 Days":
+      return { start: subDays(now, 7), end: now };
+    case "Last 30 Days":
+      return { start: subDays(now, 30), end: now };
     case "Last 12 Months":
-      return { start: subMonths(now, 12), end };
-    case "Last 2 Years":
-      return { start: subYears(now, 2), end };
-    case "Last 5 Years":
-      return { start: subYears(now, 5), end };
-    case "Last 10 Years":
-      return { start: subYears(now, 10), end };
+      return { start: subMonths(now, 12), end: now };
+    case "Current Calendar Week":
+      return { start: startOfWeek(now, { weekStartsOn: 1 }), end: now };
+    case "Current Calendar Month":
+      return { start: startOfMonth(now), end: now };
+    case "Current Calendar Year":
+      return { start: startOfYear(now), end: now };
+    case "Last Calendar Week": {
+      const lastWeek = subWeeks(now, 1);
+      return {
+        start: startOfWeek(lastWeek, { weekStartsOn: 1 }),
+        end: endOfWeek(lastWeek, { weekStartsOn: 1 }),
+      };
+    }
+    case "Last Calendar Month": {
+      const lastMonth = subMonths(now, 1);
+      return { start: startOfMonth(lastMonth), end: endOfMonth(lastMonth) };
+    }
+    case "Last Calendar Year": {
+      const lastYear = subYears(now, 1);
+      return { start: startOfYear(lastYear), end: endOfYear(lastYear) };
+    }
     case "All Time":
-      return { start: new Date(2015, 0, 1), end };
+      return { start: new Date(2015, 0, 1), end: now };
     case "Custom Range":
-      return { start: subMonths(now, 12), end };
-    default:
-      return { start: subMonths(now, 12), end };
+      return { start: subMonths(now, 12), end: now };
+    default: {
+      // Exhaustiveness guard — adding a new preset to the union without
+      // handling it here will fail to compile.
+      const _exhaustive: never = preset;
+      void _exhaustive;
+      return { start: subMonths(now, 12), end: now };
+    }
   }
 }
 
@@ -114,8 +185,38 @@ function getInitialDateRange(): DateRange {
       return getDefaultDateRange();
     }
 
-    const preset = JSON.parse(stored) as DatePreset;
-    if (preset === "Custom Range") {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(stored);
+    } catch {
+      return getDefaultDateRange();
+    }
+
+    if (typeof parsed !== "string") {
+      return getDefaultDateRange();
+    }
+
+    if (parsed === "Custom Range") {
+      // Custom dates aren't persisted alongside the preset, so we can't
+      // reconstruct the range. Fall back to the default.
+      return getDefaultDateRange();
+    }
+
+    // One-time rename: returning users with a pre-Feefo-alignment preset
+    // ("This Week", "YTD", etc.) get mapped to the current equivalent and
+    // their localStorage entry is upgraded so the migration only happens once.
+    const migrated = LEGACY_PRESET_MIGRATION[parsed];
+    let preset: DatePreset;
+    if (migrated) {
+      preset = migrated;
+      try {
+        localStorage.setItem("pref:datePreset", JSON.stringify(migrated));
+      } catch {
+        // Ignore storage errors
+      }
+    } else if (isDatePreset(parsed)) {
+      preset = parsed;
+    } else {
       return getDefaultDateRange();
     }
 


### PR DESCRIPTION
## Summary

Renames and reworks the dashboard's date-range dropdown so its presets match the exact set Feefo's own UI exposes, in the same order. The picker UI is untouched — same list-of-buttons dropdown, same Custom Range escape hatch.

## New preset list (in display order)

| # | Preset | Maps from |
|---|---|---|
| 1 | Today | (new) |
| 2 | Yesterday | (new) |
| 3 | Last 7 Days | (new) |
| 4 | Last 30 Days | (new) |
| 5 | Last 12 Months | unchanged |
| 6 | Current Calendar Week | This Week |
| 7 | Current Calendar Month | This Month |
| 8 | Current Calendar Year | YTD |
| 9 | Last Calendar Week | (new) |
| 10 | Last Calendar Month | (new) |
| 11 | Last Calendar Year | (new) |
| 12 | All Time | unchanged |

Custom Range stays as the escape hatch below the preset list.

**Removed:** Last Quarter, Last 6 Months, Last 2 Years, Last 5 Years, Last 10 Years (not on Feefo's list).

## Migration for returning users

`localStorage["pref:datePreset"]` from older sessions is mapped to the closest equivalent on first load and rewritten in place, so the rename only happens once. Removed presets collapse to "Last 12 Months" (closest semantic survivor).

## Test plan

- [x] `tsc --noEmit` passes
- [x] `eslint` passes
- [x] Verified in dev server against today (May 4, Monday): Today, Yesterday, Last Calendar Week, Last Calendar Month, Last Calendar Year all return the correct ranges
- [x] Verified migration: localStorage `"This Week"` → loaded as `"Current Calendar Week"` and persisted upgrade
- [x] Default preset still "Last 12 Months" (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)