### PR TITLE
Split service vs product reviews on the Reviews Explorer (phase B)

### DIFF
--- a/app/src/app/reviews/page.tsx
+++ b/app/src/app/reviews/page.tsx
@@ -53,7 +53,8 @@ function mapReviewDoc(
   return {
     id: doc.id,
     customerName: d.customer?.displayName || "Trusted Customer",
-    rating: d.ratings?.product ?? d.ratings?.service ?? 0,
+    serviceRating: typeof d.ratings?.service === "number" ? d.ratings.service : null,
+    productRating: typeof d.ratings?.product === "number" ? d.ratings.product : null,
     ship: d.tags?.ship || "",
     itinerary: rawItinerary,
     parentItinerary: parentLookup?.get(rawItinerary) ?? rawItinerary,
@@ -108,6 +109,10 @@ function filtersToParams(filters: Filters, search: string, sort: SortOption): st
   for (const [key, values] of Object.entries(filters)) {
     if (key === "hasMedia") {
       if (values) params.set("hasMedia", "true");
+    } else if (key === "reviewType") {
+      // Default-omitted: only write the param when not "all" so URLs stay
+      // clean for the common case.
+      if (values !== "all") params.set("reviewType", values as string);
     } else if ((values as Array<string | number>).length > 0) {
       params.set(key, (values as Array<string | number>).join(","));
     }
@@ -129,6 +134,12 @@ function paramsToFilters(searchParams: URLSearchParams): {
     return val ? val.split(",") : [];
   };
 
+  const reviewTypeParam = searchParams.get("reviewType");
+  const reviewType: Filters["reviewType"] =
+    reviewTypeParam === "service" || reviewTypeParam === "product"
+      ? reviewTypeParam
+      : "all";
+
   const filters: Filters = {
     brand: parseArray("brand"),
     rating: parseArray("rating").map(Number).filter((n) => !isNaN(n)),
@@ -140,6 +151,7 @@ function paramsToFilters(searchParams: URLSearchParams): {
     region: parseArray("region"),
     loyalty: parseArray("loyalty"),
     hasMedia: searchParams.get("hasMedia") === "true",
+    reviewType,
   };
 
   return { filters, search, sort };
@@ -219,8 +231,12 @@ function applyClientFilters(reviews: ReviewData[], filters: Filters, search: str
     // Brand filter (only if not applied server-side via brand selector)
     if (filters.brand.length && !filters.brand.includes(r.brand)) return false;
 
-    // Rating filter
-    if (filters.rating.length && !filters.rating.includes(r.rating)) return false;
+    // Rating filter — match against the primary display rating, which falls
+    // back from product to service the same way Feefo's "headline" star does.
+    if (filters.rating.length) {
+      const primary = r.productRating ?? r.serviceRating ?? 0;
+      if (!filters.rating.includes(primary)) return false;
+    }
 
     // Theme filters (array-contains can only be used once per Firestore query)
     if (
@@ -243,6 +259,10 @@ function applyClientFilters(reviews: ReviewData[], filters: Filters, search: str
 
     // Media filter
     if (filters.hasMedia && r.media.length === 0) return false;
+
+    // Review type — exclude reviews that don't have text of the active type.
+    if (filters.reviewType === "service" && !r.serviceReview) return false;
+    if (filters.reviewType === "product" && !r.productReview) return false;
 
     return true;
   });
@@ -585,6 +605,7 @@ function ReviewsContent() {
                     key={review.id}
                     review={review}
                     onThemeClick={handleThemeClick}
+                    reviewTypeFilter={filters.reviewType}
                   />
                 ))}
               </div>

--- a/app/src/components/reviews/ExportButton.tsx
+++ b/app/src/components/reviews/ExportButton.tsx
@@ -17,7 +17,8 @@ export default function ExportButton({ reviews }: ExportButtonProps) {
   function handleExport() {
     const headers = [
       "Name",
-      "Rating",
+      "Service Rating",
+      "Product Rating",
       "Ship",
       "Itinerary",
       "Title",
@@ -29,7 +30,8 @@ export default function ExportButton({ reviews }: ExportButtonProps) {
 
     const rows = reviews.map((r) => [
       escapeCsv(r.customerName || "Trusted Customer"),
-      String(r.rating),
+      r.serviceRating == null ? "" : String(r.serviceRating),
+      r.productRating == null ? "" : String(r.productRating),
       escapeCsv(r.ship),
       escapeCsv(r.itinerary),
       escapeCsv(r.serviceTitle),

--- a/app/src/components/reviews/FilterSidebar.tsx
+++ b/app/src/components/reviews/FilterSidebar.tsx
@@ -2,6 +2,12 @@
 
 import React, { useState } from "react";
 
+/** Mirrors Feefo's All / Service reviews / Product reviews tabs on their
+ * public review pages. "Service" = customer-service / booking-experience
+ * reviews; "Product" = reviews of the actual product (the cruise itinerary
+ * for Uniworld). */
+export type ReviewType = "all" | "service" | "product";
+
 export interface Filters {
   brand: string[];
   rating: number[];
@@ -13,6 +19,7 @@ export interface Filters {
   region: string[];
   loyalty: string[];
   hasMedia: boolean;
+  reviewType: ReviewType;
 }
 
 export const emptyFilters: Filters = {
@@ -26,6 +33,7 @@ export const emptyFilters: Filters = {
   region: [],
   loyalty: [],
   hasMedia: false,
+  reviewType: "all",
 };
 
 interface FilterSidebarProps {
@@ -115,12 +123,13 @@ function formatBrandName(slug: string): string {
 }
 
 export default function FilterSidebar({ filters, onChange, options }: FilterSidebarProps) {
-  const activeFilterCount = Object.entries(filters).reduce(
-    (sum, [key, val]) => sum + (key === "hasMedia" ? (val ? 1 : 0) : (val as unknown[]).length),
-    0
-  );
+  const activeFilterCount = Object.entries(filters).reduce((sum, [key, val]) => {
+    if (key === "hasMedia") return sum + (val ? 1 : 0);
+    if (key === "reviewType") return sum + (val !== "all" ? 1 : 0);
+    return sum + (val as unknown[]).length;
+  }, 0);
 
-  type ArrayFilterKey = Exclude<keyof Filters, "hasMedia">;
+  type ArrayFilterKey = Exclude<keyof Filters, "hasMedia" | "reviewType">;
 
   function toggleArrayFilter<K extends ArrayFilterKey>(
     key: K,
@@ -136,6 +145,8 @@ export default function FilterSidebar({ filters, onChange, options }: FilterSide
   function removeChip(key: keyof Filters, value: string | number | boolean) {
     if (key === "hasMedia") {
       onChange({ ...filters, hasMedia: false });
+    } else if (key === "reviewType") {
+      onChange({ ...filters, reviewType: "all" });
     } else {
       const current = filters[key] as Array<string | number>;
       onChange({ ...filters, [key]: current.filter((v) => v !== value) });
@@ -157,6 +168,11 @@ export default function FilterSidebar({ filters, onChange, options }: FilterSide
   for (const [key, values] of Object.entries(filters)) {
     if (key === "hasMedia") {
       if (values) chips.push({ key: "hasMedia", value: true, label: "Has media" });
+    } else if (key === "reviewType") {
+      if (values !== "all") {
+        const label = values === "service" ? "Service reviews" : "Product reviews";
+        chips.push({ key: "reviewType", value: values as string, label });
+      }
     } else {
       for (const value of values as Array<string | number>) {
         chips.push({ key: key as keyof Filters, value, label: chipLabel(key as keyof Filters, value) });
@@ -199,6 +215,37 @@ export default function FilterSidebar({ filters, onChange, options }: FilterSide
           </div>
         </div>
       )}
+
+      {/* Review type — mirrors Feefo's All / Service / Product tabs */}
+      <div className="border-b border-border-light py-3">
+        <div className="mb-2 text-xs font-medium uppercase tracking-wide text-text-secondary">
+          Review type
+        </div>
+        <div
+          role="tablist"
+          aria-label="Review type"
+          className="grid grid-cols-3 gap-1 rounded-full bg-surface-alt p-1"
+        >
+          {(["all", "service", "product"] as ReviewType[]).map((rt) => {
+            const active = filters.reviewType === rt;
+            return (
+              <button
+                key={rt}
+                role="tab"
+                aria-selected={active}
+                onClick={() => onChange({ ...filters, reviewType: rt })}
+                className={
+                  active
+                    ? "rounded-full bg-brand-accent px-3 py-1 text-xs font-semibold text-accent-foreground"
+                    : "rounded-full px-3 py-1 text-xs font-medium text-text-secondary hover:text-text-primary"
+                }
+              >
+                {rt === "all" ? "All" : rt === "service" ? "Service" : "Product"}
+              </button>
+            );
+          })}
+        </div>
+      </div>
 
       {/* Media toggle */}
       <div className="border-b border-border-light py-3">

--- a/app/src/components/reviews/ReviewCard.tsx
+++ b/app/src/components/reviews/ReviewCard.tsx
@@ -3,6 +3,7 @@
 import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import MediaThumbnails from "./MediaThumbnails";
+import type { ReviewType } from "./FilterSidebar";
 
 function slugify(text: string): string {
   return text
@@ -15,7 +16,14 @@ function slugify(text: string): string {
 export interface ReviewData {
   id: string;
   customerName: string;
-  rating: number;
+  /** Star rating attached to the service review (the merchant's customer
+   * service / booking experience). `null` when the customer left no service
+   * rating. */
+  serviceRating: number | null;
+  /** Star rating attached to the product review (the actual product — for
+   * Uniworld, the cruise itinerary). `null` when the customer left no
+   * product rating. */
+  productRating: number | null;
   ship: string;
   itinerary: string;
   brand: string;
@@ -36,50 +44,95 @@ function StarRating({ rating }: { rating: number }) {
   return (
     <span className="text-brand-accent" aria-label={`${rating} out of 5 stars`}>
       {Array.from({ length: 5 }, (_, i) => (
-        <span key={i}>{i < rating ? "\u2605" : "\u2606"}</span>
+        <span key={i}>{i < rating ? "★" : "☆"}</span>
       ))}
     </span>
+  );
+}
+
+/** A single labelled review section — "Service" or "Product" — with its own
+ * star rating header above the review text. */
+function ReviewSection({
+  kind,
+  rating,
+  text,
+  expanded,
+  onMeasureClamp,
+}: {
+  kind: "service" | "product";
+  rating: number | null;
+  text: string;
+  expanded: boolean;
+  onMeasureClamp: (clamped: boolean) => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (el) {
+      onMeasureClamp(el.scrollHeight > el.clientHeight + 1);
+    }
+  }, [text, onMeasureClamp]);
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2">
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-text-secondary">
+          {kind === "service" ? "Service review" : "Product review"}
+        </span>
+        {rating != null && rating > 0 && <StarRating rating={rating} />}
+      </div>
+      <div
+        ref={ref}
+        className={`text-sm text-text-primary leading-relaxed ${
+          expanded ? "" : "line-clamp-4"
+        }`}
+      >
+        {text}
+      </div>
+    </div>
   );
 }
 
 interface ReviewCardProps {
   review: ReviewData;
   onThemeClick?: (theme: string, type: "positive" | "negative") => void;
+  /** When set, hides the off-type section so the card reflects the active
+   * "All / Service / Product" filter. Undefined or "all" shows both sections
+   * if their text is present. */
+  reviewTypeFilter?: ReviewType;
 }
 
-export default function ReviewCard({ review, onThemeClick }: ReviewCardProps) {
+export default function ReviewCard({ review, onThemeClick, reviewTypeFilter }: ReviewCardProps) {
   const [expanded, setExpanded] = useState(false);
-  const [clamped, setClamped] = useState(false);
-  const textRef = useRef<HTMLDivElement>(null);
+  const [serviceClamped, setServiceClamped] = useState(false);
+  const [productClamped, setProductClamped] = useState(false);
 
-  const fullText = [review.serviceReview, review.productReview]
-    .filter(Boolean)
-    .join(" ");
+  // Decide which sections render. A section needs both non-empty text AND no
+  // off-type filter excluding it.
+  const showService =
+    Boolean(review.serviceReview) &&
+    (reviewTypeFilter !== "product");
+  const showProduct =
+    Boolean(review.productReview) &&
+    (reviewTypeFilter !== "service");
 
-  useEffect(() => {
-    const el = textRef.current;
-    if (el) {
-      setClamped(el.scrollHeight > el.clientHeight + 1);
-    }
-  }, [fullText]);
+  const clamped = (showService && serviceClamped) || (showProduct && productClamped);
 
   return (
     <div className="rounded-lg border border-border bg-surface p-5 shadow-sm">
       {/* Header */}
-      <div className="flex items-start justify-between gap-3 mb-2">
-        <div>
-          <span className="font-medium text-text-primary">
-            {review.customerName || "Trusted Customer"}
-          </span>
-          <span className="ml-2 text-xs text-text-tertiary">
-            {new Date(review.date).toLocaleDateString("en-GB", {
-              day: "numeric",
-              month: "short",
-              year: "numeric",
-            })}
-          </span>
-        </div>
-        <StarRating rating={review.rating} />
+      <div className="mb-2">
+        <span className="font-medium text-text-primary">
+          {review.customerName || "Trusted Customer"}
+        </span>
+        <span className="ml-2 text-xs text-text-tertiary">
+          {new Date(review.date).toLocaleDateString("en-GB", {
+            day: "numeric",
+            month: "short",
+            year: "numeric",
+          })}
+        </span>
       </div>
 
       {/* Service title — Feefo lets reviewers add a short headline */}
@@ -118,14 +171,28 @@ export default function ReviewCard({ review, onThemeClick }: ReviewCardProps) {
         )}
       </div>
 
-      {/* Review text */}
-      <div
-        ref={textRef}
-        className={`text-sm text-text-primary leading-relaxed ${
-          expanded ? "" : "line-clamp-4"
-        }`}
-      >
-        {fullText}
+      {/* Review sections — Service and/or Product, each labelled with its own
+       * star rating. Mirrors how Feefo's public review pages tag each card by
+       * type. When only one is present, only one renders. */}
+      <div className="space-y-3">
+        {showService && (
+          <ReviewSection
+            kind="service"
+            rating={review.serviceRating}
+            text={review.serviceReview}
+            expanded={expanded}
+            onMeasureClamp={setServiceClamped}
+          />
+        )}
+        {showProduct && (
+          <ReviewSection
+            kind="product"
+            rating={review.productRating}
+            text={review.productReview}
+            expanded={expanded}
+            onMeasureClamp={setProductClamped}
+          />
+        )}
       </div>
       {clamped && (
         <button

--- a/docs/plans/2026-05-04-service-product-review-split-phase-b.md
+++ b/docs/plans/2026-05-04-service-product-review-split-phase-b.md
@@ -1,0 +1,222 @@
+# Service vs Product Review Split — Phase B
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Surface Feefo's service-vs-product review distinction in the dashboard. Each review card shows the service text and product text as separately labelled sections with their own star ratings, and the Reviews Explorer gains an "All / Service / Product" filter.
+
+**Architecture:** Schema is unchanged — `ratings.service` / `ratings.product` and `reviews.serviceText` / `reviews.productText` are already separate fields. Mapping (`mapReviewDoc`) exposes both ratings on `ReviewData` instead of collapsing them. `ReviewCard` conditionally renders a Service section, a Product section, or both, mirroring the labels Feefo uses on their public reviews page. The new filter is a single string state (`"all" | "service" | "product"`) plumbed through URL params and applied client-side, alongside the existing theme/rating/media filters. Aggregate metrics (Overview KPI cards, themes, trend chart) remain combined in this phase — that's Phase C scope.
+
+**Tech Stack:** Next.js 16 (existing), Firebase Firestore, date-fns. No new dependencies.
+
+---
+
+## Background
+
+Feefo's data model gives each "review event" up to two pieces:
+
+- **Service review** — text + rating about the merchant's customer service / booking experience.
+- **Product review** — text + rating about the actual product (for Uniworld, the cruise itinerary).
+
+A customer can rate one without the other or rate them differently. Feefo's public page (verified at `https://www.feefo.com/en-US/reviews/uniworld`) shows two separate averages in the header ("Service 4.8/5", "Product 4.6/5") and three tabs (All / Service / Product), and each individual review card is labelled with its type.
+
+Today our app:
+
+1. Joins `serviceText + productText` with a space and renders one paragraph (`ReviewCard.tsx:55-57, :128`).
+2. Shows a single star rating using `ratings.product ?? ratings.service` (`mapReviewDoc` in `app/src/app/reviews/page.tsx:56`).
+3. Has no filter for review type.
+
+Phase B is purely a Reviews-page change. No Overview/aggregate work — that's Phase C.
+
+## Files touched
+
+- `app/src/components/reviews/ReviewCard.tsx` — split rendering into labelled Service / Product sections.
+- `app/src/app/reviews/page.tsx` — extend `ReviewData` mapping, parse/serialise `reviewType` URL param, apply client-side filter.
+- `app/src/components/reviews/FilterSidebar.tsx` — add the `Filters.reviewType` field plus a segmented "All / Service / Product" toggle UI at the top of the sidebar.
+- `app/src/components/reviews/ExportButton.tsx` — verify CSV export still works (no changes expected; both texts already exported as separate columns).
+
+No backend / Firestore index changes. No schema changes.
+
+## URL contract
+
+New optional query param: `reviewType=service|product`. Absence ⇒ "all". The default state writes no `reviewType` param to keep URLs clean (matches the existing `sort=newest` default-omitted convention).
+
+## Verification approach
+
+`app/` has no test infrastructure. Manual verification in the dev server, the same pattern used for the date-presets PR:
+
+1. Open `/reviews` with the default "All" filter — confirm reviews with both sections render both, and reviews with one section render one.
+2. Toggle to "Service" — only reviews with service text remain, only the Service section is visible per card.
+3. Toggle to "Product" — only reviews with product text remain, only the Product section is visible per card.
+4. Reload the page on a non-default filter — URL persists, state restores.
+5. Spot-check on Uniworld and Luxury Gold to make sure the split is visually consistent across brands.
+
+---
+
+## Task 1 — Extend `ReviewData` to carry both ratings
+
+**Files:**
+- Modify: `app/src/components/reviews/ReviewCard.tsx` (the `ReviewData` interface)
+- Modify: `app/src/app/reviews/page.tsx` (`mapReviewDoc`)
+
+**Change:** Replace the single `rating: number` with two optional fields:
+
+```ts
+serviceRating: number | null;
+productRating: number | null;
+```
+
+Drop the legacy `rating` field after the card stops using it.
+
+**`mapReviewDoc` change:**
+
+```ts
+serviceRating: typeof d.ratings?.service === "number" ? d.ratings.service : null,
+productRating: typeof d.ratings?.product === "number" ? d.ratings.product : null,
+```
+
+**Verify:** `npx tsc --noEmit` passes from `app/`. Anywhere in the page that previously read `r.rating` either reads one of the two new fields or computes a display fallback inline.
+
+**Commit:** `refactor(reviews): expose service and product ratings separately on ReviewData`
+
+---
+
+## Task 2 — Render labelled Service / Product sections in `ReviewCard`
+
+**File:** `app/src/components/reviews/ReviewCard.tsx`
+
+Replace the merged `fullText` block with two conditional sections. Each section renders only when its text is non-empty. Each section has a small header — a "Service" or "Product" label and a star rating (using the section's own rating, falling back to the other type's rating if missing — Feefo sometimes reports just one).
+
+Sketch:
+
+```tsx
+const sections: Array<{ kind: "service" | "product"; text: string; rating: number | null }> = [];
+if (review.serviceReview) sections.push({ kind: "service", text: review.serviceReview, rating: review.serviceRating });
+if (review.productReview) sections.push({ kind: "product", text: review.productReview, rating: review.productRating });
+```
+
+Render each section with a header row (`Service`/`Product` label + `<StarRating>`) above the text. Re-use the existing `line-clamp-4` + Read more / Show less behaviour, but per-section.
+
+Drop the single `<StarRating>` from the card header. The service-title `<h3>` stays where it is. Theme tags stay at the bottom (still apply to the whole review).
+
+**Verify:** Visit `/reviews`. Cards with both texts show two stacked labelled sections. Cards with only one show one. Star rating per section reflects the matching `ratings.service` / `ratings.product` value.
+
+**Commit:** `feat(reviews): show service and product as separate labelled sections per card`
+
+---
+
+## Task 3 — Add `reviewType` to the `Filters` shape and URL
+
+**Files:**
+- Modify: `app/src/components/reviews/FilterSidebar.tsx`
+- Modify: `app/src/app/reviews/page.tsx`
+
+**Filters interface change:**
+
+```ts
+export type ReviewType = "all" | "service" | "product";
+
+export interface Filters {
+  // ... existing ...
+  reviewType: ReviewType;
+}
+
+export const emptyFilters: Filters = {
+  // ... existing ...
+  reviewType: "all",
+};
+```
+
+**`paramsToFilters` change:** read `searchParams.get("reviewType")`, accept only `"service"` or `"product"`, default to `"all"`.
+
+**`filtersToParams` change:** write `reviewType=service|product` only when not `"all"`.
+
+**`serverFilterKey`:** include `filters.reviewType` so the main query effect still re-runs when it changes (even though the actual filter is client-side, the user expects an immediate visual refresh).
+
+**Verify:** Setting `?reviewType=service` in the URL and reloading restores the toggle to "Service" but doesn't yet affect rendering.
+
+**Commit:** `feat(reviews): add reviewType to filter state and URL contract`
+
+---
+
+## Task 4 — Add the toggle UI in `FilterSidebar`
+
+**File:** `app/src/components/reviews/FilterSidebar.tsx`
+
+Add a segmented three-button toggle at the top of the sidebar (above Brand). Style: pill-shaped button group, similar to the Brand toggle in `BrandHeader`. Active button uses `bg-brand-accent text-accent-foreground`, inactive uses muted tone.
+
+```tsx
+<div className="mb-4 grid grid-cols-3 gap-1 rounded-full bg-surface-alt p-1">
+  {(["all", "service", "product"] as ReviewType[]).map((rt) => (
+    <button
+      key={rt}
+      onClick={() => onChange({ ...filters, reviewType: rt })}
+      className={
+        filters.reviewType === rt
+          ? "rounded-full bg-brand-accent px-3 py-1 text-xs font-semibold text-accent-foreground"
+          : "rounded-full px-3 py-1 text-xs font-medium text-text-secondary hover:text-text-primary"
+      }
+    >
+      {rt === "all" ? "All" : rt === "service" ? "Service" : "Product"}
+    </button>
+  ))}
+</div>
+```
+
+Place above the existing "Only reviews with photos or videos" checkbox.
+
+**Verify:** Toggle visually switches. Selecting "Service" updates the URL to `?reviewType=service`. Selecting "All" removes the param.
+
+**Commit:** `feat(reviews): add Service / Product / All toggle to FilterSidebar`
+
+---
+
+## Task 5 — Apply the filter client-side and hide off-type sections
+
+**Files:**
+- Modify: `app/src/app/reviews/page.tsx` (`applyClientFilters`)
+- Modify: `app/src/components/reviews/ReviewCard.tsx`
+
+**`applyClientFilters`:**
+
+```ts
+if (filters.reviewType === "service" && !r.serviceReview) return false;
+if (filters.reviewType === "product" && !r.productReview) return false;
+```
+
+Add this branch alongside the existing `hasMedia` filter.
+
+**`ReviewCard`:** Accept an optional `reviewTypeFilter?: ReviewType` prop. When set to `"service"` only render the Service section even if a Product section also exists (and vice versa). When `"all"` or undefined, render both. This is what gives the user the "tab feels filtered" Feefo-style experience.
+
+Plumb `filters.reviewType` from the page through to each `<ReviewCard>` instance.
+
+**Verify:**
+- "All" tab: both sections render where present (unchanged from Task 2).
+- "Service" tab: cards without service text disappear; cards with both render only the Service section.
+- "Product" tab: mirror behaviour.
+- Reload with `?reviewType=service` — restores the filter and the visual.
+
+**Commit:** `feat(reviews): apply reviewType filter both to result set and rendered sections`
+
+---
+
+## Task 6 — Manual verification + PR
+
+1. `npx tsc --noEmit` from `app/` — clean.
+2. `npx eslint src/app/reviews/page.tsx src/components/reviews/ReviewCard.tsx src/components/reviews/FilterSidebar.tsx` — clean.
+3. Dev server walkthrough described in **Verification approach** above.
+4. Push branch, open PR against `main` referencing this design doc and the Feefo screenshots.
+5. Note in the PR body that aggregate metrics (header averages, themes, trend split) are deferred to Phase C.
+
+**Commit:** none (PR-level only).
+
+---
+
+## Out of scope (Phase C)
+
+- Two header averages on the Overview page ("Service" + "Product" KPI cards).
+- Splitting `getFleetSummaryByDateRange` and `compute-summaries.ts` to track service-only and product-only aggregates.
+- Splitting the trend chart into two lines.
+- Re-classifying themes per type (the classifier currently joins both texts; splitting requires either two batches or a prompt rework).
+- Distribution histogram split.
+
+These all consume the same `reviewType` primitive Phase B introduces.


### PR DESCRIPTION
## Summary

Surface Feefo's service-vs-product review distinction on the Reviews Explorer. Each card shows the customer's service review and product review as separately labelled sections with their own star ratings (mirroring Feefo's public review pages), and the sidebar gains an "All / Service / Product" segmented filter that's persisted to the URL.

This is **phase B** of a two-phase rollout. Aggregate metrics on the Overview (header averages, theme split, trend split) are deferred to phase C — they share the same `reviewType` primitive added here.

Plan: [`docs/plans/2026-05-04-service-product-review-split-phase-b.md`](docs/plans/2026-05-04-service-product-review-split-phase-b.md)

## What changes for users

**Card layout**
- Cards with both texts now render two stacked sections: "SERVICE REVIEW ★★★★★" then the service text, "PRODUCT REVIEW ★★★★☆" then the product text.
- Cards with only one text render only the matching section.
- The single-rating header star is gone — each section carries its own rating, matching Feefo's UI.
- "Read more / Show less" expands both sections at once.

**Filter sidebar**
- New "REVIEW TYPE" segmented control at the top: All (default) / Service / Product.
- "Service" hides cards with no service text and hides the product section on cards that have both.
- "Product" mirrors the above.
- The selection writes `?reviewType=service|product` to the URL; "All" omits the param to keep URLs clean.
- Active selection appears as a removable "Service reviews" / "Product reviews" chip alongside other filters.

**CSV export** — separate "Service Rating" and "Product Rating" columns replace the previous merged "Rating" column.

## Data plumbing

- `ReviewData.rating: number` → `ReviewData.serviceRating: number | null` + `ReviewData.productRating: number | null`. Populated directly from `ratings.service` / `ratings.product` on the Firestore doc; nothing is munged.
- The existing star-rating filter (the "5★ / 4★ / 3★" checkboxes) still matches against the primary display rating (`productRating ?? serviceRating ?? 0`), preserving today's behaviour.
- No schema, index, or backend changes. The fields have been on every review doc since day one.

## Test plan

- [x] `tsc --noEmit` passes from `app/`
- [x] `eslint` clean on the changed files
- [x] Dev-server walkthrough on http://localhost:3000/reviews:
  - "All" — cards render service + product sections where present
  - "Service" — count drops, only service sections visible per card; URL gets `?reviewType=service`
  - "Product" — mirror; URL gets `?reviewType=product`
  - Reload with `?reviewType=service` — toggle and rendering both restore correctly
  - Active-filter chip shows "Service reviews" / "Product reviews" with × to clear
- [x] Verified on a card that contains BOTH sections (David Eckels — "Would not repeat") that the off-type section disappears under the matching filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)