### PR TITLE
Restore review media after Feefo default-response change

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,6 +8,7 @@ import { syncAll } from "./sync/sync-reviews";
 import { computeSummaries } from "./sync/compute-summaries";
 import { submitClassificationBatch, processBatchResults } from "./sync/batch-classify";
 import { backfillMissingThemes } from "./sync/backfill-themes";
+import { backfillMissingMedia } from "./sync/backfill-media";
 import {
   deleteAdminUser,
   getAdminUserByEmail,
@@ -496,6 +497,43 @@ export const backfillThemes = onRequest(
       actorUid: caller.uid,
     });
     console.log(`backfillThemes by ${caller.source}:${caller.email ?? caller.uid}`, result);
+    res.json(result);
+  }
+);
+
+// One-shot repair: re-assert the `media` array on Firestore review docs by
+// fetching all media-bearing reviews from Feefo with `media=ONLY` and
+// patching matching docs (keyed by feedbackUrl). Run once after deploying
+// the sync's media-enrichment pass; subsequent syncs keep media correct on
+// their own. Pass `brand` (uniworld | luxury-gold) and optional
+// `sincePeriod` (month | year | all, default all).
+export const backfillMedia = onRequest(
+  { timeoutSeconds: 540, memory: "1GiB", invoker: "public", cors: ALLOWED_ORIGINS },
+  async (req, res) => {
+    if (!ensurePost(req, res)) return;
+    const caller = await authorizeRequest(req, res, "sync");
+    if (!caller) return;
+
+    const brand = req.body?.brand;
+    if (!isValidBrand(brand)) {
+      res.status(400).json({ error: "brand must be 'uniworld' or 'luxury-gold'." });
+      return;
+    }
+
+    const rawPeriod = req.body?.sincePeriod;
+    const sincePeriod: "month" | "year" | "all" =
+      rawPeriod === "month" || rawPeriod === "year" || rawPeriod === "all"
+        ? rawPeriod
+        : "all";
+
+    const result = await backfillMissingMedia({
+      brand,
+      sincePeriod,
+      source: "manual",
+      actorEmail: caller.email,
+      actorUid: caller.uid,
+    });
+    console.log(`backfillMedia by ${caller.source}:${caller.email ?? caller.uid}`, result);
     res.json(result);
   }
 );

--- a/functions/src/sync/backfill-media.ts
+++ b/functions/src/sync/backfill-media.ts
@@ -1,0 +1,137 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { fetchMediaByUrl, Brand } from "@feefo/shared";
+import { writeOperationLog, type OperationLogSource } from "../ops/operation-logs";
+
+interface BackfillMediaResult {
+  brand: Brand;
+  mediaReviewsFetched: number;
+  matched: number;
+  unmatched: number;
+  patched: number;
+  errors: number;
+}
+
+interface BackfillMediaOptions {
+  brand: Brand;
+  /**
+   * `since_period` to forward to Feefo. Defaults to "all" so every
+   * media-bearing review (regardless of age) gets a chance to repair.
+   */
+  sincePeriod?: "month" | "year" | "all";
+  source?: OperationLogSource;
+  actorEmail?: string | null;
+  actorUid?: string | null;
+}
+
+const URL_CHUNK = 30; // Firestore "in" filter cap.
+
+/**
+ * One-shot repair: fetch every review with media for the given brand
+ * (using `media=ONLY`) and patch the matching Firestore review documents.
+ *
+ * Why this is needed: between Feefo's behavior change that stopped
+ * surfacing media on the default `/reviews/all` response and our sync's
+ * `merge: true` writes, the Firestore `media` field has been silently
+ * wiped on most reviews that were re-synced. The going-forward fix
+ * (fetching media in a separate pass during the main sync) heals reviews
+ * as they're re-synced — but reviews that aren't due for a re-sync would
+ * stay broken. This backfill re-asserts media on all matching docs in one
+ * shot.
+ *
+ * The match key is `feedbackUrl`, which is stable for a review's lifetime
+ * (the same one used by the duplicate-doc fix in PR #44).
+ */
+export async function backfillMissingMedia(
+  options: BackfillMediaOptions
+): Promise<BackfillMediaResult> {
+  const db = getFirestore();
+  const sincePeriod = options.sincePeriod ?? "all";
+
+  const result: BackfillMediaResult = {
+    brand: options.brand,
+    mediaReviewsFetched: 0,
+    matched: 0,
+    unmatched: 0,
+    patched: 0,
+    errors: 0,
+  };
+
+  // 1. Pull every media-bearing review for the brand.
+  const mediaByUrl = await fetchMediaByUrl(options.brand, sincePeriod);
+  result.mediaReviewsFetched = mediaByUrl.size;
+
+  if (mediaByUrl.size === 0) {
+    await writeOperationLog({
+      type: "sync",
+      level: "info",
+      action: "media_backfill_no_media",
+      message: `No media-bearing reviews returned by Feefo for ${options.brand}`,
+      brand: options.brand,
+      source: options.source ?? "manual",
+      actorEmail: options.actorEmail ?? null,
+      actorUid: options.actorUid ?? null,
+    });
+    return result;
+  }
+
+  // 2. Look up matching Firestore docs by feedbackUrl. Firestore's `in`
+  // filter is capped at 30 values, so chunk the URLs.
+  const urls = Array.from(mediaByUrl.keys());
+  const writer = db.bulkWriter();
+  writer.onWriteError((err) => {
+    if (err.failedAttempts < 3) return true;
+    result.errors += 1;
+    return false;
+  });
+
+  for (let i = 0; i < urls.length; i += URL_CHUNK) {
+    const chunk = urls.slice(i, i + URL_CHUNK);
+    const snapshot = await db
+      .collection("reviews")
+      .where("feedbackUrl", "in", chunk)
+      .where("brand", "==", options.brand)
+      .get();
+
+    const matchedUrls = new Set<string>();
+    for (const doc of snapshot.docs) {
+      const url = doc.get("feedbackUrl") as string | undefined;
+      if (!url) continue;
+      const media = mediaByUrl.get(url);
+      if (!media) continue; // Defensive — should be impossible given the `in` filter.
+      matchedUrls.add(url);
+      writer.set(doc.ref, { media }, { merge: true });
+      result.patched += 1;
+    }
+
+    for (const url of chunk) {
+      if (matchedUrls.has(url)) {
+        result.matched += 1;
+      } else {
+        result.unmatched += 1;
+      }
+    }
+  }
+
+  await writer.close();
+
+  await writeOperationLog({
+    type: "sync",
+    level: result.errors > 0 ? "error" : "success",
+    action: "media_backfill",
+    message: `Backfilled media on ${result.patched} ${options.brand} review(s)`,
+    brand: options.brand,
+    source: options.source ?? "manual",
+    actorEmail: options.actorEmail ?? null,
+    actorUid: options.actorUid ?? null,
+    details: {
+      mediaReviewsFetched: result.mediaReviewsFetched,
+      matched: result.matched,
+      unmatched: result.unmatched,
+      patched: result.patched,
+      errors: result.errors,
+      sincePeriod,
+    },
+  });
+
+  return result;
+}

--- a/functions/src/sync/sync-reviews.ts
+++ b/functions/src/sync/sync-reviews.ts
@@ -1,5 +1,11 @@
 import { getFirestore } from "firebase-admin/firestore";
-import { fetchReviews, transformReview, Brand, ReviewDocument } from "@feefo/shared";
+import {
+  fetchReviews,
+  fetchMediaByUrl,
+  transformReview,
+  Brand,
+  ReviewDocument,
+} from "@feefo/shared";
 import { writeOperationLog, type OperationLogSource } from "../ops/operation-logs";
 
 interface SyncResult {
@@ -69,6 +75,16 @@ export async function syncBrand(
   }
 
   try {
+    // 1.5. Build the media-by-URL map up front from a single `media=ONLY`
+    // pass. The default `/reviews/all` response no longer includes the
+    // `media` field (Feefo behavior change), so without this enrichment
+    // every transformed review would write `media: []` and overwrite any
+    // existing media on the Firestore doc thanks to merge:true. The pass
+    // is small — currently around 7% of reviews have media — so it adds a
+    // few extra paginated requests, not a meaningful cost.
+    const mediaSincePeriod = fullSync ? "all" : "month";
+    const mediaByUrl = await fetchMediaByUrl(brand, mediaSincePeriod);
+
     // 2. Paginate through Feefo reviews — fetch, transform, write per page
     let page = 1;
     let maxUpdated = "";
@@ -85,7 +101,9 @@ export async function syncBrand(
       const pageReviews: ReviewDocument[] = [];
       for (const raw of response.reviews) {
         try {
-          const doc = transformReview(raw);
+          // Inject media from the media=ONLY pass; reviews not in the map
+          // get an empty array (correct — they have no media).
+          const doc = transformReview(raw, mediaByUrl.get(raw.url) ?? []);
           pageReviews.push(doc);
           if (doc.dates.lastUpdated > maxUpdated) {
             maxUpdated = doc.dates.lastUpdated;

--- a/shared/src/feefo/__tests__/transform.test.ts
+++ b/shared/src/feefo/__tests__/transform.test.ts
@@ -103,4 +103,40 @@ describe("transformReview", () => {
     const result = transformReview(ratingOnly);
     expect(result.hasComment).toBe(false);
   });
+
+  // Media handling — Feefo's default `/reviews/all` response no longer
+  // includes the `media` field. The sync now fetches a separate `media=ONLY`
+  // pass and passes the resulting array in via `mediaOverride`.
+  describe("media override", () => {
+    it("falls back to product.media when no override is given", () => {
+      const result = transformReview(sampleReview);
+      expect(result.media).toEqual([{ type: "PHOTO", url: "https://img.com/1.jpg" }]);
+    });
+
+    it("uses mediaOverride when provided, ignoring product.media", () => {
+      const override = [
+        { type: "PHOTO" as const, url: "https://feefo.com/api/feedback-image/abc" },
+        { type: "VIDEO" as const, url: "https://feefo.com/api/feedback-video/xyz" },
+      ];
+      const result = transformReview(sampleReview, override);
+      expect(result.media).toEqual(override);
+    });
+
+    it("uses mediaOverride even when product.media is undefined", () => {
+      const noProductMedia: FeefoReview = {
+        ...sampleReview,
+        products: [{ ...sampleReview.products[0], media: undefined }],
+      };
+      const override = [
+        { type: "PHOTO" as const, url: "https://feefo.com/api/feedback-image/abc" },
+      ];
+      const result = transformReview(noProductMedia, override);
+      expect(result.media).toEqual(override);
+    });
+
+    it("writes an empty array when override is empty (lets us positively assert no-media)", () => {
+      const result = transformReview(sampleReview, []);
+      expect(result.media).toEqual([]);
+    });
+  });
 });

--- a/shared/src/feefo/client.ts
+++ b/shared/src/feefo/client.ts
@@ -99,6 +99,15 @@ export async function fetchReviews(
     pageSize?: number;
     sincePeriod?: "month" | "year" | "all";
     sinceUpdatedPeriod?: "month" | "year" | "all";
+    /**
+     * When true, sets `media=ONLY` on the request. Feefo returns the `media`
+     * field on `products[]` only when this filter is active — the default
+     * `/reviews/all` response strips media entirely. Note that ONLY is also
+     * a *filter*: the response is limited to reviews that have media
+     * (currently around 7% of reviews). Use this for the media-enrichment
+     * sync pass, not the main sync.
+     */
+    mediaOnly?: boolean;
   } = {}
 ): Promise<FeefoReviewsResponse> {
   const token = await getAccessToken(brand);
@@ -112,6 +121,7 @@ export async function fetchReviews(
 
   if (params.sincePeriod) searchParams.set("since_period", params.sincePeriod);
   if (params.sinceUpdatedPeriod) searchParams.set("since_updated_period", params.sinceUpdatedPeriod);
+  if (params.mediaOnly) searchParams.set("media", "ONLY");
 
   const url = `${FEEFO_BASE_URL}/20/reviews/all?${searchParams}`;
   const res = await fetchWithRetry(url, {
@@ -139,6 +149,41 @@ export async function fetchAllReviews(
   }
 
   return allReviews;
+}
+
+/**
+ * Paginate through every review that has media (using `media=ONLY`) and
+ * return a `feedbackUrl → flattened media array` map. Aggregates media
+ * across all products on a single review into one array per URL, since
+ * our review document collapses both products into one `media` field.
+ *
+ * The map's key (`feedbackUrl`) matches `ReviewDocument.feedbackUrl`, which
+ * is the stable identifier the sync uses for review re-targeting after
+ * the URL-based ID fix in PR #44.
+ */
+export async function fetchMediaByUrl(
+  brand: Brand,
+  sincePeriod: "month" | "year" | "all" = "all"
+): Promise<Map<string, { type: "PHOTO" | "VIDEO"; url: string }[]>> {
+  const map = new Map<string, { type: "PHOTO" | "VIDEO"; url: string }[]>();
+  let page = 1;
+  while (true) {
+    const response = await fetchReviews(brand, { page, sincePeriod, mediaOnly: true });
+    for (const review of response.reviews) {
+      const merged: { type: "PHOTO" | "VIDEO"; url: string }[] = [];
+      for (const product of review.products ?? []) {
+        for (const m of product.media ?? []) {
+          merged.push({ type: m.type, url: m.url });
+        }
+      }
+      if (merged.length > 0 && review.url) {
+        map.set(review.url, merged);
+      }
+    }
+    if (page >= response.summary.meta.pages) break;
+    page++;
+  }
+  return map;
 }
 
 export async function fetchSummary(brand: Brand): Promise<FeefoSummaryResponse> {

--- a/shared/src/feefo/transform.ts
+++ b/shared/src/feefo/transform.ts
@@ -1,10 +1,25 @@
-import { FeefoReview, Brand } from "./types";
+import { FeefoReview, Brand, FeefoMedia } from "./types";
 import { ReviewDocument } from "../types/review";
 import { parseTags } from "./parse-tags";
 
 const VALID_BRANDS: Set<string> = new Set(["uniworld", "luxury-gold"]);
 
-export function transformReview(raw: FeefoReview): ReviewDocument {
+/** What `transformReview` actually consumes from each media item. The full
+ * `FeefoMedia` type also has an `id` (which we drop on the way to Firestore),
+ * so the override accepts either a slim object or a full FeefoMedia. */
+export type MediaOverrideItem = Pick<FeefoMedia, "type" | "url">;
+
+/**
+ * @param mediaOverride - When provided, replaces whatever (if anything) is on
+ *   `raw.products[0].media`. Use this when fetching reviews from an endpoint
+ *   that omits the media field (the default `/reviews/all` response no longer
+ *   includes media; the sync now does a separate `media=ONLY` pass and feeds
+ *   the result back in here).
+ */
+export function transformReview(
+  raw: FeefoReview,
+  mediaOverride?: MediaOverrideItem[]
+): ReviewDocument {
   const product = raw.products[0];
   const tags = parseTags(raw.tags, product?.product?.tags);
 
@@ -66,7 +81,10 @@ export function transformReview(raw: FeefoReview): ReviewDocument {
       negative: [],
       classifiedAt: null,
     },
-    media: (product?.media ?? []).map((m) => ({ type: m.type, url: m.url })),
+    media: (mediaOverride ?? product?.media ?? []).map((m) => ({
+      type: m.type,
+      url: m.url,
+    })),
     dates: {
       created:
         product?.created_at ?? raw.service?.created_at ?? raw.last_updated_date,


### PR DESCRIPTION
## Root cause

Feefo's `/api/20/reviews/all` endpoint **no longer returns the `media` field** on products in the default response. The field is only included when the request passes `media=ONLY` — and that param is also a filter, returning only the ~7% of reviews that actually have media.

Our sync reads `product.media` (always undefined under the new behavior) and writes `media: []` to Firestore. With `merge: true`, every sync since [PR #44 (URL-based dedup, Apr 28)](https://github.com/Uniworld-River-Cruises/reviews-dashboard/pull/44) has been overwriting previously-populated media arrays. Older docs that haven't been re-synced still have their media — so this looked like a slow-bleed regression rather than a clean break.

## Production-data evidence

Newest 1,000 review docs in Firestore, by month:

| Month | reviews-with-media / total | rate |
|---|---|---|
| 2025-12 | 10/187 | 5.3% |
| 2026-01 | 11/121 | 9.1% |
| 2026-02 | 8/95 | 8.4% |
| 2026-03 | 10/103 | 9.7% |
| 2026-04 | 20/370 | 5.4% |
| **2026-05** | **1/124** | **0.8%** |

User-reported symptom: Reviews Explorer's "Has media" filter returns 0 results for Uniworld over Last 12 Months because the entire first 50-doc page returned by Firestore is media-less.

## Fix

1. `fetchReviews` learns `mediaOnly?: boolean` (sets `media=ONLY`).
2. New `fetchMediaByUrl(brand, sincePeriod)` paginates that query and returns `Map<feedbackUrl, MediaItem[]>`, aggregating media across all products per review.
3. `transformReview` accepts an optional `mediaOverride: MediaItem[]` that wins over `raw.products[0].media`.
4. The sync's `syncBrand` builds the media map up front and feeds each review's media into `transformReview`. Reviews without media in the map get `[]` (correct — they have no media).
5. New one-shot `backfillMedia` HTTP endpoint (mirrors `backfillThemes`): runs the media-only fetch and patches matching Firestore docs by `feedbackUrl`. Heals already-wiped docs without waiting for natural re-syncs.

## Test plan

- [x] 4 new test cases in `transform.test.ts` covering the override: defaults, override wins, override fills when `product.media` is undefined, empty override writes `[]`. **All 37 shared tests pass.**
- [x] `tsc` clean across `shared/`, `functions/`, and `app/`.
- [ ] After deploy: POST `/backfillMedia` once per brand and verify that the Reviews Explorer "Has media" filter starts returning results.
- [ ] Wait for the next scheduled `dailySync` cycle and confirm logs report a sane media-by-url map size (~287 for Uniworld at 1-year scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)