### PR TITLE
fix(reviews): never display unmasked customer name

### DIFF
--- a/app/src/app/reviews/page.tsx
+++ b/app/src/app/reviews/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import { useDashboard, type DateField } from "@/contexts/DashboardContext";
 import { useBrand } from "@/contexts/BrandContext";
 import { getClientDb } from "@/lib/firebase";
+import { resolveDisplayName } from "@/lib/format/customer";
 import {
   collection,
   query,
@@ -55,7 +56,7 @@ function mapReviewDoc(
         : "";
   return {
     id: doc.id,
-    customerName: d.customer?.displayName || "Trusted Customer",
+    customerName: resolveDisplayName(d.customer),
     serviceRating: typeof d.ratings?.service === "number" ? d.ratings.service : null,
     productRating: typeof d.ratings?.product === "number" ? d.ratings.product : null,
     ship: d.tags?.ship || "",

--- a/app/src/lib/firestore/itinerary-queries.ts
+++ b/app/src/lib/firestore/itinerary-queries.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { getClientDb } from "@/lib/firebase";
+import { resolveDisplayName } from "@/lib/format/customer";
 import type { DateField, DateRange } from "@/contexts/DashboardContext";
 import {
   dateFieldPath,
@@ -352,7 +353,7 @@ function mapItineraryReviewDoc(
 
   return {
     id,
-    guestName: data.customer?.displayName || data.customer?.name || "Trusted Customer",
+    guestName: resolveDisplayName(data.customer),
     rating: data.ratings?.product ?? data.ratings?.service ?? 0,
     itinerary: data.tags?.tour || data.product?.title || "",
     ship: data.tags?.ship || "",
@@ -528,7 +529,7 @@ export async function getItineraryQuotes(
 
     const quote: Quote = {
       id: d.id,
-      guestName: data.customer?.displayName || data.customer?.name || "Guest",
+      guestName: resolveDisplayName(data.customer, "Guest"),
       rating,
       ship: data.tags?.ship || "",
       itinerary: data.tags?.tour || data.product?.title || itineraryName,

--- a/app/src/lib/firestore/queries.ts
+++ b/app/src/lib/firestore/queries.ts
@@ -2,6 +2,7 @@
 
 import { format } from "date-fns";
 import { getClientDb } from "@/lib/firebase";
+import { resolveDisplayName } from "@/lib/format/customer";
 import type { DateField } from "@/contexts/DashboardContext";
 import {
   collection,
@@ -727,7 +728,7 @@ function mapReviewDoc(
   const data = review.data;
   return {
     id: review.id,
-    guestName: data.customer?.displayName || "Trusted Customer",
+    guestName: resolveDisplayName(data.customer),
     rating: data.ratings?.product ?? data.ratings?.service ?? 0,
     itinerary: data.tags?.tour || data.product?.title || "",
     ship: data.tags?.ship || "",

--- a/app/src/lib/firestore/ship-queries.ts
+++ b/app/src/lib/firestore/ship-queries.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { getClientDb } from "@/lib/firebase";
+import { resolveDisplayName } from "@/lib/format/customer";
 import type { DateField, DateRange } from "@/contexts/DashboardContext";
 import {
   dateFieldPath,
@@ -388,7 +389,7 @@ function mapShipReviewDoc(
 
   return {
     id,
-    guestName: data.customer?.displayName || data.customer?.name || "Trusted Customer",
+    guestName: resolveDisplayName(data.customer),
     rating: data.ratings?.product ?? data.ratings?.service ?? 0,
     itinerary: data.tags?.tour || data.product?.title || "",
     ship: data.tags?.ship || "",
@@ -559,7 +560,7 @@ export async function getShipQuotes(
 
     const quote: Quote = {
       id: d.id,
-      guestName: data.customer?.displayName || data.customer?.name || "Guest",
+      guestName: resolveDisplayName(data.customer, "Guest"),
       rating,
       ship: data.tags?.ship || shipName,
       itinerary: data.tags?.tour || data.product?.title || "",

--- a/app/src/lib/format/customer.ts
+++ b/app/src/lib/format/customer.ts
@@ -1,8 +1,8 @@
 /**
  * Resolve the customer name we are allowed to display publicly.
  *
- * The ONLY name we ever surface is Feefo's `display_name` — the value the
- * reviewer consented to show publicly. We deliberately do NOT fall back to
+ * The ONLY name we ever surface is the consented display name
+ * (`customer.displayName`, sourced from Feefo's `display_name`). We deliberately do NOT fall back to
  * `customer.name` (the unmasked full name), which is PII and must never reach
  * a rendered surface or the public API.
  *

--- a/app/src/lib/format/customer.ts
+++ b/app/src/lib/format/customer.ts
@@ -1,0 +1,22 @@
+/**
+ * Resolve the customer name we are allowed to display publicly.
+ *
+ * The ONLY name we ever surface is Feefo's `display_name` — the value the
+ * reviewer consented to show publicly. We deliberately do NOT fall back to
+ * `customer.name` (the unmasked full name), which is PII and must never reach
+ * a rendered surface or the public API.
+ *
+ * This is the single source of truth for the rule across the dashboard. The
+ * public reviews API mirrors it exactly so the API can never display a name
+ * the website wouldn't.
+ *
+ * @param customer  The review's customer object (loosely typed; may be absent).
+ * @param fallback  Placeholder shown when no consented display name exists.
+ */
+export function resolveDisplayName(
+  customer: { displayName?: string | null } | null | undefined,
+  fallback = "Trusted Customer"
+): string {
+  const name = customer?.displayName;
+  return typeof name === "string" && name.trim() ? name.trim() : fallback;
+}


### PR DESCRIPTION
## Problem

The itinerary and ship pages fell back to the raw `customer.name` (the unmasked full name — PII) whenever Feefo's consented `display_name` was missing:

- `app/src/lib/firestore/itinerary-queries.ts` (review mapper + featured quotes)
- `app/src/lib/firestore/ship-queries.ts` (review mapper + featured quotes)

So real customer names could render on the live dashboard. Feefo's `display_name` is the value a reviewer consents to show publicly; the raw `name` is not meant for display.

## Fix

- New single source-of-truth helper `app/src/lib/format/customer.ts` → `resolveDisplayName(customer, fallback?)`, which returns the trimmed consented `display_name` or a placeholder and **never** reads `customer.name`.
- All customer-name resolution (Reviews Explorer, overview panels, itinerary, ship) now routes through it; the `|| customer.name` fallback is removed.
- Existing placeholders preserved — "Trusted Customer" everywhere, "Guest" on featured quotes — to keep this PR scoped strictly to the privacy fix.

## Why now

This is the exact rule the planned public reviews API will reuse so the API can never display a name the website wouldn't — but it's a privacy fix that stands on its own regardless of the API.

## Verification

- `tsc --noEmit` (Node 22): clean
- `eslint` on the changed files: clean
- Manual: itinerary / ship / reviews surfaces render `display_name` or the placeholder; no raw names.

## Note

Placeholder strings still vary intentionally ("Guest" on featured quotes vs "Trusted Customer" elsewhere). Full standardization can ride along with the reviews-API work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
