### PR TITLE
Style Load more reviews as a real button

### DIFF
--- a/app/src/app/reviews/page.tsx
+++ b/app/src/app/reviews/page.tsx
@@ -643,18 +643,18 @@ function ReviewsContent() {
                   <button
                     onClick={handleLoadMore}
                     disabled={loadingMore}
-                    className="inline-flex items-center gap-2 rounded-lg bg-header-bg px-6 py-2.5 text-sm font-medium text-header-text shadow-sm hover:opacity-90 transition-colors disabled:opacity-50"
+                    className="cursor-pointer inline-flex items-center gap-2 rounded-full bg-brand-accent px-6 py-2.5 text-sm font-semibold text-accent-foreground shadow-sm transition-colors hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {loadingMore ? (
                       <>
-                        <div className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white" />
+                        <div className="h-4 w-4 animate-spin rounded-full border-2 border-current/30 border-t-current" />
                         Loading...
                       </>
                     ) : (
                       <>
                         Load more reviews
                         {totalMatching != null && totalMatching - allReviews.length > 0 && (
-                          <span className="text-white/70">
+                          <span className="opacity-75">
                             ({(totalMatching - allReviews.length).toLocaleString()} remaining)
                           </span>
                         )}


### PR DESCRIPTION
## What was wrong

The "Load more reviews" control at the bottom of the Reviews Explorer was rendering as bare text — no visible background, no border, no `cursor-pointer` on hover. It happened to use `bg-header-bg` / `text-header-text` tokens, which collapse against the surrounding page surface in our current theme, so visually nothing distinguished it from the surrounding chrome.

## Change

- Switch the className to the primary-action pattern used elsewhere: brand-accent pill with shadow.
- Add `cursor-pointer` (and `disabled:cursor-not-allowed` for the loading state).
- Drop the hard-coded `text-white/70` on the "(N remaining)" span in favour of `opacity-75`, and swap the spinner's `border-white/*` for `border-current/*`, so the button reads correctly in both light and dark mode.

One file, three style-only edits — no behaviour change.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] Verified locally on `http://localhost:3000/reviews?hasMedia=true` — button now renders as a clear pill at the bottom of the list ("Load more reviews (300 remaining)") and shows a pointer on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)