### PR TITLE
docs(api): public reviews API design + Postman collection

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -67,37 +67,31 @@ CDN-cached**, so you lose the cheap/fast edge cache.
 So: never put the `client_secret` (or a long-lived token derived from it) in a
 public web page.
 
-### Calling from the browser — three safe patterns
+### Calling from the browser
 
-1. **Publishable key (recommended for on-page widgets).** Issue a *separate*,
-   restricted key that is safe to embed because it is **origin-locked**
-   (only works from your domains, checked via the `Origin`/`Referer` header),
-   **read-only**, tightly rate-limited, and cacheable. Even if copied, it only
-   works from your site. This is the Stripe *publishable key* / Algolia
-   *search-only key* / Google Maps *API key* model — and Feefo's own *public
-   widgets* vs its OAuth Reviews API.
+The decision for this project is **server-side only** — we do **not** issue a
+browser-embeddable key. Front-end review data is served by **your own backend**,
+not by calling this API directly from the browser:
 
-2. **Backend proxy (most control, best for SEO).** Your server exposes a thin
-   *same-origin* endpoint (e.g. `/api/reviews`) that calls the real API with the
-   secret server-side and returns sanitized JSON. The browser never sees a
-   credential; you also get server-side caching and can server-render review
-   content + schema.org JSON-LD for rich snippets.
+- **Backend proxy (the pattern we use).** Your server exposes a thin
+  *same-origin* endpoint (e.g. `/api/reviews`) that calls this API with the
+  `client_secret` server-side and returns JSON to your front end. The browser
+  never sees a credential, you get server-side caching, and it's the right place
+  to server-render review content + schema.org JSON-LD for SEO.
 
-3. **Token broker.** Your server mints a short-lived, scope-limited token on
-   demand and hands it to the browser. More moving parts; usually unnecessary
-   when (1) or (2) suffice.
+A publishable, origin-locked key for direct browser calls (the Stripe /
+Algolia / Google Maps model) is intentionally **out of scope for v1**. It could
+be added later if a true on-page widget is ever needed — see the plan's
+[open decisions](../plans/2026-06-09-public-reviews-api.md#open-decisions).
 
 ### Recommendation for this project
 
-> Mostly server-to-server, with some client-side JS.
+> Mostly server-to-server, with front-end needs served by your own backend.
 
-- **Server-to-server** → confidential client (`client_id` + `client_secret`).
-  Use it from your site's backend and for partners.
-- **Client-side JS / widgets / SEO** → a **publishable, origin-locked key** on
-  the cached public path, *or* a **backend proxy** when you want to server-render
-  for SEO.
+- **Server-to-server** (your site's backend, partners, pipelines) → confidential
+  client (`client_id` + `client_secret`), exactly as in this Postman collection.
+- **Anything the front end needs** → route it through your backend's own
+  same-origin endpoints (backend proxy), which call this API server-side.
 
-This mirrors Feefo (OAuth API for servers + public widgets for pages) and keeps
-the `client_secret` off every public surface. The publishable-key path is an
-[open decision](../plans/2026-06-09-public-reviews-api.md#open-decisions) — flag
-whether you want it and we'll include it in the build.
+This mirrors Feefo's own split (a server-side OAuth API; public widgets are a
+separate concern) and keeps the `client_secret` off every public surface.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,103 @@
+# Reviews API — Postman & developer guide
+
+A Postman collection for the public, read-only **Reviews API** described in
+[docs/plans/2026-06-09-public-reviews-api.md](../plans/2026-06-09-public-reviews-api.md).
+
+> **Status:** the API is being built against this contract. The collection
+> targets the planned `/v1` endpoints so it's ready to point at the
+> Functions emulator (during development) or production (once deployed).
+
+## Files
+
+| File | Import as |
+|---|---|
+| `reviews-api.postman_collection.json` | Collection |
+| `reviews-api.postman_environment.json` | Environment |
+
+## Quick start
+
+1. In Postman: **Import** → drop both files in.
+2. Select the **Uniworld Reviews API** environment (top-right).
+3. Set `clientId` and `clientSecret` (from the dashboard's **API Access** page).
+4. Run **Auth → Get access token**. Its test script saves `accessToken` automatically.
+5. Run anything under **Reviews** / **Meta** — they inherit the bearer token.
+
+When you get a `401`, the token expired (default 1h) — re-run **Get access token**.
+
+### Variables
+
+| Variable | Meaning | Example |
+|---|---|---|
+| `baseUrl` | API base (Hosting rewrite `/api`) | `https://feefo-reviews.web.app/api` |
+| `clientId` / `clientSecret` | Your API credentials | minted in the dashboard |
+| `accessToken` | Filled automatically by the token request | — |
+| `merchantIdentifier` | Brand selector | `uniworld`, `luxury-gold`, `all` |
+
+For local development against the Firebase emulator, set `baseUrl` to the
+Hosting emulator (e.g. `http://127.0.0.1:5000/api`) so the `/api` rewrite
+resolves to the `reviewsApi` function.
+
+---
+
+## Authentication: server-side vs client-side
+
+The API uses **OAuth 2.0 client-credentials**, exactly like Feefo: you exchange
+a `client_id` + `client_secret` for a short-lived bearer token, then send
+`Authorization: Bearer <token>`. This model is built for **confidential
+clients** — code that can keep a secret. That has direct consequences for
+*where* you can safely call it.
+
+### Server-to-server (the safe default)
+
+Your website's backend (a Next.js Route Handler / SSR / build step), a partner's
+server, or a data pipeline holds the `client_secret` in an environment variable,
+calls `POST /v1/oauth/token`, caches the token for ~1h, and calls the API. The
+secret never leaves the server. This is how the dashboard already consumes Feefo
+(see `shared/src/feefo/client.ts`).
+
+### Why you can't just call it from browser JavaScript
+
+If you ship the `client_secret` to the browser, it's trivially extractable from
+DevTools / the network tab / view-source. Anyone can then mint tokens as you —
+exhaust your rate limits, scrape under your identity, etc. **There is no way to
+hide a secret in client-side JS.** Two more friction points: browsers enforce
+**CORS** (the API must allow your origin), and **bearer-auth responses aren't
+CDN-cached**, so you lose the cheap/fast edge cache.
+
+So: never put the `client_secret` (or a long-lived token derived from it) in a
+public web page.
+
+### Calling from the browser — three safe patterns
+
+1. **Publishable key (recommended for on-page widgets).** Issue a *separate*,
+   restricted key that is safe to embed because it is **origin-locked**
+   (only works from your domains, checked via the `Origin`/`Referer` header),
+   **read-only**, tightly rate-limited, and cacheable. Even if copied, it only
+   works from your site. This is the Stripe *publishable key* / Algolia
+   *search-only key* / Google Maps *API key* model — and Feefo's own *public
+   widgets* vs its OAuth Reviews API.
+
+2. **Backend proxy (most control, best for SEO).** Your server exposes a thin
+   *same-origin* endpoint (e.g. `/api/reviews`) that calls the real API with the
+   secret server-side and returns sanitized JSON. The browser never sees a
+   credential; you also get server-side caching and can server-render review
+   content + schema.org JSON-LD for rich snippets.
+
+3. **Token broker.** Your server mints a short-lived, scope-limited token on
+   demand and hands it to the browser. More moving parts; usually unnecessary
+   when (1) or (2) suffice.
+
+### Recommendation for this project
+
+> Mostly server-to-server, with some client-side JS.
+
+- **Server-to-server** → confidential client (`client_id` + `client_secret`).
+  Use it from your site's backend and for partners.
+- **Client-side JS / widgets / SEO** → a **publishable, origin-locked key** on
+  the cached public path, *or* a **backend proxy** when you want to server-render
+  for SEO.
+
+This mirrors Feefo (OAuth API for servers + public widgets for pages) and keeps
+the `client_secret` off every public surface. The publishable-key path is an
+[open decision](../plans/2026-06-09-public-reviews-api.md#open-decisions) — flag
+whether you want it and we'll include it in the build.

--- a/docs/api/reviews-api.postman_collection.json
+++ b/docs/api/reviews-api.postman_collection.json
@@ -86,6 +86,13 @@
                 { "key": "region", "value": "", "disabled": true },
                 { "key": "positive_theme", "value": "Staff", "disabled": true },
                 { "key": "negative_theme", "value": "Value", "disabled": true },
+                { "key": "date_time_from", "value": "", "disabled": true, "description": "ISO created-date window start" },
+                { "key": "date_time_to", "value": "", "disabled": true, "description": "ISO created-date window end" },
+                { "key": "product_sku", "value": "", "disabled": true },
+                { "key": "parent_product_sku", "value": "", "disabled": true },
+                { "key": "booking_type", "value": "", "disabled": true },
+                { "key": "loyalty", "value": "", "disabled": true },
+                { "key": "search", "value": "", "disabled": true, "description": "free-text (Phase 5)" },
                 { "key": "sort", "value": "newest", "disabled": true, "description": "newest|oldest" }
               ]
             },

--- a/docs/api/reviews-api.postman_collection.json
+++ b/docs/api/reviews-api.postman_collection.json
@@ -1,0 +1,161 @@
+{
+  "info": {
+    "_postman_id": "b3f1c0de-1a2b-4c3d-8e9f-0a1b2c3d4e5f",
+    "name": "Uniworld Reviews API (v1)",
+    "description": "Public, read-only reviews API for Uniworld brands. Emulates the Feefo NativeReviews API (merchant_identifier selection, OAuth client-credentials token exchange, reviews/all + reviews/summary/all envelopes) and adds AI enrichment (themes, normalized attributes, itinerary grouping, media/comment flags).\n\nAUTH: run **Auth > Get access token** first. Its test script saves `access_token` into the `accessToken` collection variable, and every other request inherits Bearer auth from the collection. Tokens are short-lived (default 1h) — re-run when you get a 401.\n\nSet `baseUrl`, `clientId`, and `clientSecret` (collection variables, or import the bundled environment). The API is being built against this contract — see docs/plans/2026-06-09-public-reviews-api.md.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "bearer",
+    "bearer": [{ "key": "token", "value": "{{accessToken}}", "type": "string" }]
+  },
+  "variable": [
+    { "key": "baseUrl", "value": "https://feefo-reviews.web.app/api", "type": "string" },
+    { "key": "clientId", "value": "", "type": "string" },
+    { "key": "clientSecret", "value": "", "type": "string" },
+    { "key": "accessToken", "value": "", "type": "string" },
+    { "key": "merchantIdentifier", "value": "uniworld", "type": "string" }
+  ],
+  "item": [
+    {
+      "name": "Auth",
+      "item": [
+        {
+          "name": "Get access token",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', () => pm.response.to.have.status(200));",
+                  "const body = pm.response.json();",
+                  "if (body && body.access_token) {",
+                  "  pm.collectionVariables.set('accessToken', body.access_token);",
+                  "  console.log('Saved accessToken; expires_in=' + body.expires_in + 's');",
+                  "} else {",
+                  "  console.warn('No access_token in response — check client_id / client_secret');",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "header": [{ "key": "Content-Type", "value": "application/json" }],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"client_id\": \"{{clientId}}\",\n  \"client_secret\": \"{{clientSecret}}\",\n  \"grant_type\": \"client_credentials\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/oauth/token",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "oauth", "token"]
+            },
+            "description": "Exchange client_id + client_secret for a short-lived bearer token. Mirrors Feefo's POST /oauth/v2/token. The test script stores access_token in the `accessToken` collection variable so the rest of the collection authenticates automatically."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Reviews",
+      "item": [
+        {
+          "name": "List reviews",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/reviews/all?merchant_identifier={{merchantIdentifier}}&page_size=20",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "reviews", "all"],
+              "query": [
+                { "key": "merchant_identifier", "value": "{{merchantIdentifier}}", "description": "uniworld | luxury-gold | all" },
+                { "key": "page_size", "value": "20", "description": "max 100" },
+                { "key": "page", "value": "1", "disabled": true },
+                { "key": "cursor", "value": "", "disabled": true, "description": "opaque token for deep pagination (preferred over page)" },
+                { "key": "since_period", "value": "year", "disabled": true, "description": "week|month|quarter|half_year|year|all (created date)" },
+                { "key": "since_updated_period", "value": "month", "disabled": true },
+                { "key": "rating", "value": "5", "disabled": true, "description": "minimum headline star 1-5" },
+                { "key": "has_media", "value": "true", "disabled": true },
+                { "key": "review_type", "value": "product", "disabled": true, "description": "all|service|product" },
+                { "key": "ship", "value": "", "disabled": true },
+                { "key": "tour", "value": "", "disabled": true },
+                { "key": "region", "value": "", "disabled": true },
+                { "key": "positive_theme", "value": "Staff", "disabled": true },
+                { "key": "negative_theme", "value": "Value", "disabled": true },
+                { "key": "sort", "value": "newest", "disabled": true, "description": "newest|oldest" }
+              ]
+            },
+            "description": "Paginated, filtered review list (Feefo /reviews/all envelope + per-review `enrichment`). `merchant_identifier` selects the brand; results are also constrained to the credential's merchant scope."
+          }
+        },
+        {
+          "name": "Get review by id",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/reviews/:id",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "reviews", ":id"],
+              "variable": [{ "key": "id", "value": "REPLACE_WITH_REVIEW_ID", "description": "stable review id from a list response" }]
+            },
+            "description": "Single review by its stable id — for permalinks / SEO pages."
+          }
+        },
+        {
+          "name": "Get summary",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/reviews/summary/all?merchant_identifier={{merchantIdentifier}}&scope=fleet",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "reviews", "summary", "all"],
+              "query": [
+                { "key": "merchant_identifier", "value": "{{merchantIdentifier}}" },
+                { "key": "scope", "value": "fleet", "description": "fleet | ship | itinerary" },
+                { "key": "scope_value", "value": "", "disabled": true, "description": "ship or itinerary name when scope != fleet" }
+              ]
+            },
+            "description": "Aggregate ratings, star distribution, and top themes (served from the precomputed summaries collection — one cheap read)."
+          }
+        }
+      ]
+    },
+    {
+      "name": "Meta",
+      "item": [
+        {
+          "name": "List themes",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/meta/themes",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "meta", "themes"]
+            },
+            "description": "The AI theme taxonomy (positive/negative names + descriptions) for building filter UIs."
+          }
+        },
+        {
+          "name": "List merchants",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/v1/meta/merchants",
+              "host": ["{{baseUrl}}"],
+              "path": ["v1", "meta", "merchants"]
+            },
+            "description": "Available merchant_identifiers + display labels for this org."
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/api/reviews-api.postman_environment.json
+++ b/docs/api/reviews-api.postman_environment.json
@@ -1,0 +1,12 @@
+{
+  "id": "a1b2c3d4-0000-4444-8888-1234567890ab",
+  "name": "Uniworld Reviews API",
+  "values": [
+    { "key": "baseUrl", "value": "https://feefo-reviews.web.app/api", "type": "default", "enabled": true },
+    { "key": "clientId", "value": "", "type": "default", "enabled": true },
+    { "key": "clientSecret", "value": "", "type": "secret", "enabled": true },
+    { "key": "accessToken", "value": "", "type": "secret", "enabled": true },
+    { "key": "merchantIdentifier", "value": "uniworld", "type": "default", "enabled": true }
+  ],
+  "_postman_variable_scope": "environment"
+}

--- a/docs/plans/2026-06-09-public-reviews-api.md
+++ b/docs/plans/2026-06-09-public-reviews-api.md
@@ -1,0 +1,441 @@
+# Public Reviews API — Recommendation & Design
+
+**Date:** 2026-06-09
+**Status:** Proposed (recommendation)
+**Owner:** TBD
+
+**Goal:** Expose Uniworld's synced, AI-enriched reviews through a read-only HTTP API so the company marketing website (and partners) can render reviews, ratings, and aggregates — **without** leaking customer PII, **without** coupling consumers to Firestore internals, and using a **Feefo-style credential model** that anyone who has integrated Feefo will recognize.
+
+**Guiding principle:** *Emulate the Feefo NativeReviews API as closely as practical, then layer our value-add on top.* That applies to three things at once:
+1. **The data shape** — mirror Feefo's `/reviews/all` and `/reviews/summary/all` payloads.
+2. **The brand model** — select brand via `merchant_identifier`, exactly like Feefo.
+3. **The auth model** — issue `client_id` + `client_secret`, exchange for a short-lived bearer token, exactly like Feefo's `POST /oauth/v2/token`.
+
+Then add what Feefo can't: AI theme classifications, normalized attributes (ship / itinerary / region / loyalty), itinerary grouping, and media/comment flags.
+
+**Brand model:** Our internal `ReviewDocument.brand` value is *already* the Feefo merchant identifier (`uniworld`, `luxury-gold`), so `merchant_identifier` maps 1:1. The contract is designed to survive the [multi-tenant migration](2026-04-03-multi-tenant-roadmap.md) without a breaking change.
+
+---
+
+## Recommendation summary
+
+Stand up a single, versioned, read-only Cloud Function (`reviewsApi`) plus a small credential system, all in the existing `functions/` + `shared/` packages — no new infrastructure:
+
+1. **Mirror Feefo's two core endpoints** — `GET /v1/reviews/all` and `GET /v1/reviews/summary/all` — using Feefo's envelope and field names, plus our extensions (`/v1/reviews/{id}`, `/v1/meta/*`).
+2. **Select brand via `merchant_identifier`** (`uniworld` | `luxury-gold` | `all`), matching Feefo's parameter exactly.
+3. **Add an `enrichment` block to every review** carrying AI themes + derived metadata, namespaced so it never collides with Feefo's schema.
+4. **Authenticate Feefo-style:** dashboard users self-mint `client_id` + `client_secret`; consumers exchange them at `POST /v1/oauth/token` for a bearer token. (See [Authentication](#authentication--api-credentials).)
+5. **Enforce the *site's own* customer-name rule** via one shared `resolveDisplayName()` function used by both the website and the API — so what the API returns is byte-for-byte what the site shows, and the raw `name`/email/refs never escape. (See [PII firewall](#pii-firewall--name-display-parity).)
+6. **Read Firestore via the Admin SDK**, which lets us simultaneously **close the currently world-open Firestore read rules**.
+7. **Cache on the consumer side** — the calling backend caches the token and payloads, and aggregates come from precomputed summaries — since the API is server-to-server and data changes only every ~2 hours.
+
+---
+
+## Background — what we have to expose
+
+The sync pipeline ([`functions/src/sync/sync-reviews.ts`](../../functions/src/sync/sync-reviews.ts)) normalizes every Feefo review into a [`ReviewDocument`](../../shared/src/types/review.ts) in Firestore, then enriches it:
+
+- **Themes** — Anthropic Batch classification writes `themes.positive[]` / `themes.negative[]` / `themes.classifiedAt` against a fixed taxonomy ([`shared/src/themes/definitions.ts`](../../shared/src/themes/definitions.ts)): 10 positive (Staff, Service, Food, Excursions, Ship, Accommodation, Wine & Drinks, Overall Experience, Destination & Culture, Entertainment) and 10 negative (Food Quality, Excursion Quality, Unmet Expectations, Ship Condition, Space & Size, Value, Temperature & Comfort, Noise, Itinerary Changes, Communication).
+- **Normalized attributes** — `parseTags` extracts `tags.ship`, `tags.tour`, `tags.tourDirector`, `tags.bookingType`, `tags.region`, `tags.loyalty`, `tags.clientType`, `tags.package`.
+- **Itinerary grouping** — `itinerary_mappings` resolves raw tour names to a parent itinerary group.
+- **Flags** — `hasMedia` and `hasComment` booleans.
+- **Aggregates** — [`summaries`](../../functions/src/sync/compute-summaries.ts) holds precomputed fleet / ship / itinerary rollups; `monthly_summaries` holds per-month rollups. So the summary endpoint is a single cheap doc read.
+
+---
+
+## PII firewall & name-display parity
+
+### The rule we must match
+
+You asked that the API enforce the **exact** name rules the website uses: show the customer's name when the site shows it, show "Trusted Customer" when the site does. The wrinkle is that **the site is not internally consistent today**:
+
+| Surface | Rule today | Leaks raw `name`? |
+|---|---|---|
+| Reviews Explorer, `ReviewCard`, Export, Overview panels | `displayName \|\| "Trusted Customer"` | No |
+| Itinerary pages ([itinerary-queries.ts:355,531](../../app/src/lib/firestore/itinerary-queries.ts)), Ship pages ([ship-queries.ts:391,562](../../app/src/lib/firestore/ship-queries.ts)) | `displayName \|\| customer.name \|\| "Trusted Customer"` (one uses `"Guest"`) | **Yes** |
+
+The itinerary/ship surfaces fall back to the unmasked `customer.name`. That is almost certainly unintended: Feefo's `display_name` is the reviewer's **consent-approved** public name (often a full name when they opted in); the raw `name` is the unmasked record value and is not meant for public display. This is a latent privacy issue **independent of this API**.
+
+### The fix: one shared rule, used by site and API
+
+Centralize the rule so the two can never drift:
+
+```ts
+// shared/src/reviews/display-name.ts
+export function resolveDisplayName(customer: { displayName?: string | null }): string {
+  return customer.displayName?.trim() || "Trusted Customer";
+}
+```
+
+- The **website** refactors all surfaces ([queries.ts](../../app/src/lib/firestore/queries.ts), [reviews/page.tsx](../../app/src/app/reviews/page.tsx), [itinerary-queries.ts](../../app/src/lib/firestore/itinerary-queries.ts), [ship-queries.ts](../../app/src/lib/firestore/ship-queries.ts), [ExportButton.tsx](../../app/src/components/reviews/ExportButton.tsx)) to call this, **dropping the `|| customer.name` fallback** and standardizing the placeholder to "Trusted Customer".
+- The **API** calls the same function for `customer.display_name`.
+
+Result: the API returns precisely what the site shows. When a reviewer consented (so `display_name` exists, possibly a full name), that name flows through — matching your requirement. When they didn't, both show "Trusted Customer". The raw `name` flows **nowhere**.
+
+### The firewall (allowlist mapper)
+
+A single allowlist mapper is the only thing that constructs public output — never a `spread` of the raw doc, so a new PII field added later cannot leak by default:
+
+```ts
+// shared/src/reviews/public.ts
+export function toPublicReview(d: ReviewDocument): PublicReview {
+  return {
+    merchant: { identifier: d.brand },
+    id: d.id,
+    url: d.feedbackUrl,
+    customer: {
+      display_name: resolveDisplayName(d.customer),  // identical to the website
+      display_location: d.customer.location,          // Feefo-public city/region
+      // d.customer.name / email / orderRef / customerRef are NEVER mapped
+    },
+    service: /* {min,max,rating}, title, review, created_at */,
+    products: [ /* single product: rating, review, media, product{...}, created_at */ ],
+    last_updated_date: d.dates.lastUpdated,
+    verified: d.verified,
+    enrichment: { themes, attributes, itinerary, flags },  // see below
+  };
+}
+```
+
+---
+
+## API design
+
+### Base URL & routing
+
+Expose the function under a clean, stable base URL via a Firebase Hosting rewrite (`/api/** → reviewsApi`). Because responses are authenticated, the rewrite is for URL tidiness and routing, not CDN caching:
+
+```jsonc
+// firebase.json → hosting
+"rewrites": [
+  { "source": "/api/**", "function": "reviewsApi", "region": "us-central1" },
+  { "source": "**", "destination": "/index.html" }   // keep SPA fallback last
+]
+```
+
+Public base: `https://<site-domain>/api/v1/...`. The `reviewsApi` function routes internally.
+
+> **Versioning:** we use our own `/v1/` rather than Feefo's `/20/`, so our contract evolves independently. Feefo analogues are noted per endpoint.
+
+### Endpoint map
+
+| Our endpoint | Feefo analogue | Auth | Purpose |
+|---|---|---|---|
+| `POST /v1/oauth/token` | `POST /oauth/v2/token` | client_id + secret | Exchange credentials for a bearer token |
+| `GET /v1/reviews/all` | `GET /20/reviews/all` | Bearer (or public path) | Paginated, filtered review list |
+| `GET /v1/reviews/summary/all` | `GET /20/reviews/summary/all` | Bearer (or public path) | Aggregate ratings + star distribution |
+| `GET /v1/reviews/{id}` | *(none)* | Bearer (or public path) | Single review — permalinks / SEO |
+| `GET /v1/meta/themes` | *(none)* | Bearer | AI theme taxonomy for filter UIs |
+| `GET /v1/meta/merchants` | *(none)* | Bearer | Available `merchant_identifier`s + labels |
+
+---
+
+### `GET /v1/reviews/all`
+
+**Query parameters** — Feefo-compatible names first, our extensions marked ➕:
+
+| Param | Feefo? | Notes |
+|---|---|---|
+| `merchant_identifier` | ✓ | `uniworld` \| `luxury-gold` \| ➕`all`. Constrained to the caller's credential scope. |
+| `page`, `page_size` | ✓ | `page_size` default 20, max 100. Shallow paging. |
+| `cursor` | ➕ | Opaque token; preferred for deep iteration (see [Pagination](#pagination)). |
+| `since_period` / `since_updated_period` | ✓ | `week`…`year`\|`all`; created vs last-updated windows. |
+| `date_time_from` / `date_time_to` | ✓ | ISO created-date window. |
+| `product_sku` / `parent_product_sku` | ✓ | Filter by product. |
+| `review_type` | ➕ | `all` \| `service` \| `product`. |
+| `rating` | ✓ | Minimum headline star (1–5). |
+| `has_media` | ➕ | Only reviews with media (server-side via `hasMedia`). |
+| `ship` / `tour` / `region` / `booking_type` / `loyalty` | ➕ | Normalized-attribute filters. |
+| `positive_theme` / `negative_theme` | ➕ | Filter by AI theme name. |
+| `search` | ✓ | Free-text (Phase 5 — Algolia; see [Search](#search)). |
+| `sort` | ✓ | `newest` (default) \| `oldest`. |
+
+**Response** — Feefo's envelope (`summary.meta` + `reviews[]`), each review Feefo-shaped plus `enrichment`:
+
+```jsonc
+{
+  "summary": {
+    "meta": { "count": 1842, "pages": 93, "page_size": 20, "current_page": 1 },
+    "next_cursor": "eyJkIjoiMjAyNi0wNi0wMVQ..."
+  },
+  "reviews": [
+    {
+      "merchant": { "identifier": "uniworld" },
+      "id": "60a3f2c1e4b0a1b2c3d4e5f6",
+      "url": "https://www.feefo.com/en-US/reviews/uniworld/...",
+      "customer": { "display_name": "Jane D.", "display_location": "London, UK" },
+      "service": {
+        "rating": { "min": 1, "max": 5, "rating": 5 },
+        "title": "A wonderful trip from start to finish",
+        "review": "The booking team were responsive and...",
+        "created_at": "2026-05-20T09:15:00Z"
+      },
+      "products": [
+        {
+          "rating": { "min": 1, "max": 5, "rating": 5 },
+          "review": "The Danube itinerary was breathtaking...",
+          "media": [ { "type": "PHOTO", "url": "https://media.feefo.com/.../photo.jpg" } ],
+          "product": {
+            "title": "Enchanting Danube", "sku": "UW-DAN-8", "parent_sku": "UW-DAN",
+            "url": "https://www.uniworld.com/...", "image_url": "https://www.uniworld.com/.../danube.jpg"
+          },
+          "created_at": "2026-05-20T09:15:00Z"
+        }
+      ],
+      "last_updated_date": "2026-05-21T11:02:00Z",
+      "verified": true,
+
+      "enrichment": {
+        "themes": { "positive": ["Staff", "Excursions", "Food"], "negative": [], "classified_at": "2026-05-21T03:00:00Z" },
+        "attributes": {
+          "ship": "S.S. Beatrice", "tour": "Enchanting Danube", "tour_director": "Markus W.",
+          "booking_type": "Direct", "region": "Central Europe", "loyalty": "Returning Guest",
+          "client_type": "Couple", "package": "All-Inclusive"
+        },
+        "itinerary": { "raw": "Enchanting Danube (8 Days)", "group": "Enchanting Danube" },
+        "flags": { "has_media": true, "has_comment": true }
+      }
+    }
+  ]
+}
+```
+
+**Design notes:** single `products[]` element (our model collapses to one product); `rating` objects synthesize `{min:1,max:5,rating}`; `created_at` maps from `dates.created` (per-section precision would need a sync change); raw Feefo `tags[]` are exposed normalized under `enrichment.attributes` (raw passthrough is an [open decision](#open-decisions)).
+
+---
+
+### `GET /v1/reviews/summary/all`
+
+Feefo-shaped summary served from the precomputed [`summaries`](../../functions/src/sync/compute-summaries.ts) collection. Params: `merchant_identifier`, ➕`scope` (`fleet` default | `ship` | `itinerary`), ➕`scope_value`.
+
+```jsonc
+{
+  "merchant": { "identifier": "uniworld", "name": "Uniworld" },
+  "meta": { "count": 1842 },
+  "rating": {
+    "min": 1, "max": 5, "rating": 4.81,
+    "product": { "count": 1790, "5_star": 1500, "4_star": 210, "3_star": 50, "2_star": 20, "1_star": 10 },
+    "service": { "count": 1760, "5_star": 1480, "4_star": 200, "3_star": 50, "2_star": 18, "1_star": 12 }
+  },
+  "enrichment": {
+    "scope": "fleet", "reviews_with_comments": 1203,
+    "top_positive_themes": [ { "theme": "Staff", "count": 980 } ],
+    "top_negative_themes": [ { "theme": "Value", "count": 88 } ],
+    "ships": ["S.S. Beatrice"], "itineraries": ["Enchanting Danube"]
+  }
+}
+```
+
+> **Star-distribution caveat:** `compute-summaries.ts` currently builds `starDistribution` from the **product** rating only. Serve `product` now; populating `service` needs a small sync addition. Until then emit `product` and null `service` rather than faking it.
+
+---
+
+## Authentication & API credentials
+
+**Model: OAuth 2.0 client-credentials, mirroring Feefo.** Feefo issues a `client_id` + `client_secret` and you exchange them at `POST /oauth/v2/token` for a short-lived bearer token — see our own consumer implementation in [`shared/src/feefo/client.ts`](../../shared/src/feefo/client.ts). We emulate that flow exactly so a partner who has integrated Feefo can reuse their code against us by changing only the base URL and credentials.
+
+### Credential model — server-side only
+
+A single **confidential client**: `client_id` + `client_secret` → bearer token, for the website's backend, partners, and data pipelines. The secret always stays server-side; we do **not** issue a browser-embeddable key.
+
+**Front-end access** is handled on the consumer's side: the website's own backend exposes thin, same-origin endpoints that call this API server-side and return JSON to its front end (the "backend proxy" pattern). That keeps the secret off every public surface, lets the consumer cache and shape responses, and is the right place to server-render review HTML + JSON-LD for SEO.
+
+**Postman** is itself a confidential client — it holds the credentials locally, performs the token exchange, and sends the bearer token — so the server-only model works in Postman with no special handling. See [`docs/api/`](../api/README.md).
+
+### Self-service creation in the dashboard
+
+Add an **"API Access"** area under admin/settings:
+
+- An owner/admin clicks **Create API client**, gives it a label and a **merchant scope** (which `merchant_identifier`s it may read), and receives `client_id` + `client_secret`. **The secret is shown once**; only a hash is stored.
+- Manage: list clients (with `lastUsedAt`), **rotate** secret, **revoke**.
+- Gated by a new `manageApiClients` permission added to the existing Firestore access-control model ([`functions/src/auth/access-control.ts`](../../functions/src/auth/access-control.ts), `admin_users`) — same pattern as the existing `adminUsers` endpoint.
+
+### Token endpoint (Feefo-shaped)
+
+```http
+POST /api/v1/oauth/token
+Content-Type: application/json
+
+{ "client_id": "uw_live_a1b2...", "client_secret": "...", "grant_type": "client_credentials" }
+```
+```jsonc
+// 200
+{ "access_token": "<JWT>", "token_type": "Bearer", "expires_in": 3600 }
+```
+
+- Look up the client, verify `status: "active"`, **constant-time** compare the secret against the stored hash.
+- Mint a short-lived signed **JWT** (HS256 via a Secret Manager key, or RS256) with claims `{ sub: clientId, merchants: [...], scopes: [...], exp }`.
+- Response mirrors Feefo's `{ access_token, expires_in }` exactly. (Implementation: add `jose`/`jsonwebtoken`, or self-sign with Node `crypto` HMAC — no new dep.)
+
+### Authenticated requests
+
+```http
+GET /api/v1/reviews/all?merchant_identifier=uniworld
+Authorization: Bearer <access_token>
+```
+
+`reviewsApi` verifies the JWT signature + expiry, then checks that the requested `merchant_identifier` ∈ `token.merchants` and that scope allows `reviews:read`. A client scoped to `luxury-gold` cannot read `uniworld`.
+
+### Firestore model
+
+```
+api_clients/{clientId}
+  clientId    : string            // public id, e.g. "uw_live_a1b2c3"
+  secretHash  : string            // sha256/bcrypt of the secret (shown to user once)
+  label       : string            // "Marketing website (prod)"
+  merchants   : string[]          // allowed identifiers, or ["*"]
+  scopes      : string[]          // ["reviews:read","summary:read"]
+  status      : "active"|"revoked"
+  createdBy   : string            // dashboard uid/email
+  createdAt, lastUsedAt
+  rateLimitTier? : string
+  orgId?      : string            // multi-tenant future
+```
+
+Rules: `allow read, write: if false` — Admin SDK only; secrets are never client-readable (mirrors the roadmap's `credentials` subcollection). Signing key lives in Secret Manager / functions env as `REVIEWS_API_JWT_SECRET`.
+
+### Caching (server-side)
+
+Bearer-auth responses aren't CDN-cached, so caching lives with the consumer: the calling backend caches the bearer token (~1h) and the review payloads (e.g. Next.js fetch revalidation), while aggregate reads stay cheap because `/v1/reviews/summary/all` comes from the precomputed `summaries` collection. We still send `Cache-Control` + `ETag` so any shared HTTP cache the consumer runs can honour them.
+
+Credentials buy us per-consumer **analytics, revocation, rate-limit tiers, and brand scoping** — and keep metering/monetization open later.
+
+---
+
+## Brand / merchant support
+
+`merchant_identifier` maps directly to `ReviewDocument.brand` (identical values), validated against `VALID_BRANDS` ([index.ts](../../functions/src/index.ts)); filtering is an indexed `where("brand","==",…)`. `merchant_identifier=all` fans out and merges (the dashboard's "combined" logic). Every request is additionally constrained to the **caller's credential `merchants` scope**.
+
+**Forward-compatible with multi-tenant:** a `merchant_registry/{merchant_identifier} → { orgId, collectionPath, label }` resolver keeps the API merchant-centric (Feefo-style) even after data moves to `organizations/{orgId}/reviews` — the `/v1` contract never changes, only the resolver does. API clients gain an `orgId` and belong to one org.
+
+---
+
+## Pagination
+
+Support both, honestly: **`page`/`page_size`** for Feefo familiarity and shallow paging (`summary.meta` returns `{count,pages,page_size,current_page}`, `count` via a cheap `getCountFromServer` aggregate), and an opaque **`cursor`/`next_cursor`** for efficient deep iteration and full exports (preferred past the first few pages, since Firestore offset paging re-reads skipped docs).
+
+---
+
+## Caching, CORS & methods
+
+- **Caching:** responses carry `Cache-Control` + `ETag`; the consuming backend does the real caching (token + payloads). Aggregates are cheap (precomputed `summaries`), and data changes only every ~2h, so generous TTLs are safe.
+- **CORS:** not required for server-to-server callers (CORS is a browser concern), so it stays off by default. Any browser access goes through the consumer's own same-origin backend, never directly here.
+- **Methods:** `POST` for the token endpoint, `GET` elsewhere (405 otherwise).
+
+---
+
+## Security tie-in
+
+Standing up the sanitized API is the moment to fix the open-rules exposure flagged in [`docs/security-and-access.md`](../../docs/security-and-access.md): the function reads via the Admin SDK (bypasses rules), so we can tighten [`firestore.rules`](../../firestore.rules) `reviews` (and other dashboard collections) from `allow read: if true` to `allow read: if request.auth != null` — matching the roadmap's legacy-collection rules. Public consumers use the sanitized API instead of raw PII.
+
+---
+
+## Data-source options
+
+| Option | What | When |
+|---|---|---|
+| **A. Live read + map (recommended v1)** | Function reads `reviews` via Admin SDK, maps through `toPublicReview()`. | MVP; reuses existing indexes. |
+| **B. Precomputed `public_reviews` projection** | Sync writes a sanitized copy (public-read). API reads only that. | Scale path: cheaper reads, cleaner separation. |
+| **C. Static JSON export** | Sync emits per-merchant badge JSON to Hosting/Storage. | Ratings badges / SEO blocks. |
+
+Keep the firewall in `shared/` so B/C adopt it unchanged.
+
+---
+
+## Search
+
+`search` is Phase 5. A **dormant**, already-PII-stripped Algolia projection exists ([algolia-sync.ts](../../functions/src/sync/algolia-sync.ts)) but is never invoked and unused by the app. If needed, activate that sync and either proxy search through `reviewsApi` or issue Algolia **search-only** keys.
+
+---
+
+## SEO note (confirm scope)
+
+For **star ratings in Google results**, the site must server-render review content and emit schema.org `Review` / `AggregateRating` JSON-LD; a client-fetched widget won't be indexed. The API supplies the data; rendering must be server-side. Confirm before build — it shapes whether the site consumes the **credentialed server path** (recommended for SEO) vs a browser widget.
+
+---
+
+## Phases
+
+| Phase | Scope | Effort |
+|---|---|---|
+| **1 — Name rule + firewall + contract** | `resolveDisplayName()` in `shared/`; refactor all app surfaces to use it (drop `\|\| name` fallback on itinerary/ship); `PublicReview`/`PublicSummary` types + `toPublicReview()`/`toPublicSummary()`; unit tests asserting PII never serializes. | S–M |
+| **2 — Core endpoints** | `reviewsApi`: `/v1/reviews/summary/all`, `/v1/reviews/all`, `/v1/reviews/{id}`; Hosting rewrite; cache/ETag; pagination. | M |
+| **3 — Auth & credentials** | `POST /v1/oauth/token`; `api_clients` model + hashing + JWT mint/verify; `apiClients` management function; `manageApiClients` permission; dashboard "API Access" UI; per-client merchant scoping + revoke/rotate. | M–L |
+| **4 — Hardening + extensions** | Tighten Firestore rules; `merchant_registry`; `/v1/meta/*`; `merchant_identifier=all`; service-star distribution in sync. | M |
+| **5 — Search & scale (optional)** | Activate Algolia for `search`; or Option B/C. | M |
+
+---
+
+## Key files & changes
+
+| File | Action | Purpose |
+|---|---|---|
+| `shared/src/reviews/display-name.ts` | Create | `resolveDisplayName()` — single source of truth for the name rule |
+| `shared/src/reviews/public.ts` | Create | `PublicReview`/`PublicSummary` + allowlist mappers |
+| `shared/src/reviews/__tests__/public.test.ts` | Create | Assert no PII field serializes; name parity with the site rule |
+| `shared/src/index.ts` | Modify | Re-export public mappers/types + `resolveDisplayName` |
+| `app/src/lib/firestore/{queries,itinerary-queries,ship-queries}.ts` | Modify | Use `resolveDisplayName`; **remove `\|\| customer.name` fallback** |
+| `app/src/app/reviews/page.tsx`, `app/src/components/reviews/ExportButton.tsx` | Modify | Use `resolveDisplayName` |
+| `functions/src/api/reviews-api.ts` | Create | Param parsing, query building, pagination, cache headers, router |
+| `functions/src/api/oauth.ts` | Create | Token endpoint; JWT mint/verify; constant-time secret check |
+| `functions/src/api/api-clients.ts` | Create | Client CRUD (create/list/revoke/rotate), secret hashing |
+| `functions/src/api/merchant-registry.ts` | Create | `merchant_identifier → { orgId, collectionPath, label }` |
+| `functions/src/auth/access-control.ts` | Modify | Add `manageApiClients` permission |
+| `functions/src/index.ts` | Modify | Export `reviewsApi`, `oauthToken`, `apiClients` |
+| `app/src/app/admin/api-access/page.tsx` (+ component) | Create | Self-service credential UI |
+| `firebase.json` | Modify | Hosting rewrite `/api/** → reviewsApi`; keep SPA fallback last |
+| `firestore.rules` | Modify | `api_clients` deny-all to clients; tighten `reviews` to `auth != null` |
+| `firestore.indexes.json` | Modify | Brand-less attribute/date indexes for `merchant_identifier=all` |
+| `functions/.env.example` | Modify | `REVIEWS_API_JWT_SECRET`, `REVIEWS_API_ALLOWED_ORIGINS` |
+| `docs/feefo-api-reference.md` | Modify | Cross-link the Feefo→ours param/field/auth mapping |
+
+---
+
+## Risks & mitigations
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| PII leak through the API | Critical | Allowlist mapper (never spread); unit test asserts forbidden keys absent; `resolveDisplayName` shared with site |
+| Existing itinerary/ship pages already render raw names | High (privacy) | Fix as Phase 1 (drop `\|\| name`); ship before the API launches |
+| Client secret leakage | High | Store only a hash; show secret once; `api_clients` deny-all client reads; signing key in Secret Manager |
+| Auth breaks CDN caching | Medium | Consumer-side caching for credentialed path; publishable-key/public cached path for browser/SEO |
+| `merchant_identifier=all` hits unindexed queries | Medium | Pre-create composite indexes; cap `page_size`; prefer cursor |
+| Contract churn at multi-tenant | Medium | `merchant_registry` indirection keeps `/v1` stable |
+| Consumers expect 1:1 Feefo parity | Low | Document every deviation (single product, synthesized `created_at`, normalized tags, `/v1/oauth/token` vs `/oauth/v2/token`) |
+
+---
+
+## Open decisions
+
+1. **Customer-name rule (needs a call):** confirm the canonical rule is `displayName \|\| "Trusted Customer"` everywhere and that we **remove the `\|\| customer.name` fallback** on itinerary/ship pages. (Recommended — it's a privacy fix regardless of the API.)
+2. **Auth surface:** ✅ **Resolved — server-side only.** Feefo-style `client_id`/`client_secret` → bearer token; no browser-embeddable key. Front-end access goes through the consumer's own same-origin backend endpoints. Remaining sub-decision: token TTL (default 1h) and JWT vs opaque token.
+3. **`display_location`:** keep Feefo's city/region (it treats it as public) or drop for extra caution?
+4. **Raw Feefo `tags[]`:** normalized `enrichment.attributes` only, or also retain + passthrough raw tags (needs a sync change)?
+5. **Per-section `created_at`:** accept the collapsed-date approximation, or extend the sync to retain `service`/`product` timestamps separately?
+6. **Hosting surface:** path-based (`/api/...` on the marketing domain) vs a dedicated `reviews-api.` subdomain.
+7. **SEO scope:** is server-rendered JSON-LD in scope?
+
+---
+
+## Appendix — field mapping (internal → public)
+
+| `ReviewDocument` | Public API path | Notes |
+|---|---|---|
+| `brand` | `merchant.identifier` | Already equals Feefo merchant id |
+| `id` | `id` | Stable doc id |
+| `feedbackUrl` | `url` | |
+| `customer.displayName` | `customer.display_name` | via `resolveDisplayName()`; empty ⇒ `"Trusted Customer"` |
+| `customer.location` | `customer.display_location` | Public-safe |
+| `customer.name` / `email` / `orderRef` / `customerRef` | — | **Dropped (PII).** `name` is the value some site pages currently leak as a fallback — to be removed |
+| `ratings.service` / `ratings.product` | `service.rating.rating` / `products[0].rating.rating` | wrapped `{min:1,max:5,rating}` |
+| `reviews.serviceTitle` / `serviceText` / `productText` | `service.title` / `service.review` / `products[0].review` | |
+| `product.{title,sku,parentSku,url,imageUrl}` | `products[0].product.{title,sku,parent_sku,url,image_url}` | |
+| `media[]` | `products[0].media[]` | `{type,url}` |
+| `dates.created` / `dates.lastUpdated` | `*.created_at` / `last_updated_date` | created collapsed |
+| `verified` | `verified` | Always true for synced reviews |
+| `themes.{positive,negative,classifiedAt}` | `enrichment.themes.*` | **AI value-add** |
+| `tags.*` | `enrichment.attributes.*` | snake_cased |
+| `tags.tour` + `itinerary_mappings` | `enrichment.itinerary.{raw,group}` | grouping value-add |
+| `hasMedia` / `hasComment` | `enrichment.flags.*` | |
+| `moderationStatus` | — | Internal; all synced are `published` |
+</content>

--- a/docs/plans/2026-06-09-public-reviews-api.md
+++ b/docs/plans/2026-06-09-public-reviews-api.md
@@ -1,7 +1,7 @@
 # Public Reviews API — Recommendation & Design
 
 **Date:** 2026-06-09
-**Status:** Proposed (recommendation)
+**Status:** Proposed (recommendation) · revised after code review (Codex, PR #61)
 **Owner:** TBD
 
 **Goal:** Expose Uniworld's synced, AI-enriched reviews through a read-only HTTP API so the company marketing website (and partners) can render reviews, ratings, and aggregates — **without** leaking customer PII, **without** coupling consumers to Firestore internals, and using a **Feefo-style credential model** that anyone who has integrated Feefo will recognize.
@@ -24,7 +24,7 @@ Stand up a single, versioned, read-only Cloud Function (`reviewsApi`) plus a sma
 1. **Mirror Feefo's two core endpoints** — `GET /v1/reviews/all` and `GET /v1/reviews/summary/all` — using Feefo's envelope and field names, plus our extensions (`/v1/reviews/{id}`, `/v1/meta/*`).
 2. **Select brand via `merchant_identifier`** (`uniworld` | `luxury-gold` | `all`), matching Feefo's parameter exactly.
 3. **Add an `enrichment` block to every review** carrying AI themes + derived metadata, namespaced so it never collides with Feefo's schema.
-4. **Authenticate Feefo-style:** dashboard users self-mint `client_id` + `client_secret`; consumers exchange them at `POST /v1/oauth/token` for a bearer token. (See [Authentication](#authentication--api-credentials).)
+4. **Authenticate Feefo-style, server-side only:** dashboard users self-mint `client_id` + `client_secret`; consumers exchange them at `POST /v1/oauth/token` for a bearer token. (See [Authentication](#authentication--api-credentials).)
 5. **Enforce the *site's own* customer-name rule** via one shared `resolveDisplayName()` function used by both the website and the API — so what the API returns is byte-for-byte what the site shows, and the raw `name`/email/refs never escape. (See [PII firewall](#pii-firewall--name-display-parity).)
 6. **Read Firestore via the Admin SDK**, which lets us simultaneously **close the currently world-open Firestore read rules**.
 7. **Cache on the consumer side** — the calling backend caches the token and payloads, and aggregates come from precomputed summaries — since the API is server-to-server and data changes only every ~2 hours.
@@ -47,30 +47,20 @@ The sync pipeline ([`functions/src/sync/sync-reviews.ts`](../../functions/src/sy
 
 ### The rule we must match
 
-You asked that the API enforce the **exact** name rules the website uses: show the customer's name when the site shows it, show "Trusted Customer" when the site does. The wrinkle is that **the site is not internally consistent today**:
-
-| Surface | Rule today | Leaks raw `name`? |
-|---|---|---|
-| Reviews Explorer, `ReviewCard`, Export, Overview panels | `displayName \|\| "Trusted Customer"` | No |
-| Itinerary pages ([itinerary-queries.ts:355,531](../../app/src/lib/firestore/itinerary-queries.ts)), Ship pages ([ship-queries.ts:391,562](../../app/src/lib/firestore/ship-queries.ts)) | `displayName \|\| customer.name \|\| "Trusted Customer"` (one uses `"Guest"`) | **Yes** |
-
-The itinerary/ship surfaces fall back to the unmasked `customer.name`. That is almost certainly unintended: Feefo's `display_name` is the reviewer's **consent-approved** public name (often a full name when they opted in); the raw `name` is the unmasked record value and is not meant for public display. This is a latent privacy issue **independent of this API**.
-
-### The fix: one shared rule, used by site and API
-
-Centralize the rule so the two can never drift:
+The API enforces the **exact** name rules the website uses: show the customer's name when the site shows it, show "Trusted Customer" when the site does. The canonical rule (`displayName || "Trusted Customer"`, never the raw `name`) was shared and shipped to the website in **PR #60** via `resolveDisplayName()`:
 
 ```ts
-// shared/src/reviews/display-name.ts
-export function resolveDisplayName(customer: { displayName?: string | null }): string {
-  return customer.displayName?.trim() || "Trusted Customer";
+// app/src/lib/format/customer.ts  (shipped in #60; the API mirrors it)
+export function resolveDisplayName(
+  customer: { displayName?: string | null } | null | undefined,
+  fallback = "Trusted Customer"
+): string {
+  const name = customer?.displayName;
+  return typeof name === "string" && name.trim() ? name.trim() : fallback;
 }
 ```
 
-- The **website** refactors all surfaces ([queries.ts](../../app/src/lib/firestore/queries.ts), [reviews/page.tsx](../../app/src/app/reviews/page.tsx), [itinerary-queries.ts](../../app/src/lib/firestore/itinerary-queries.ts), [ship-queries.ts](../../app/src/lib/firestore/ship-queries.ts), [ExportButton.tsx](../../app/src/components/reviews/ExportButton.tsx)) to call this, **dropping the `|| customer.name` fallback** and standardizing the placeholder to "Trusted Customer".
-- The **API** calls the same function for `customer.display_name`.
-
-Result: the API returns precisely what the site shows. When a reviewer consented (so `display_name` exists, possibly a full name), that name flows through — matching your requirement. When they didn't, both show "Trusted Customer". The raw `name` flows **nowhere**.
+When the API moves into `functions/`/`shared/`, the same rule is reused verbatim (the canonical copy can live in `shared/` and the app import it, once the app consumes `shared`). The raw `name` flows **nowhere**.
 
 ### The firewall (allowlist mapper)
 
@@ -85,17 +75,21 @@ export function toPublicReview(d: ReviewDocument): PublicReview {
     url: d.feedbackUrl,
     customer: {
       display_name: resolveDisplayName(d.customer),  // identical to the website
-      display_location: d.customer.location,          // Feefo-public city/region
-      // d.customer.name / email / orderRef / customerRef are NEVER mapped
+      // display_location is OMITTED by default — the dashboard never renders
+      // customer location, so to match the site we don't expose it either
+      // (opt-in open decision). name / email / orderRef / customerRef NEVER map.
     },
     service: /* {min,max,rating}, title, review, created_at */,
     products: [ /* single product: rating, review, media, product{...}, created_at */ ],
     last_updated_date: d.dates.lastUpdated,
     verified: d.verified,
-    enrichment: { themes, attributes, itinerary, flags },  // see below
+    // attributes EXCLUDES tour_director by default (a staff member's name — open decision)
+    enrichment: { themes, attributes, itinerary, flags },
   };
 }
 ```
+
+**Conservative defaults (from review):** the v1 mapper **omits** `customer.display_location` (the dashboard never shows location, so omitting matches the site rule) and `enrichment.attributes.tour_director` (a staff member's personal name). Both are opt-in [open decisions](#open-decisions). The unit test asserts the *exact* output key set so any future addition is a deliberate, reviewed change.
 
 ---
 
@@ -122,9 +116,9 @@ Public base: `https://<site-domain>/api/v1/...`. The `reviewsApi` function route
 | Our endpoint | Feefo analogue | Auth | Purpose |
 |---|---|---|---|
 | `POST /v1/oauth/token` | `POST /oauth/v2/token` | client_id + secret | Exchange credentials for a bearer token |
-| `GET /v1/reviews/all` | `GET /20/reviews/all` | Bearer (or public path) | Paginated, filtered review list |
-| `GET /v1/reviews/summary/all` | `GET /20/reviews/summary/all` | Bearer (or public path) | Aggregate ratings + star distribution |
-| `GET /v1/reviews/{id}` | *(none)* | Bearer (or public path) | Single review — permalinks / SEO |
+| `GET /v1/reviews/all` | `GET /20/reviews/all` | Bearer | Paginated, filtered review list |
+| `GET /v1/reviews/summary/all` | `GET /20/reviews/summary/all` | Bearer | Aggregate ratings + star distribution |
+| `GET /v1/reviews/{id}` | *(none)* | Bearer | Single review — permalinks / SEO |
 | `GET /v1/meta/themes` | *(none)* | Bearer | AI theme taxonomy for filter UIs |
 | `GET /v1/meta/merchants` | *(none)* | Bearer | Available `merchant_identifier`s + labels |
 
@@ -163,7 +157,7 @@ Public base: `https://<site-domain>/api/v1/...`. The `reviewsApi` function route
       "merchant": { "identifier": "uniworld" },
       "id": "60a3f2c1e4b0a1b2c3d4e5f6",
       "url": "https://www.feefo.com/en-US/reviews/uniworld/...",
-      "customer": { "display_name": "Jane D.", "display_location": "London, UK" },
+      "customer": { "display_name": "Jane D." },
       "service": {
         "rating": { "min": 1, "max": 5, "rating": 5 },
         "title": "A wonderful trip from start to finish",
@@ -188,7 +182,7 @@ Public base: `https://<site-domain>/api/v1/...`. The `reviewsApi` function route
       "enrichment": {
         "themes": { "positive": ["Staff", "Excursions", "Food"], "negative": [], "classified_at": "2026-05-21T03:00:00Z" },
         "attributes": {
-          "ship": "S.S. Beatrice", "tour": "Enchanting Danube", "tour_director": "Markus W.",
+          "ship": "S.S. Beatrice", "tour": "Enchanting Danube",
           "booking_type": "Direct", "region": "Central Europe", "loyalty": "Returning Guest",
           "client_type": "Couple", "package": "All-Inclusive"
         },
@@ -200,7 +194,7 @@ Public base: `https://<site-domain>/api/v1/...`. The `reviewsApi` function route
 }
 ```
 
-**Design notes:** single `products[]` element (our model collapses to one product); `rating` objects synthesize `{min:1,max:5,rating}`; `created_at` maps from `dates.created` (per-section precision would need a sync change); raw Feefo `tags[]` are exposed normalized under `enrichment.attributes` (raw passthrough is an [open decision](#open-decisions)).
+**Design notes:** single `products[]` element (our model collapses to one product); `rating` objects synthesize `{min:1,max:5,rating}`; `created_at` maps from `dates.created` (per-section precision would need a sync change); raw Feefo `tags[]` are exposed normalized under `enrichment.attributes` (raw passthrough is an [open decision](#open-decisions)). Per the review, the example above already reflects the v1 defaults: **no `display_location`, no `tour_director`**.
 
 ---
 
@@ -215,7 +209,7 @@ Feefo-shaped summary served from the precomputed [`summaries`](../../functions/s
   "rating": {
     "min": 1, "max": 5, "rating": 4.81,
     "product": { "count": 1790, "5_star": 1500, "4_star": 210, "3_star": 50, "2_star": 20, "1_star": 10 },
-    "service": { "count": 1760, "5_star": 1480, "4_star": 200, "3_star": 50, "2_star": 18, "1_star": 12 }
+    "service": null
   },
   "enrichment": {
     "scope": "fleet", "reviews_with_comments": 1203,
@@ -226,13 +220,13 @@ Feefo-shaped summary served from the precomputed [`summaries`](../../functions/s
 }
 ```
 
-> **Star-distribution caveat:** `compute-summaries.ts` currently builds `starDistribution` from the **product** rating only. Serve `product` now; populating `service` needs a small sync addition. Until then emit `product` and null `service` rather than faking it.
+> **Star-distribution caveat:** `compute-summaries.ts` builds `starDistribution` and `avgRating` from the **product** rating only (for fleet, ship, itinerary, and monthly summaries). So `rating.service` is emitted as **`null`** (shown above) until a sync change computes the service distribution — never faked. Adding `service` is part of Phase 4.
 
 ---
 
 ## Authentication & API credentials
 
-**Model: OAuth 2.0 client-credentials, mirroring Feefo.** Feefo issues a `client_id` + `client_secret` and you exchange them at `POST /oauth/v2/token` for a short-lived bearer token — see our own consumer implementation in [`shared/src/feefo/client.ts`](../../shared/src/feefo/client.ts). We emulate that flow exactly so a partner who has integrated Feefo can reuse their code against us by changing only the base URL and credentials.
+**Model: OAuth 2.0 client-credentials, mirroring Feefo, server-side only.** Feefo issues a `client_id` + `client_secret` and you exchange them at `POST /oauth/v2/token` for a short-lived bearer token — see our own consumer implementation in [`shared/src/feefo/client.ts`](../../shared/src/feefo/client.ts). We emulate that flow exactly so a partner who has integrated Feefo can reuse their code against us by changing only the base URL and credentials.
 
 ### Credential model — server-side only
 
@@ -246,7 +240,7 @@ A single **confidential client**: `client_id` + `client_secret` → bearer token
 
 Add an **"API Access"** area under admin/settings:
 
-- An owner/admin clicks **Create API client**, gives it a label and a **merchant scope** (which `merchant_identifier`s it may read), and receives `client_id` + `client_secret`. **The secret is shown once**; only a hash is stored.
+- An owner/admin clicks **Create API client**, gives it a label and a **merchant scope** (which `merchant_identifier`s it may read), and receives `client_id` + `client_secret`. **The secret is shown once**; only a verifier is stored.
 - Manage: list clients (with `lastUsedAt`), **rotate** secret, **revoke**.
 - Gated by a new `manageApiClients` permission added to the existing Firestore access-control model ([`functions/src/auth/access-control.ts`](../../functions/src/auth/access-control.ts), `admin_users`) — same pattern as the existing `adminUsers` endpoint.
 
@@ -260,12 +254,15 @@ Content-Type: application/json
 ```
 ```jsonc
 // 200
-{ "access_token": "<JWT>", "token_type": "Bearer", "expires_in": 3600 }
+{ "access_token": "...", "token_type": "Bearer", "expires_in": 3600 }
 ```
 
-- Look up the client, verify `status: "active"`, **constant-time** compare the secret against the stored hash.
-- Mint a short-lived signed **JWT** (HS256 via a Secret Manager key, or RS256) with claims `{ sub: clientId, merchants: [...], scopes: [...], exp }`.
-- Response mirrors Feefo's `{ access_token, expires_in }` exactly. (Implementation: add `jose`/`jsonwebtoken`, or self-sign with Node `crypto` HMAC — no new dep.)
+- Look up the client, verify `status: "active"`, and **constant-time** compare the secret against the stored verifier (see [Credential storage & verification](#credential-storage--verification)).
+- Issue a short-lived token (default TTL 1h). **Two options — pick one in build:**
+  - **(a) Opaque token** whose hash is stored server-side and looked up per request → **revocation is immediate**.
+  - **(b) Signed JWT** (`{ sub: clientId, merchants, scopes, ver, exp }`) → stateless, but a revoked client keeps working until `exp` **unless every request also re-checks the client's `status`/`tokenVersion`** (a cheap, cacheable read).
+  - **Default recommendation:** opaque tokens, for simple immediate revocation; use a JWT only if statelessness is required.
+- Response mirrors Feefo's `{ access_token, token_type, expires_in }` exactly.
 
 ### Authenticated requests
 
@@ -274,25 +271,40 @@ GET /api/v1/reviews/all?merchant_identifier=uniworld
 Authorization: Bearer <access_token>
 ```
 
-`reviewsApi` verifies the JWT signature + expiry, then checks that the requested `merchant_identifier` ∈ `token.merchants` and that scope allows `reviews:read`. A client scoped to `luxury-gold` cannot read `uniworld`.
+`reviewsApi` validates the token (signature/lookup + expiry + `status`/`tokenVersion`), then checks that the requested `merchant_identifier` ∈ `token.merchants` and that scope allows `reviews:read`. A client scoped to `luxury-gold` cannot read `uniworld`.
+
+### Abuse controls & per-endpoint authorization
+
+- **Rate limiting is enforced** per `clientId` (the `rateLimitTier`), not merely recorded — e.g. a token bucket in Firestore/Memorystore — returning `429` with `Retry-After` when exceeded.
+- **`GET /v1/reviews/{id}` is scope-checked after load:** fetch the doc, then return it only if its `brand` is within the caller's `merchants`. Return an **identical `404`** for both "not found" and "out of scope", so ids (which can be derived from Feefo URLs) can't be enumerated or probed across merchants.
+- **Request logging** records `clientId`, merchant(s), endpoint, status, latency, and result count — for abuse investigation and per-client analytics.
 
 ### Firestore model
 
 ```
 api_clients/{clientId}
-  clientId    : string            // public id, e.g. "uw_live_a1b2c3"
-  secretHash  : string            // sha256/bcrypt of the secret (shown to user once)
-  label       : string            // "Marketing website (prod)"
-  merchants   : string[]          // allowed identifiers, or ["*"]
-  scopes      : string[]          // ["reviews:read","summary:read"]
-  status      : "active"|"revoked"
-  createdBy   : string            // dashboard uid/email
+  clientId       : string         // public id, e.g. "uw_live_a1b2c3"
+  secretVerifier : string         // argon2id/bcrypt hash, OR HMAC-SHA256(secret, pepper) — see below
+  label          : string         // "Marketing website (prod)"
+  merchants      : string[]       // allowed identifiers, or ["*"]
+  scopes         : string[]       // ["reviews:read","summary:read"]
+  status         : "active"|"revoked"
+  tokenVersion   : number         // bumped on rotate/revoke; invalidates opaque tokens / re-checked by JWTs
+  createdBy      : string         // dashboard uid/email
   createdAt, lastUsedAt
   rateLimitTier? : string
-  orgId?      : string            // multi-tenant future
+  orgId?         : string         // multi-tenant future
 ```
 
-Rules: `allow read, write: if false` — Admin SDK only; secrets are never client-readable (mirrors the roadmap's `credentials` subcollection). Signing key lives in Secret Manager / functions env as `REVIEWS_API_JWT_SECRET`.
+Rules: `allow read, write: if false` — Admin SDK only; secrets/verifiers are never client-readable (mirrors the roadmap's `credentials` subcollection).
+
+### Credential storage & verification
+
+- **Secrets are server-generated** with high entropy (e.g. 32 random bytes, base64url) — never user-chosen — and shown once.
+- **Store a verifier, not the secret:** `argon2id` (preferred) or `bcrypt`, **or** `HMAC-SHA256(secret, pepper)` where the pepper is a Secret Manager value. Plain unsalted SHA-256 is *not* the spec — choose a slow KDF or a peppered HMAC explicitly in build.
+- **Verify in constant time** (`crypto.timingSafeEqual` for HMAC; the library's own compare for argon2/bcrypt).
+- **JWT signing material** (option b) lives in Secret Manager, bound to the function as `REVIEWS_API_JWT_SECRET`; rotate via `kid`.
+- **Revocation:** opaque tokens are killed immediately by deleting their server-side hash or bumping `tokenVersion`; JWTs need the per-request `status`/`tokenVersion` check noted above.
 
 ### Caching (server-side)
 
@@ -304,7 +316,9 @@ Credentials buy us per-consumer **analytics, revocation, rate-limit tiers, and b
 
 ## Brand / merchant support
 
-`merchant_identifier` maps directly to `ReviewDocument.brand` (identical values), validated against `VALID_BRANDS` ([index.ts](../../functions/src/index.ts)); filtering is an indexed `where("brand","==",…)`. `merchant_identifier=all` fans out and merges (the dashboard's "combined" logic). Every request is additionally constrained to the **caller's credential `merchants` scope**.
+`merchant_identifier` maps directly to `ReviewDocument.brand` (identical values); filtering is an indexed `where("brand","==",…)`. Validate it against a **shared, exported** brand/merchant constant in `shared/` — today there are *two private* `VALID_BRANDS` constants ([functions/src/index.ts](../../functions/src/index.ts) and [shared/src/feefo/transform.ts](../../shared/src/feefo/transform.ts)); the API should add **one exported source of truth** rather than reference a private local.
+
+**`merchant_identifier=all` is a fan-out, not a brandless query:** run the per-merchant brand-scoped query for each allowed merchant and merge/sort. This reuses the existing `brand + …` composite indexes and **avoids adding brandless composites** — the current [`firestore.indexes.json`](../../firestore.indexes.json) has brandless indexes for `tags.tour`/`tags.ship`/themes/`hasMedia` but **not** for `tags.region`, `tags.bookingType`, `tags.loyalty`, or `ratings.product`+date, so a brandless `all`+filter query would otherwise fail. Every request is additionally constrained to the caller's credential `merchants` scope.
 
 **Forward-compatible with multi-tenant:** a `merchant_registry/{merchant_identifier} → { orgId, collectionPath, label }` resolver keeps the API merchant-centric (Feefo-style) even after data moves to `organizations/{orgId}/reviews` — the `/v1` contract never changes, only the resolver does. API clients gain an `orgId` and belong to one org.
 
@@ -312,7 +326,7 @@ Credentials buy us per-consumer **analytics, revocation, rate-limit tiers, and b
 
 ## Pagination
 
-Support both, honestly: **`page`/`page_size`** for Feefo familiarity and shallow paging (`summary.meta` returns `{count,pages,page_size,current_page}`, `count` via a cheap `getCountFromServer` aggregate), and an opaque **`cursor`/`next_cursor`** for efficient deep iteration and full exports (preferred past the first few pages, since Firestore offset paging re-reads skipped docs).
+Support both, honestly: **`page`/`page_size`** for Feefo familiarity and shallow paging (`summary.meta` returns `{count,pages,page_size,current_page}`, `count` via a cheap `getCountFromServer` aggregate), and an opaque **`cursor`/`next_cursor`** for efficient deep iteration and full exports (preferred past the first few pages, since Firestore offset paging re-reads skipped docs). For `merchant_identifier=all`, the cursor encodes **per-merchant positions** (the fan-out merges each merchant's ordered stream), so deep paging stays correct across the merged result.
 
 ---
 
@@ -324,9 +338,18 @@ Support both, honestly: **`page`/`page_size`** for Feefo familiarity and shallow
 
 ---
 
+## Errors & observability
+
+- **Uniform error envelope:** `{ "error": { "code": "string", "message": "string", "request_id": "string" } }`.
+- **Status codes:** `400` bad params · `401` missing/invalid/expired token · `403` valid token but merchant/scope not allowed · `404` unknown route or review (also used for out-of-scope ids) · `405` wrong method · `429` rate-limited (with `Retry-After`) · `500` server error.
+- **`request_id`** echoed in the body and an `X-Request-Id` header.
+- **Structured logs** per request: `clientId`, merchant(s), endpoint, status, latency, result count, rate-limit outcome — reuse the existing `operation_logs` pattern or Cloud Logging.
+
+---
+
 ## Security tie-in
 
-Standing up the sanitized API is the moment to fix the open-rules exposure flagged in [`docs/security-and-access.md`](../../docs/security-and-access.md): the function reads via the Admin SDK (bypasses rules), so we can tighten [`firestore.rules`](../../firestore.rules) `reviews` (and other dashboard collections) from `allow read: if true` to `allow read: if request.auth != null` — matching the roadmap's legacy-collection rules. Public consumers use the sanitized API instead of raw PII.
+Standing up the sanitized API is the moment to fix the open-rules exposure flagged in [`docs/security-and-access.md`](../../docs/security-and-access.md). The function reads via the Admin SDK (bypasses rules), so we can tighten [`firestore.rules`](../../firestore.rules). **All five currently world-readable collections must change** from `allow read: if true` to `allow read: if request.auth != null`: `reviews`, `summaries`, `monthly_summaries`, `sync_meta`, and `itinerary_mappings`. The new `api_clients` collection is **deny-all** to client SDKs (Admin-SDK-only). Public consumers use the sanitized API instead of raw PII.
 
 ---
 
@@ -344,13 +367,13 @@ Keep the firewall in `shared/` so B/C adopt it unchanged.
 
 ## Search
 
-`search` is Phase 5. A **dormant**, already-PII-stripped Algolia projection exists ([algolia-sync.ts](../../functions/src/sync/algolia-sync.ts)) but is never invoked and unused by the app. If needed, activate that sync and either proxy search through `reviewsApi` or issue Algolia **search-only** keys.
+`search` is Phase 5. A **dormant** Algolia projection exists ([algolia-sync.ts](../../functions/src/sync/algolia-sync.ts)) — confirmed never invoked and unused by the app — but it is **only partially sanitized**: it indexes `customerName` (the `displayName`) as a *searchable* attribute. Before activation it needs a privacy pass: **drop `customerName` from the index** (or derive it via `resolveDisplayName()` and mark it non-searchable). Then activate the sync and either proxy search through `reviewsApi` or issue Algolia **search-only** keys.
 
 ---
 
 ## SEO note (confirm scope)
 
-For **star ratings in Google results**, the site must server-render review content and emit schema.org `Review` / `AggregateRating` JSON-LD; a client-fetched widget won't be indexed. The API supplies the data; rendering must be server-side. Confirm before build — it shapes whether the site consumes the **credentialed server path** (recommended for SEO) vs a browser widget.
+For **star ratings in Google results**, the site must server-render review content and emit schema.org `Review` / `AggregateRating` JSON-LD; a client-fetched widget won't be indexed. The API supplies the data; rendering must be server-side — which fits the server-only model: the site's backend fetches from the API with credentials and server-renders. Confirm whether JSON-LD is in scope before build.
 
 ---
 
@@ -358,11 +381,11 @@ For **star ratings in Google results**, the site must server-render review conte
 
 | Phase | Scope | Effort |
 |---|---|---|
-| **1 — Name rule + firewall + contract** | `resolveDisplayName()` in `shared/`; refactor all app surfaces to use it (drop `\|\| name` fallback on itinerary/ship); `PublicReview`/`PublicSummary` types + `toPublicReview()`/`toPublicSummary()`; unit tests asserting PII never serializes. | S–M |
-| **2 — Core endpoints** | `reviewsApi`: `/v1/reviews/summary/all`, `/v1/reviews/all`, `/v1/reviews/{id}`; Hosting rewrite; cache/ETag; pagination. | M |
-| **3 — Auth & credentials** | `POST /v1/oauth/token`; `api_clients` model + hashing + JWT mint/verify; `apiClients` management function; `manageApiClients` permission; dashboard "API Access" UI; per-client merchant scoping + revoke/rotate. | M–L |
-| **4 — Hardening + extensions** | Tighten Firestore rules; `merchant_registry`; `/v1/meta/*`; `merchant_identifier=all`; service-star distribution in sync. | M |
-| **5 — Search & scale (optional)** | Activate Algolia for `search`; or Option B/C. | M |
+| **1 — Name rule + firewall + contract** | `resolveDisplayName()` (✅ shipped to the app in #60) promoted/shared; `PublicReview`/`PublicSummary` types + `toPublicReview()`/`toPublicSummary()` allowlist mappers (omit `display_location`/`tour_director`); unit test asserting the exact public key set. | S–M |
+| **2 — Core endpoints** | `reviewsApi`: `/v1/reviews/summary/all`, `/v1/reviews/all`, `/v1/reviews/{id}` (scope-checked, uniform 404); Hosting rewrite; cache/ETag; pagination; uniform error envelope + request ids. | M |
+| **3 — Auth & credentials** | `POST /v1/oauth/token`; `api_clients` model with server-generated secrets + `argon2id`/peppered-HMAC verifier; opaque-or-JWT tokens with revocation (`tokenVersion`); `apiClients` management function; `manageApiClients` permission; dashboard "API Access" UI; per-client merchant scoping, **rate-limit enforcement**, revoke/rotate. | M–L |
+| **4 — Hardening + extensions** | Tighten **all five** public collections' rules; shared brand constant; `merchant_registry`; `/v1/meta/*`; `merchant_identifier=all` fan-out; **service** star distribution in sync. | M |
+| **5 — Search & scale (optional)** | Privacy-pass + activate Algolia for `search`; or Option B/C. | M |
 
 ---
 
@@ -370,23 +393,23 @@ For **star ratings in Google results**, the site must server-render review conte
 
 | File | Action | Purpose |
 |---|---|---|
-| `shared/src/reviews/display-name.ts` | Create | `resolveDisplayName()` — single source of truth for the name rule |
-| `shared/src/reviews/public.ts` | Create | `PublicReview`/`PublicSummary` + allowlist mappers |
-| `shared/src/reviews/__tests__/public.test.ts` | Create | Assert no PII field serializes; name parity with the site rule |
-| `shared/src/index.ts` | Modify | Re-export public mappers/types + `resolveDisplayName` |
-| `app/src/lib/firestore/{queries,itinerary-queries,ship-queries}.ts` | Modify | Use `resolveDisplayName`; **remove `\|\| customer.name` fallback** |
-| `app/src/app/reviews/page.tsx`, `app/src/components/reviews/ExportButton.tsx` | Modify | Use `resolveDisplayName` |
-| `functions/src/api/reviews-api.ts` | Create | Param parsing, query building, pagination, cache headers, router |
-| `functions/src/api/oauth.ts` | Create | Token endpoint; JWT mint/verify; constant-time secret check |
-| `functions/src/api/api-clients.ts` | Create | Client CRUD (create/list/revoke/rotate), secret hashing |
+| `shared/src/reviews/display-name.ts` | Create | Canonical `resolveDisplayName()` (shared with the app's #60 copy) |
+| `shared/src/reviews/public.ts` | Create | `PublicReview`/`PublicSummary` + allowlist mappers (omit location/tour_director) |
+| `shared/src/reviews/__tests__/public.test.ts` | Create | Assert the exact public key set; no PII field serializes |
+| `shared/src/feefo/brands.ts` | Create | **One exported** brand/merchant constant; replace the two private `VALID_BRANDS` |
+| `shared/src/index.ts` | Modify | Re-export public mappers/types, `resolveDisplayName`, brands |
+| `functions/src/api/reviews-api.ts` | Create | Param parsing, query building, fan-out for `all`, pagination, cache/ETag, error envelope, router |
+| `functions/src/api/oauth.ts` | Create | Token endpoint; opaque/JWT mint+verify; constant-time secret check |
+| `functions/src/api/api-clients.ts` | Create | Client CRUD (create/list/revoke/rotate); secret generation + verifier hashing |
+| `functions/src/api/rate-limit.ts` | Create | Per-client token-bucket enforcement (`429` + `Retry-After`) |
 | `functions/src/api/merchant-registry.ts` | Create | `merchant_identifier → { orgId, collectionPath, label }` |
 | `functions/src/auth/access-control.ts` | Modify | Add `manageApiClients` permission |
 | `functions/src/index.ts` | Modify | Export `reviewsApi`, `oauthToken`, `apiClients` |
 | `app/src/app/admin/api-access/page.tsx` (+ component) | Create | Self-service credential UI |
 | `firebase.json` | Modify | Hosting rewrite `/api/** → reviewsApi`; keep SPA fallback last |
-| `firestore.rules` | Modify | `api_clients` deny-all to clients; tighten `reviews` to `auth != null` |
-| `firestore.indexes.json` | Modify | Brand-less attribute/date indexes for `merchant_identifier=all` |
-| `functions/.env.example` | Modify | `REVIEWS_API_JWT_SECRET`, `REVIEWS_API_ALLOWED_ORIGINS` |
+| `firestore.rules` | Modify | `api_clients` deny-all; tighten **all five** public collections (`reviews`, `summaries`, `monthly_summaries`, `sync_meta`, `itinerary_mappings`) to `auth != null` |
+| `firestore.indexes.json` | No change expected | `merchant_identifier=all` fans out over per-merchant brand-scoped queries, reusing existing indexes |
+| `functions/.env.example` | Modify | `REVIEWS_API_JWT_SECRET` / `REVIEWS_API_SECRET_PEPPER` |
 | `docs/feefo-api-reference.md` | Modify | Cross-link the Feefo→ours param/field/auth mapping |
 
 ---
@@ -395,25 +418,27 @@ For **star ratings in Google results**, the site must server-render review conte
 
 | Risk | Impact | Mitigation |
 |---|---|---|
-| PII leak through the API | Critical | Allowlist mapper (never spread); unit test asserts forbidden keys absent; `resolveDisplayName` shared with site |
-| Existing itinerary/ship pages already render raw names | High (privacy) | Fix as Phase 1 (drop `\|\| name`); ship before the API launches |
-| Client secret leakage | High | Store only a hash; show secret once; `api_clients` deny-all client reads; signing key in Secret Manager |
-| Auth breaks CDN caching | Medium | Consumer-side caching for credentialed path; publishable-key/public cached path for browser/SEO |
-| `merchant_identifier=all` hits unindexed queries | Medium | Pre-create composite indexes; cap `page_size`; prefer cursor |
+| PII leak through the API | Critical | Allowlist mapper (never spread); unit test asserts the exact key set; `resolveDisplayName` shared with site; location + tour_director omitted by default |
+| Client secret leakage | High | Server-generated high-entropy secrets; store only a verifier (`argon2id`/peppered-HMAC); show once; `api_clients` deny-all; signing key in Secret Manager |
+| Revoked credential keeps working (JWT) | Medium | Prefer **opaque** tokens, or re-check `status`/`tokenVersion` per request; short TTL |
+| `merchant_identifier=all` hits unindexed queries | Medium | Implement `all` as a per-merchant **fan-out** over existing brand-scoped indexes (no brandless composites); cap `page_size` |
+| Endpoint abuse / id enumeration | Medium | Per-client rate limiting (`429`); uniform `404` for missing vs out-of-scope ids; request logging |
+| Under-tightening Firestore rules | High (privacy) | Enumerate **all five** public collections explicitly in `firestore.rules` |
 | Contract churn at multi-tenant | Medium | `merchant_registry` indirection keeps `/v1` stable |
-| Consumers expect 1:1 Feefo parity | Low | Document every deviation (single product, synthesized `created_at`, normalized tags, `/v1/oauth/token` vs `/oauth/v2/token`) |
+| Consumers expect 1:1 Feefo parity | Low | Document every deviation (single product, synthesized `created_at`, normalized tags, `/v1/oauth/token` vs `/oauth/v2/token`, omitted location/tour_director) |
 
 ---
 
 ## Open decisions
 
-1. **Customer-name rule (needs a call):** confirm the canonical rule is `displayName \|\| "Trusted Customer"` everywhere and that we **remove the `\|\| customer.name` fallback** on itinerary/ship pages. (Recommended — it's a privacy fix regardless of the API.)
-2. **Auth surface:** ✅ **Resolved — server-side only.** Feefo-style `client_id`/`client_secret` → bearer token; no browser-embeddable key. Front-end access goes through the consumer's own same-origin backend endpoints. Remaining sub-decision: token TTL (default 1h) and JWT vs opaque token.
-3. **`display_location`:** keep Feefo's city/region (it treats it as public) or drop for extra caution?
-4. **Raw Feefo `tags[]`:** normalized `enrichment.attributes` only, or also retain + passthrough raw tags (needs a sync change)?
-5. **Per-section `created_at`:** accept the collapsed-date approximation, or extend the sync to retain `service`/`product` timestamps separately?
-6. **Hosting surface:** path-based (`/api/...` on the marketing domain) vs a dedicated `reviews-api.` subdomain.
-7. **SEO scope:** is server-rendered JSON-LD in scope?
+1. **Customer-name rule:** ✅ **Resolved** — canonical `displayName || "Trusted Customer"`, `|| customer.name` fallback removed (shipped in **PR #60** via shared `resolveDisplayName()`).
+2. **Auth surface:** ✅ **Resolved — server-side only.** Feefo-style `client_id`/`client_secret` → bearer token; no browser-embeddable key. Remaining sub-decision: token format — **opaque (recommended) vs JWT** — and TTL (default 1h).
+3. **`display_location`:** ✅ default **omit** in v1 (the dashboard never displays customer location, so omitting matches the site rule). Open: expose later with product sign-off?
+4. **`tour_director` (staff name):** ✅ default **omit** in v1 (it's a person's name). Open: expose as public metadata, or keep internal-only?
+5. **Raw Feefo `tags[]`:** normalized `enrichment.attributes` only, or also retain + passthrough raw tags (needs a sync change)?
+6. **Per-section `created_at`:** accept the collapsed-date approximation, or extend the sync to retain `service`/`product` timestamps separately?
+7. **Hosting surface:** path-based (`/api/...` on the marketing domain) vs a dedicated `reviews-api.` subdomain.
+8. **SEO scope:** is server-rendered JSON-LD in scope?
 
 ---
 
@@ -425,8 +450,8 @@ For **star ratings in Google results**, the site must server-render review conte
 | `id` | `id` | Stable doc id |
 | `feedbackUrl` | `url` | |
 | `customer.displayName` | `customer.display_name` | via `resolveDisplayName()`; empty ⇒ `"Trusted Customer"` |
-| `customer.location` | `customer.display_location` | Public-safe |
-| `customer.name` / `email` / `orderRef` / `customerRef` | — | **Dropped (PII).** `name` is the value some site pages currently leak as a fallback — to be removed |
+| `customer.location` | — (default) | **Omitted in v1** — the site never shows location; opt-in open decision |
+| `customer.name` / `email` / `orderRef` / `customerRef` | — | **Dropped (PII).** (`name` was the value some site pages leaked as a fallback; removed in #60) |
 | `ratings.service` / `ratings.product` | `service.rating.rating` / `products[0].rating.rating` | wrapped `{min:1,max:5,rating}` |
 | `reviews.serviceTitle` / `serviceText` / `productText` | `service.title` / `service.review` / `products[0].review` | |
 | `product.{title,sku,parentSku,url,imageUrl}` | `products[0].product.{title,sku,parent_sku,url,image_url}` | |
@@ -434,7 +459,7 @@ For **star ratings in Google results**, the site must server-render review conte
 | `dates.created` / `dates.lastUpdated` | `*.created_at` / `last_updated_date` | created collapsed |
 | `verified` | `verified` | Always true for synced reviews |
 | `themes.{positive,negative,classifiedAt}` | `enrichment.themes.*` | **AI value-add** |
-| `tags.*` | `enrichment.attributes.*` | snake_cased |
+| `tags.*` (except `tourDirector`) | `enrichment.attributes.*` | snake_cased; **`tour_director` omitted in v1** (staff name — open decision) |
 | `tags.tour` + `itinerary_mappings` | `enrichment.itinerary.{raw,group}` | grouping value-add |
 | `hasMedia` / `hasComment` | `enrichment.flags.*` | |
 | `moderationStatus` | — | Internal; all synced are `published` |

--- a/docs/plans/2026-06-09-public-reviews-api.md
+++ b/docs/plans/2026-06-09-public-reviews-api.md
@@ -4,7 +4,7 @@
 **Status:** Proposed (recommendation) · revised after code review (Codex, PR #61)
 **Owner:** TBD
 
-> **Dependency / status:** the customer-name rule this design reuses (`resolveDisplayName()`) is introduced on the website in **PR #60**, which is **still open**. This branch (`reviews-public-api`) does **not** contain those `app/` changes. The name-rule items below are therefore *pending #60* — the "same as the website" guarantee holds once #60 merges.
+> **Dependency / status:** the customer-name rule this design reuses (`resolveDisplayName()`) was added to the website in **PR #60**, now **merged** — `app/src/lib/format/customer.ts` is on `main`, so the base dependency is satisfied. (This `reviews-public-api` branch was cut before #60, so it won't contain that file until it's synced with `main`; that doesn't affect the design.)
 
 **Goal:** Expose Uniworld's synced, AI-enriched reviews through a read-only HTTP API so the company marketing website (and partners) can render reviews, ratings, and aggregates — **without** leaking customer PII, **without** coupling consumers to Firestore internals, and using a **Feefo-style credential model** that anyone who has integrated Feefo will recognize.
 
@@ -27,7 +27,7 @@ Stand up a single, versioned, read-only Cloud Function (`reviewsApi`) plus a sma
 2. **Select brand via `merchant_identifier`** (`uniworld` | `luxury-gold` | `all`), matching Feefo's parameter exactly.
 3. **Add an `enrichment` block to every review** carrying AI themes + derived metadata, namespaced so it never collides with Feefo's schema.
 4. **Authenticate Feefo-style, server-side only:** dashboard users self-mint `client_id` + `client_secret`; consumers exchange them at `POST /v1/oauth/token` for a bearer token. (See [Authentication](#authentication--api-credentials).)
-5. **Enforce the *site's own* customer-name rule** via one shared `resolveDisplayName()` rule — added to the website in PR #60 (open) and reused by the API — so what the API returns is byte-for-byte what the site shows, and the raw `name`/email/refs never escape. (See [PII firewall](#pii-firewall--name-display-parity).)
+5. **Enforce the *site's own* customer-name rule** via one shared `resolveDisplayName()` rule — added to the website in PR #60 (merged) and reused by the API — so what the API returns is byte-for-byte what the site shows, and the raw `name`/email/refs never escape. (See [PII firewall](#pii-firewall--name-display-parity).)
 6. **Read Firestore via the Admin SDK**, which lets us simultaneously **close the currently world-open Firestore read rules**.
 7. **Cache on the consumer side** — the calling backend caches the token and payloads, and aggregates come from precomputed summaries — since the API is server-to-server and data changes only every ~2 hours.
 
@@ -49,10 +49,10 @@ The sync pipeline ([`functions/src/sync/sync-reviews.ts`](../../functions/src/sy
 
 ### The rule we must match
 
-The API enforces the **exact** name rules the website uses: show the customer's name when the site shows it, show "Trusted Customer" when the site does. The canonical rule (`displayName || "Trusted Customer"`, never the raw `name`) is introduced on the website in **PR #60** — currently **open / in review** — via `resolveDisplayName()`:
+The API enforces the **exact** name rules the website uses: show the customer's name when the site shows it, show "Trusted Customer" when the site does. The canonical rule (`displayName || "Trusted Customer"`, never the raw `name`) was introduced on the website in **PR #60** (now **merged** to `main`) via `resolveDisplayName()`:
 
 ```ts
-// app/src/lib/format/customer.ts  (added in PR #60, still open; the API mirrors it)
+// app/src/lib/format/customer.ts  (added in PR #60, merged; the API mirrors it)
 export function resolveDisplayName(
   customer: { displayName?: string | null } | null | undefined,
   fallback = "Trusted Customer"
@@ -383,7 +383,7 @@ For **star ratings in Google results**, the site must server-render review conte
 
 | Phase | Scope | Effort |
 |---|---|---|
-| **1 — Name rule + firewall + contract** | `resolveDisplayName()` (added to the app in **PR #60**, open) promoted to `shared/`; `PublicReview`/`PublicSummary` types + `toPublicReview()`/`toPublicSummary()` allowlist mappers (omit `display_location`/`tour_director`); unit test asserting the exact public key set. **Depends on #60 merging.** | S–M |
+| **1 — Name rule + firewall + contract** | `resolveDisplayName()` (added to the app in **PR #60**, merged) promoted to `shared/` as the single source of truth; `PublicReview`/`PublicSummary` types + `toPublicReview()`/`toPublicSummary()` allowlist mappers (omit `display_location`/`tour_director`); unit test asserting the exact public key set. | S–M |
 | **2 — Core endpoints** | `reviewsApi`: `/v1/reviews/summary/all`, `/v1/reviews/all`, `/v1/reviews/{id}` (scope-checked, uniform 404); Hosting rewrite; cache/ETag; pagination; uniform error envelope + request ids. | M |
 | **3 — Auth & credentials** | `POST /v1/oauth/token`; `api_clients` model with server-generated secrets + `argon2id`/peppered-HMAC verifier; opaque-or-JWT tokens with revocation (`tokenVersion`); `apiClients` management function; `manageApiClients` permission; dashboard "API Access" UI; per-client merchant scoping, **rate-limit enforcement**, revoke/rotate. | M–L |
 | **4 — Hardening + extensions** | Tighten **all five** public collections' rules; shared brand constant; `merchant_registry`; `/v1/meta/*`; `merchant_identifier=all` fan-out; **service** star distribution in sync. | M |
@@ -433,7 +433,7 @@ For **star ratings in Google results**, the site must server-render review conte
 
 ## Open decisions
 
-1. **Customer-name rule:** 🔄 **In review (PR #60, open)** — canonical `displayName || "Trusted Customer"` with the `|| customer.name` fallback removed; merges independently of this API and counts as settled once #60 lands.
+1. **Customer-name rule:** ✅ **Resolved (PR #60, merged)** — canonical `displayName || "Trusted Customer"` with the `|| customer.name` fallback removed; the rule now lives on `main` for the website, and the API reuses it.
 2. **Auth surface:** ✅ **Resolved — server-side only.** Feefo-style `client_id`/`client_secret` → bearer token; no browser-embeddable key. Remaining sub-decision: token format — **opaque (recommended) vs JWT** — and TTL (default 1h).
 3. **`display_location`:** ✅ default **omit** in v1 (the dashboard never displays customer location, so omitting matches the site rule). Open: expose later with product sign-off?
 4. **`tour_director` (staff name):** ✅ default **omit** in v1 (it's a person's name). Open: expose as public metadata, or keep internal-only?
@@ -453,7 +453,7 @@ For **star ratings in Google results**, the site must server-render review conte
 | `feedbackUrl` | `url` | |
 | `customer.displayName` | `customer.display_name` | via `resolveDisplayName()`; empty ⇒ `"Trusted Customer"` |
 | `customer.location` | — (default) | **Omitted in v1** — the site never shows location; opt-in open decision |
-| `customer.name` / `email` / `orderRef` / `customerRef` | — | **Dropped (PII).** (`name` was the value some site pages leaked as a fallback; removal proposed in **PR #60**, open) |
+| `customer.name` / `email` / `orderRef` / `customerRef` | — | **Dropped (PII).** (`name` was the value some site pages leaked as a fallback; removed in **PR #60**, merged) |
 | `ratings.service` / `ratings.product` | `service.rating.rating` / `products[0].rating.rating` | wrapped `{min:1,max:5,rating}` |
 | `reviews.serviceTitle` / `serviceText` / `productText` | `service.title` / `service.review` / `products[0].review` | |
 | `product.{title,sku,parentSku,url,imageUrl}` | `products[0].product.{title,sku,parent_sku,url,image_url}` | |

--- a/docs/plans/2026-06-09-public-reviews-api.md
+++ b/docs/plans/2026-06-09-public-reviews-api.md
@@ -4,6 +4,8 @@
 **Status:** Proposed (recommendation) · revised after code review (Codex, PR #61)
 **Owner:** TBD
 
+> **Dependency / status:** the customer-name rule this design reuses (`resolveDisplayName()`) is introduced on the website in **PR #60**, which is **still open**. This branch (`reviews-public-api`) does **not** contain those `app/` changes. The name-rule items below are therefore *pending #60* — the "same as the website" guarantee holds once #60 merges.
+
 **Goal:** Expose Uniworld's synced, AI-enriched reviews through a read-only HTTP API so the company marketing website (and partners) can render reviews, ratings, and aggregates — **without** leaking customer PII, **without** coupling consumers to Firestore internals, and using a **Feefo-style credential model** that anyone who has integrated Feefo will recognize.
 
 **Guiding principle:** *Emulate the Feefo NativeReviews API as closely as practical, then layer our value-add on top.* That applies to three things at once:
@@ -25,7 +27,7 @@ Stand up a single, versioned, read-only Cloud Function (`reviewsApi`) plus a sma
 2. **Select brand via `merchant_identifier`** (`uniworld` | `luxury-gold` | `all`), matching Feefo's parameter exactly.
 3. **Add an `enrichment` block to every review** carrying AI themes + derived metadata, namespaced so it never collides with Feefo's schema.
 4. **Authenticate Feefo-style, server-side only:** dashboard users self-mint `client_id` + `client_secret`; consumers exchange them at `POST /v1/oauth/token` for a bearer token. (See [Authentication](#authentication--api-credentials).)
-5. **Enforce the *site's own* customer-name rule** via one shared `resolveDisplayName()` function used by both the website and the API — so what the API returns is byte-for-byte what the site shows, and the raw `name`/email/refs never escape. (See [PII firewall](#pii-firewall--name-display-parity).)
+5. **Enforce the *site's own* customer-name rule** via one shared `resolveDisplayName()` rule — added to the website in PR #60 (open) and reused by the API — so what the API returns is byte-for-byte what the site shows, and the raw `name`/email/refs never escape. (See [PII firewall](#pii-firewall--name-display-parity).)
 6. **Read Firestore via the Admin SDK**, which lets us simultaneously **close the currently world-open Firestore read rules**.
 7. **Cache on the consumer side** — the calling backend caches the token and payloads, and aggregates come from precomputed summaries — since the API is server-to-server and data changes only every ~2 hours.
 
@@ -47,10 +49,10 @@ The sync pipeline ([`functions/src/sync/sync-reviews.ts`](../../functions/src/sy
 
 ### The rule we must match
 
-The API enforces the **exact** name rules the website uses: show the customer's name when the site shows it, show "Trusted Customer" when the site does. The canonical rule (`displayName || "Trusted Customer"`, never the raw `name`) was shared and shipped to the website in **PR #60** via `resolveDisplayName()`:
+The API enforces the **exact** name rules the website uses: show the customer's name when the site shows it, show "Trusted Customer" when the site does. The canonical rule (`displayName || "Trusted Customer"`, never the raw `name`) is introduced on the website in **PR #60** — currently **open / in review** — via `resolveDisplayName()`:
 
 ```ts
-// app/src/lib/format/customer.ts  (shipped in #60; the API mirrors it)
+// app/src/lib/format/customer.ts  (added in PR #60, still open; the API mirrors it)
 export function resolveDisplayName(
   customer: { displayName?: string | null } | null | undefined,
   fallback = "Trusted Customer"
@@ -381,7 +383,7 @@ For **star ratings in Google results**, the site must server-render review conte
 
 | Phase | Scope | Effort |
 |---|---|---|
-| **1 — Name rule + firewall + contract** | `resolveDisplayName()` (✅ shipped to the app in #60) promoted/shared; `PublicReview`/`PublicSummary` types + `toPublicReview()`/`toPublicSummary()` allowlist mappers (omit `display_location`/`tour_director`); unit test asserting the exact public key set. | S–M |
+| **1 — Name rule + firewall + contract** | `resolveDisplayName()` (added to the app in **PR #60**, open) promoted to `shared/`; `PublicReview`/`PublicSummary` types + `toPublicReview()`/`toPublicSummary()` allowlist mappers (omit `display_location`/`tour_director`); unit test asserting the exact public key set. **Depends on #60 merging.** | S–M |
 | **2 — Core endpoints** | `reviewsApi`: `/v1/reviews/summary/all`, `/v1/reviews/all`, `/v1/reviews/{id}` (scope-checked, uniform 404); Hosting rewrite; cache/ETag; pagination; uniform error envelope + request ids. | M |
 | **3 — Auth & credentials** | `POST /v1/oauth/token`; `api_clients` model with server-generated secrets + `argon2id`/peppered-HMAC verifier; opaque-or-JWT tokens with revocation (`tokenVersion`); `apiClients` management function; `manageApiClients` permission; dashboard "API Access" UI; per-client merchant scoping, **rate-limit enforcement**, revoke/rotate. | M–L |
 | **4 — Hardening + extensions** | Tighten **all five** public collections' rules; shared brand constant; `merchant_registry`; `/v1/meta/*`; `merchant_identifier=all` fan-out; **service** star distribution in sync. | M |
@@ -431,7 +433,7 @@ For **star ratings in Google results**, the site must server-render review conte
 
 ## Open decisions
 
-1. **Customer-name rule:** ✅ **Resolved** — canonical `displayName || "Trusted Customer"`, `|| customer.name` fallback removed (shipped in **PR #60** via shared `resolveDisplayName()`).
+1. **Customer-name rule:** 🔄 **In review (PR #60, open)** — canonical `displayName || "Trusted Customer"` with the `|| customer.name` fallback removed; merges independently of this API and counts as settled once #60 lands.
 2. **Auth surface:** ✅ **Resolved — server-side only.** Feefo-style `client_id`/`client_secret` → bearer token; no browser-embeddable key. Remaining sub-decision: token format — **opaque (recommended) vs JWT** — and TTL (default 1h).
 3. **`display_location`:** ✅ default **omit** in v1 (the dashboard never displays customer location, so omitting matches the site rule). Open: expose later with product sign-off?
 4. **`tour_director` (staff name):** ✅ default **omit** in v1 (it's a person's name). Open: expose as public metadata, or keep internal-only?
@@ -451,7 +453,7 @@ For **star ratings in Google results**, the site must server-render review conte
 | `feedbackUrl` | `url` | |
 | `customer.displayName` | `customer.display_name` | via `resolveDisplayName()`; empty ⇒ `"Trusted Customer"` |
 | `customer.location` | — (default) | **Omitted in v1** — the site never shows location; opt-in open decision |
-| `customer.name` / `email` / `orderRef` / `customerRef` | — | **Dropped (PII).** (`name` was the value some site pages leaked as a fallback; removed in #60) |
+| `customer.name` / `email` / `orderRef` / `customerRef` | — | **Dropped (PII).** (`name` was the value some site pages leaked as a fallback; removal proposed in **PR #60**, open) |
 | `ratings.service` / `ratings.product` | `service.rating.rating` / `products[0].rating.rating` | wrapped `{min:1,max:5,rating}` |
 | `reviews.serviceTitle` / `serviceText` / `productText` | `service.title` / `service.review` / `products[0].review` | |
 | `product.{title,sku,parentSku,url,imageUrl}` | `products[0].product.{title,sku,parent_sku,url,image_url}` | |


### PR DESCRIPTION
Design proposal (docs + tooling only — no runtime code yet) for a public, read-only **Reviews API** that exposes our synced, AI-enriched reviews for the company website.

## What's here

- **`docs/plans/2026-06-09-public-reviews-api.md`** — full design & recommendation.
- **`docs/api/`** — a ready-to-import Postman collection, environment, and developer guide.

## Key design decisions

- **Emulates the Feefo NativeReviews API.** `GET /v1/reviews/all` and `GET /v1/reviews/summary/all` reuse Feefo's envelope and field names; `merchant_identifier` selects the brand (`uniworld` | `luxury-gold` | `all`) exactly like Feefo. Our internal `ReviewDocument.brand` already equals the Feefo merchant id, so the mapping is 1:1.
- **Adds our AI value-add** in a namespaced `enrichment` block per review: theme classifications, normalized attributes (ship / itinerary / region / loyalty / …), itinerary grouping, and media/comment flags.
- **PII firewall.** An allowlist mapper (`toPublicReview()`) only ever emits the consented `display_name` (via the same rule the site uses — see #60) and the public `display_location`; raw `name` / `email` / `order_ref` / `customer_ref` can never serialize.
- **Auth: server-side only.** Feefo-style OAuth client-credentials — dashboard users self-mint a `client_id` + `client_secret`, exchange them at `POST /v1/oauth/token` for a short-lived bearer token. No browser-embeddable key; front-end access goes through the consumer's own same-origin backend.
- **Security tie-in.** The function reads via the Admin SDK, which lets us close the currently world-open Firestore read rules at the same time.
- **Multi-tenant ready.** A `merchant_registry` indirection keeps the `/v1` contract stable through the planned org-scoped migration.

## Phasing

The doc breaks delivery into: (1) name rule + firewall + contract, (2) core endpoints, (3) auth & credentials, (4) hardening + extensions, (5) optional search/scale.

## Related

- Builds on the privacy fix in #60 (shared `resolveDisplayName()` rule), which this API reuses verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
