### PR TITLE
Make hasMedia filter server-side so it returns matches across the date range

### DIFF
--- a/app/src/app/reviews/page.tsx
+++ b/app/src/app/reviews/page.tsx
@@ -213,6 +213,16 @@ function buildServerConstraints(
     constraints.push(where("tags.tour", "in", filters.itinerary));
   }
 
+  // hasMedia is a persisted boolean (mirror of `media.length > 0`) so the
+  // filter runs server-side. Doing it client-side meant the filter only
+  // saw whatever first 50 the page had loaded — when those happened to be
+  // media-less (the common case for the newest reviews), the filter
+  // returned 0 even though hundreds of media-bearing reviews existed
+  // within the date range.
+  if (filters.hasMedia) {
+    constraints.push(where("hasMedia", "==", true));
+  }
+
   constraints.push(orderBy(path, "desc"));
 
   return constraints;
@@ -257,8 +267,9 @@ function applyClientFilters(reviews: ReviewData[], filters: Filters, search: str
     if (filters.loyalty.length > 30 && !filters.loyalty.includes(r.loyalty)) return false;
     if (filters.itinerary.length > 30 && !filters.itinerary.includes(r.itinerary)) return false;
 
-    // Media filter
-    if (filters.hasMedia && r.media.length === 0) return false;
+    // Note: hasMedia filter is applied server-side via the `hasMedia`
+    // boolean (see buildServerConstraints) so it correctly returns matches
+    // across the whole date range, not just the first page.
 
     // Review type — exclude reviews that don't have text of the active type.
     if (filters.reviewType === "service" && !r.serviceReview) return false;
@@ -276,6 +287,7 @@ function serverFilterKey(filters: Filters): string {
     filters.bookingType.join("|"),
     filters.loyalty.join("|"),
     filters.itinerary.join("|"),
+    filters.hasMedia ? "media" : "",
   ].join("~");
 }
 

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -289,6 +289,40 @@
         { "fieldPath": "themes.negative", "arrayConfig": "CONTAINS" },
         { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "brand", "order": "ASCENDING" },
+        { "fieldPath": "hasMedia", "order": "ASCENDING" },
+        { "fieldPath": "dates.created", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "brand", "order": "ASCENDING" },
+        { "fieldPath": "hasMedia", "order": "ASCENDING" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "hasMedia", "order": "ASCENDING" },
+        { "fieldPath": "dates.created", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "hasMedia", "order": "ASCENDING" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,6 +9,7 @@ import { computeSummaries } from "./sync/compute-summaries";
 import { submitClassificationBatch, processBatchResults } from "./sync/batch-classify";
 import { backfillMissingThemes } from "./sync/backfill-themes";
 import { backfillMissingMedia } from "./sync/backfill-media";
+import { backfillHasMedia } from "./sync/backfill-has-media";
 import {
   deleteAdminUser,
   getAdminUserByEmail,
@@ -534,6 +535,33 @@ export const backfillMedia = onRequest(
       actorUid: caller.uid,
     });
     console.log(`backfillMedia by ${caller.source}:${caller.email ?? caller.uid}`, result);
+    res.json(result);
+  }
+);
+
+// One-shot repair: derive `hasMedia: boolean` from each review's `media`
+// array and persist it. Run once after the schema change so the Reviews
+// Explorer's server-side "Has media" filter has the field to query.
+// Subsequent syncs maintain the field via `transformReview`.
+export const backfillHasMediaFlag = onRequest(
+  { timeoutSeconds: 540, memory: "1GiB", invoker: "public", cors: ALLOWED_ORIGINS },
+  async (req, res) => {
+    if (!ensurePost(req, res)) return;
+    const caller = await authorizeRequest(req, res, "sync");
+    if (!caller) return;
+
+    const maxDocs =
+      typeof req.body?.maxDocs === "number" && req.body.maxDocs > 0
+        ? Math.min(req.body.maxDocs, 50000)
+        : undefined;
+
+    const result = await backfillHasMedia({
+      maxDocs,
+      source: "manual",
+      actorEmail: caller.email,
+      actorUid: caller.uid,
+    });
+    console.log(`backfillHasMediaFlag by ${caller.source}:${caller.email ?? caller.uid}`, result);
     res.json(result);
   }
 );

--- a/functions/src/sync/backfill-has-media.ts
+++ b/functions/src/sync/backfill-has-media.ts
@@ -1,0 +1,117 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { writeOperationLog, type OperationLogSource } from "../ops/operation-logs";
+
+interface BackfillHasMediaResult {
+  scanned: number;
+  patched: number;
+  alreadyOk: number;
+  errors: number;
+  done: boolean;
+  lastScannedId: string | null;
+}
+
+interface BackfillHasMediaOptions {
+  maxDocs?: number;
+  source?: OperationLogSource;
+  actorEmail?: string | null;
+  actorUid?: string | null;
+}
+
+const DEFAULT_MAX_DOCS = 30000;
+const PAGE_SIZE = 500;
+
+/**
+ * One-shot repair: derive the `hasMedia` boolean from the existing `media`
+ * array on every review document. Run once after the schema change so the
+ * Reviews Explorer's server-side "Has media" filter has the field to query.
+ *
+ * Subsequent syncs maintain `hasMedia` automatically via `transformReview`,
+ * so this only ever needs to run during the rollout.
+ */
+export async function backfillHasMedia(
+  options: BackfillHasMediaOptions = {}
+): Promise<BackfillHasMediaResult> {
+  const db = getFirestore();
+  const maxDocs = options.maxDocs ?? DEFAULT_MAX_DOCS;
+
+  const result: BackfillHasMediaResult = {
+    scanned: 0,
+    patched: 0,
+    alreadyOk: 0,
+    errors: 0,
+    done: false,
+    lastScannedId: null,
+  };
+
+  let cursor: FirebaseFirestore.QueryDocumentSnapshot | null = null;
+
+  while (result.scanned < maxDocs) {
+    let q = db
+      .collection("reviews")
+      .orderBy("dates.synced", "desc")
+      .limit(PAGE_SIZE);
+
+    if (cursor) {
+      q = q.startAfter(cursor);
+    }
+
+    const snapshot = await q.get();
+    if (snapshot.empty) {
+      result.done = true;
+      break;
+    }
+
+    const writer = db.bulkWriter();
+    writer.onWriteError((err) => {
+      if (err.failedAttempts < 3) return true;
+      result.errors += 1;
+      return false;
+    });
+
+    for (const doc of snapshot.docs) {
+      result.scanned += 1;
+      result.lastScannedId = doc.id;
+
+      const data = doc.data() as Record<string, unknown>;
+      const media = Array.isArray(data.media) ? data.media : [];
+      const expected = media.length > 0;
+      const stored = data.hasMedia;
+
+      if (typeof stored === "boolean" && stored === expected) {
+        result.alreadyOk += 1;
+        continue;
+      }
+
+      writer.set(doc.ref, { hasMedia: expected }, { merge: true });
+      result.patched += 1;
+    }
+
+    await writer.close();
+
+    if (snapshot.docs.length < PAGE_SIZE) {
+      result.done = true;
+      break;
+    }
+
+    cursor = snapshot.docs[snapshot.docs.length - 1];
+  }
+
+  await writeOperationLog({
+    type: "sync",
+    level: result.errors > 0 ? "error" : "success",
+    action: "has_media_backfill",
+    message: `Set hasMedia on ${result.patched} review(s)`,
+    source: options.source ?? "manual",
+    actorEmail: options.actorEmail ?? null,
+    actorUid: options.actorUid ?? null,
+    details: {
+      scanned: result.scanned,
+      patched: result.patched,
+      alreadyOk: result.alreadyOk,
+      errors: result.errors,
+      done: result.done,
+    },
+  });
+
+  return result;
+}

--- a/shared/src/feefo/__tests__/transform.test.ts
+++ b/shared/src/feefo/__tests__/transform.test.ts
@@ -139,4 +139,37 @@ describe("transformReview", () => {
       expect(result.media).toEqual([]);
     });
   });
+
+  // hasMedia mirrors media.length > 0 — drives the Reviews Explorer's
+  // server-side "Has media" filter.
+  describe("hasMedia boolean", () => {
+    it("is true when product.media is non-empty (no override)", () => {
+      const result = transformReview(sampleReview);
+      expect(result.hasMedia).toBe(true);
+    });
+
+    it("is false when product.media is undefined (no override)", () => {
+      const noMedia: FeefoReview = {
+        ...sampleReview,
+        products: [{ ...sampleReview.products[0], media: undefined }],
+      };
+      const result = transformReview(noMedia);
+      expect(result.hasMedia).toBe(false);
+    });
+
+    it("follows the override even when product.media disagrees", () => {
+      // override empty, product has media → hasMedia false
+      expect(transformReview(sampleReview, []).hasMedia).toBe(false);
+      // override has items, product has none → hasMedia true
+      const noProductMedia: FeefoReview = {
+        ...sampleReview,
+        products: [{ ...sampleReview.products[0], media: undefined }],
+      };
+      expect(
+        transformReview(noProductMedia, [
+          { type: "PHOTO", url: "https://feefo.com/api/feedback-image/abc" },
+        ]).hasMedia
+      ).toBe(true);
+    });
+  });
 });

--- a/shared/src/feefo/transform.ts
+++ b/shared/src/feefo/transform.ts
@@ -47,6 +47,12 @@ export function transformReview(
       (productText && productText.trim().length > 0)
   );
 
+  // Mirror of `media.length > 0` so the Reviews Explorer's "Has media"
+  // filter can be applied server-side. Computed here from the same source
+  // we'd persist into `media` so the boolean and the array can never drift.
+  const mediaSource = mediaOverride ?? product?.media ?? [];
+  const hasMedia = mediaSource.length > 0;
+
   return {
     id,
     feedbackUrl: raw.url,
@@ -81,10 +87,7 @@ export function transformReview(
       negative: [],
       classifiedAt: null,
     },
-    media: (mediaOverride ?? product?.media ?? []).map((m) => ({
-      type: m.type,
-      url: m.url,
-    })),
+    media: mediaSource.map((m) => ({ type: m.type, url: m.url })),
     dates: {
       created:
         product?.created_at ?? raw.service?.created_at ?? raw.last_updated_date,
@@ -92,6 +95,7 @@ export function transformReview(
       synced: new Date().toISOString(),
     },
     hasComment,
+    hasMedia,
     moderationStatus: "published",
     verified: true,
   };

--- a/shared/src/types/review.ts
+++ b/shared/src/types/review.ts
@@ -48,6 +48,10 @@ export interface ReviewDocument {
     synced: string;
   };
   hasComment: boolean;
+  /** Mirror of `media.length > 0`. Persisted as its own boolean so the
+   * Reviews Explorer can filter media-bearing reviews server-side —
+   * Firestore can't query "array length > 0" directly. */
+  hasMedia: boolean;
   moderationStatus: string;
   verified: boolean;
 }


### PR DESCRIPTION
## What was wrong

The Reviews Explorer's "Has media" checkbox was applied client-side over only the first 50 reviews Firestore returned for a given date range. Because media density is ~7% and concentrated outside of the very newest reviews, the filter routinely returned 0 results.

Verified with a direct production Firestore query: **Uniworld + last 12 months has 276 media-bearing reviews out of 3,849 — but 0 of them in the newest 50**. The user clicks the filter, sees 0 results, even though hundreds of matches exist.

PR #54 restored the underlying media data. This PR makes the filter actually use it.

## Approach

Firestore can't filter "array length > 0" directly, so we mirror the array as a boolean and filter on the boolean. Same shape as the existing `hasComment` flag.

- **`hasMedia: boolean`** added to `ReviewDocument`.
- `transformReview` derives it from the same merged media source that lands on `media`, so the two can never drift.
- New `backfillHasMediaFlag` HTTP endpoint sets the field on existing docs.
- `buildServerConstraints` now appends `where("hasMedia", "==", true)` when the filter is on; the client-side short-circuit is removed.
- Four new composite indexes: `(brand?, hasMedia, dates.{created,lastUpdated})`.

## Test plan

- [x] 3 new test cases for `hasMedia` in `transform.test.ts` — all 40 shared tests pass.
- [x] `tsc --noEmit` clean across all three packages.
- [ ] After deploy: POST `/backfillHasMediaFlag` and verify the user's exact scenario (Uniworld, Last 12 Months, Has media) shows results.

## Rollout order

1. Deploy firestore indexes (must finish building first) + functions.
2. Run the backfill to set `hasMedia` on every existing doc.
3. Deploy hosting (the new server-side filter depends on the field being present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)