### PR TITLE
[codex] Keep review filter sections open while filtering

### DIFF
--- a/app/src/app/reviews/page.tsx
+++ b/app/src/app/reviews/page.tsx
@@ -26,6 +26,8 @@ import {
 } from "@/lib/firestore/queries";
 import FilterSidebar, {
   type Filters,
+  type FilterSectionKey,
+  defaultOpenFilterSections,
   emptyFilters,
 } from "@/components/reviews/FilterSidebar";
 import ReviewCard, { type ReviewData } from "@/components/reviews/ReviewCard";
@@ -303,6 +305,7 @@ function ReviewsContent() {
   const { merchantQueryId: brand } = useBrand();
   const { dateRange, dateField, dataVersion } = useDashboard();
   const filterPanelRef = useRef<HTMLDivElement>(null);
+  const hasLoadedReviewsRef = useRef(false);
 
   // Parse initial state from URL
   const initial = paramsToFilters(searchParams);
@@ -311,10 +314,12 @@ function ReviewsContent() {
   const [sort, setSort] = useState<SortOption>(initial.sort);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [filterPanelStickyTop, setFilterPanelStickyTop] = useState(16);
+  const [openFilterSections, setOpenFilterSections] = useState(defaultOpenFilterSections);
 
   // Firestore data
   const [allReviews, setAllReviews] = useState<ReviewData[]>([]);
   const [loading, setLoading] = useState(true);
+  const [hasLoadedReviews, setHasLoadedReviews] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [lastDoc, setLastDoc] = useState<QueryDocumentSnapshot<DocumentData> | null>(null);
   const [hasMoreFirestore, setHasMoreFirestore] = useState(true);
@@ -369,9 +374,12 @@ function ReviewsContent() {
   // Main query — re-fetch when brand, date range, or server-side filters change
   useEffect(() => {
     let cancelled = false;
+    const isInitialLoad = !hasLoadedReviewsRef.current;
     setLoading(true);
     setError(null);
-    setAllReviews([]);
+    if (isInitialLoad) {
+      setAllReviews([]);
+    }
     setLastDoc(null);
     setHasMoreFirestore(true);
     setTotalMatching(null);
@@ -395,6 +403,8 @@ function ReviewsContent() {
       setAllReviews(reviews);
       setLastDoc(snap.docs[snap.docs.length - 1] || null);
       setHasMoreFirestore(snap.docs.length === PAGE_SIZE);
+      hasLoadedReviewsRef.current = true;
+      setHasLoadedReviews(true);
       setLoading(false);
     }).catch((err) => {
       if (cancelled) return;
@@ -461,7 +471,7 @@ function ReviewsContent() {
   // takes 6 clicks (PAGE_SIZE chunks) instead of 30 with the previous
   // 10-at-a-time display pagination.
   const visible = sorted;
-  const hasMore = hasMoreFirestore;
+  const hasMore = hasMoreFirestore && !loading;
 
   const handleLoadMore = useCallback(() => {
     if (hasMoreFirestore) loadMoreFromFirestore();
@@ -478,12 +488,20 @@ function ReviewsContent() {
     [filters]
   );
 
-  const activeFilterCount = Object.values(filters).reduce(
-    (sum, arr) => sum + arr.length,
-    0
-  );
+  const handleToggleFilterSection = useCallback((section: FilterSectionKey) => {
+    setOpenFilterSections((current) => ({
+      ...current,
+      [section]: !current[section],
+    }));
+  }, []);
 
-  if (loading) {
+  const activeFilterCount = Object.entries(filters).reduce((sum, [key, val]) => {
+    if (key === "hasMedia") return sum + (val ? 1 : 0);
+    if (key === "reviewType") return sum + (val !== "all" ? 1 : 0);
+    return sum + (val as unknown[]).length;
+  }, 0);
+
+  if (loading && !hasLoadedReviews) {
     return (
       <div className="flex items-center justify-center py-24">
         <div
@@ -493,7 +511,7 @@ function ReviewsContent() {
     );
   }
 
-  if (error) {
+  if (error && !hasLoadedReviews) {
     return (
       <div className="rounded-2xl border border-red-200 bg-red-50 px-6 py-5 text-sm text-red-900">
         {error}
@@ -537,7 +555,13 @@ function ReviewsContent() {
         </div>
         <div className="flex items-center gap-3">
           <ExportButton reviews={sorted} />
-          <span className="text-sm text-text-secondary whitespace-nowrap">
+          {loading && hasLoadedReviews && (
+            <span className="inline-flex items-center gap-2 rounded-full border border-border bg-surface px-3 py-1 text-xs font-medium text-text-secondary">
+              <span className="h-3 w-3 animate-spin rounded-full border-2 border-spinner-track border-t-spinner-accent" />
+              Updating
+            </span>
+          )}
+          <span className="text-sm text-text-secondary whitespace-nowrap" aria-live="polite">
             {/* Total comes from a getCountFromServer aggregate on the same
              * server-side constraints, so it reflects every match in the
              * collection — not just the docs we've paged in. Falls back to
@@ -631,6 +655,8 @@ function ReviewsContent() {
             <FilterSidebar
               filters={filters}
               onChange={setFilters}
+              openSections={openFilterSections}
+              onToggleSection={handleToggleFilterSection}
               options={options}
             />
           </div>
@@ -638,7 +664,12 @@ function ReviewsContent() {
 
         {/* Results */}
         <div className="flex-1 min-w-0">
-          {sorted.length === 0 ? (
+          {error && (
+            <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-900">
+              {error}
+            </div>
+          )}
+          {sorted.length === 0 && !loading ? (
             <div className="rounded-lg border border-border bg-surface p-12 text-center">
               <p className="text-text-secondary">
                 No reviews match your search and filters.
@@ -655,7 +686,7 @@ function ReviewsContent() {
             </div>
           ) : (
             <>
-              <div className="space-y-4">
+              <div className={`space-y-4 transition-opacity ${loading ? "opacity-60" : ""}`}>
                 {visible.map((review) => (
                   <ReviewCard
                     key={review.id}

--- a/app/src/components/reviews/FilterSidebar.tsx
+++ b/app/src/components/reviews/FilterSidebar.tsx
@@ -106,16 +106,23 @@ function FilterSection({
   onToggle: () => void;
   children: React.ReactNode;
 }) {
+  const contentId = React.useId();
+
   return (
     <div className="border-b border-border-light last:border-0">
       <button
+        type="button"
+        aria-expanded={open}
+        aria-controls={contentId}
         onClick={onToggle}
         className="flex w-full items-center justify-between py-3 text-sm font-medium text-text-primary hover:text-text-primary/80"
       >
         {title}
         <ChevronIcon open={open} />
       </button>
-      {open && <div className="pb-3 space-y-1.5">{children}</div>}
+      <div id={contentId} hidden={!open} className="pb-3 space-y-1.5">
+        {children}
+      </div>
     </div>
   );
 }

--- a/app/src/components/reviews/FilterSidebar.tsx
+++ b/app/src/components/reviews/FilterSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React from "react";
 
 /** Mirrors Feefo's All / Service reviews / Product reviews tabs on their
  * public review pages. "Service" = customer-service / booking-experience
@@ -22,6 +22,31 @@ export interface Filters {
   reviewType: ReviewType;
 }
 
+export type FilterSectionKey =
+  | "brand"
+  | "rating"
+  | "ship"
+  | "itinerary"
+  | "positiveThemes"
+  | "negativeThemes"
+  | "bookingType"
+  | "region"
+  | "loyalty";
+
+export type OpenFilterSections = Record<FilterSectionKey, boolean>;
+
+export const defaultOpenFilterSections: OpenFilterSections = {
+  brand: true,
+  rating: true,
+  ship: false,
+  itinerary: false,
+  positiveThemes: false,
+  negativeThemes: false,
+  bookingType: false,
+  region: false,
+  loyalty: false,
+};
+
 export const emptyFilters: Filters = {
   brand: [],
   rating: [],
@@ -39,6 +64,8 @@ export const emptyFilters: Filters = {
 interface FilterSidebarProps {
   filters: Filters;
   onChange: (filters: Filters) => void;
+  openSections: OpenFilterSections;
+  onToggleSection: (section: FilterSectionKey) => void;
   options: {
     brands: string[];
     ratings: number[];
@@ -70,19 +97,19 @@ function ChevronIcon({ open }: { open: boolean }) {
 
 function FilterSection({
   title,
-  defaultOpen = false,
+  open,
+  onToggle,
   children,
 }: {
   title: string;
-  defaultOpen?: boolean;
+  open: boolean;
+  onToggle: () => void;
   children: React.ReactNode;
 }) {
-  const [open, setOpen] = useState(defaultOpen);
-
   return (
     <div className="border-b border-border-light last:border-0">
       <button
-        onClick={() => setOpen(!open)}
+        onClick={onToggle}
         className="flex w-full items-center justify-between py-3 text-sm font-medium text-text-primary hover:text-text-primary/80"
       >
         {title}
@@ -122,7 +149,13 @@ function formatBrandName(slug: string): string {
     .join(" ");
 }
 
-export default function FilterSidebar({ filters, onChange, options }: FilterSidebarProps) {
+export default function FilterSidebar({
+  filters,
+  onChange,
+  openSections,
+  onToggleSection,
+  options,
+}: FilterSidebarProps) {
   const activeFilterCount = Object.entries(filters).reduce((sum, [key, val]) => {
     if (key === "hasMedia") return sum + (val ? 1 : 0);
     if (key === "reviewType") return sum + (val !== "all" ? 1 : 0);
@@ -261,7 +294,11 @@ export default function FilterSidebar({ filters, onChange, options }: FilterSide
       </div>
 
       {/* Brand */}
-      <FilterSection title="Brand" defaultOpen>
+      <FilterSection
+        title="Brand"
+        open={openSections.brand}
+        onToggle={() => onToggleSection("brand")}
+      >
         {options.brands.map((brand) => (
           <CheckboxItem
             key={brand}
@@ -273,7 +310,11 @@ export default function FilterSidebar({ filters, onChange, options }: FilterSide
       </FilterSection>
 
       {/* Star Rating */}
-      <FilterSection title="Star Rating" defaultOpen>
+      <FilterSection
+        title="Star Rating"
+        open={openSections.rating}
+        onToggle={() => onToggleSection("rating")}
+      >
         {(options.ratings.length > 0 ? options.ratings : [5, 4, 3, 2, 1]).map((star) => {
           const count = options.ratingCounts?.[star];
           return (
@@ -304,7 +345,11 @@ export default function FilterSidebar({ filters, onChange, options }: FilterSide
       </FilterSection>
 
       {/* Ship */}
-      <FilterSection title="Ship">
+      <FilterSection
+        title="Ship"
+        open={openSections.ship}
+        onToggle={() => onToggleSection("ship")}
+      >
         {options.ships.map((ship) => (
           <CheckboxItem
             key={ship}
@@ -316,7 +361,11 @@ export default function FilterSidebar({ filters, onChange, options }: FilterSide
       </FilterSection>
 
       {/* Itinerary */}
-      <FilterSection title="Itinerary">
+      <FilterSection
+        title="Itinerary"
+        open={openSections.itinerary}
+        onToggle={() => onToggleSection("itinerary")}
+      >
         {options.itineraries.map((itin) => (
           <CheckboxItem
             key={itin}
@@ -328,7 +377,11 @@ export default function FilterSidebar({ filters, onChange, options }: FilterSide
       </FilterSection>
 
       {/* Positive Themes */}
-      <FilterSection title="Positive Themes">
+      <FilterSection
+        title="Positive Themes"
+        open={openSections.positiveThemes}
+        onToggle={() => onToggleSection("positiveThemes")}
+      >
         {options.positiveThemes.map((theme) => (
           <CheckboxItem
             key={theme}
@@ -340,7 +393,11 @@ export default function FilterSidebar({ filters, onChange, options }: FilterSide
       </FilterSection>
 
       {/* Negative Themes */}
-      <FilterSection title="Negative Themes">
+      <FilterSection
+        title="Negative Themes"
+        open={openSections.negativeThemes}
+        onToggle={() => onToggleSection("negativeThemes")}
+      >
         {options.negativeThemes.map((theme) => (
           <CheckboxItem
             key={theme}
@@ -352,7 +409,11 @@ export default function FilterSidebar({ filters, onChange, options }: FilterSide
       </FilterSection>
 
       {/* Booking Type */}
-      <FilterSection title="Booking Type">
+      <FilterSection
+        title="Booking Type"
+        open={openSections.bookingType}
+        onToggle={() => onToggleSection("bookingType")}
+      >
         {options.bookingTypes.map((bt) => (
           <CheckboxItem
             key={bt}
@@ -364,7 +425,11 @@ export default function FilterSidebar({ filters, onChange, options }: FilterSide
       </FilterSection>
 
       {/* Region */}
-      <FilterSection title="Region">
+      <FilterSection
+        title="Region"
+        open={openSections.region}
+        onToggle={() => onToggleSection("region")}
+      >
         {options.regions.map((region) => (
           <CheckboxItem
             key={region}
@@ -376,7 +441,11 @@ export default function FilterSidebar({ filters, onChange, options }: FilterSide
       </FilterSection>
 
       {/* Loyalty */}
-      <FilterSection title="Loyalty">
+      <FilterSection
+        title="Loyalty"
+        open={openSections.loyalty}
+        onToggle={() => onToggleSection("loyalty")}
+      >
         {options.loyaltyLevels.map((level) => (
           <CheckboxItem
             key={level}


### PR DESCRIPTION
## Summary
- Keep Reviews Explorer filter accordion state outside each individual section so open panels stay open while filters update.
- Preserve the existing results/sidebar during server-backed filter refreshes instead of swapping the page to the initial loading spinner.
- Applies to Ship, Itinerary, Booking Type, Region, Loyalty, and the other checkbox sections.

## Root Cause
Server-backed filters trigger the Reviews page data query to refresh. The page previously entered the same full-page loading state used for first load, which could unmount the filter sidebar, reset each section's local state, and pull the user back toward the active-filter chips.

## Validation
- `C:\nvm4w\nodejs\npm.cmd run lint` passes with existing warnings only.
- `C:\nvm4w\nodejs\npm.cmd run build` passes.
