### PR TITLE
feat(api): public reviews API — Feefo-emulating endpoints, OAuth credentials, PII firewall (phases 1–3)

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -78,6 +78,7 @@ jobs:
           V_REQUIRE_ADMIN_CLAIM: ${{ secrets.REQUIRE_ADMIN_CLAIM }}
           V_SYNC_API_TOKEN: ${{ secrets.SYNC_API_TOKEN }}
           V_CORS_ALLOWED_ORIGINS: ${{ secrets.CORS_ALLOWED_ORIGINS }}
+          V_REVIEWS_API_SECRET_PEPPER: ${{ secrets.REVIEWS_API_SECRET_PEPPER }}
         run: |
           {
             echo "FEEFO_UNIWORLD_CLIENT_ID=${FEEFO_UNI_ID}"
@@ -92,6 +93,7 @@ jobs:
           [ -n "${V_REQUIRE_ADMIN_CLAIM}" ] && echo "REQUIRE_ADMIN_CLAIM=${V_REQUIRE_ADMIN_CLAIM}" >> functions/.env.feefo-reviews || true
           [ -n "${V_SYNC_API_TOKEN}" ] && echo "SYNC_API_TOKEN=${V_SYNC_API_TOKEN}" >> functions/.env.feefo-reviews || true
           [ -n "${V_CORS_ALLOWED_ORIGINS}" ] && echo "CORS_ALLOWED_ORIGINS=${V_CORS_ALLOWED_ORIGINS}" >> functions/.env.feefo-reviews || true
+          [ -n "${V_REVIEWS_API_SECRET_PEPPER}" ] && echo "REVIEWS_API_SECRET_PEPPER=${V_REVIEWS_API_SECRET_PEPPER}" >> functions/.env.feefo-reviews || true
 
       - name: Build frontend
         run: npm --prefix app run build

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -104,6 +104,11 @@ Optional GitHub Actions secrets:
 - `ALGOLIA_APP_ID`
 - `ALGOLIA_ADMIN_KEY`
 - `REQUIRE_ADMIN_CLAIM`
+- `REVIEWS_API_SECRET_PEPPER`
+  Required for the public reviews API (`reviewsApi` / `apiClients` functions):
+  a long random value (32+ chars) used to HMAC API client secret verifiers.
+  Without it the token endpoint returns 500 `not_configured`. Rotating it
+  invalidates every existing API client secret.
 
 The workflow writes:
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -33,9 +33,14 @@ When you get a `401`, the token expired (default 1h) — re-run **Get access tok
 | `accessToken` | Filled automatically by the token request | — |
 | `merchantIdentifier` | Brand selector | `uniworld`, `luxury-gold`, `all` |
 
-For local development against the Firebase emulator, set `baseUrl` to the
-Hosting emulator (e.g. `http://127.0.0.1:5000/api`) so the `/api` rewrite
-resolves to the `reviewsApi` function.
+For local development against the Firebase emulators, point `baseUrl`
+directly at the functions emulator — no Hosting emulator needed:
+`http://127.0.0.1:5001/feefo-reviews/us-central1/reviewsApi`
+(the router accepts paths with or without the `/api` prefix). Start the
+emulators with `firebase emulators:start --only functions,firestore`, seed
+data + test credentials with `node scripts/seed-emulator.js`
+(`FIRESTORE_EMULATOR_HOST=127.0.0.1:8080`), and optionally run the full
+contract check with `bash scripts/smoke-api.sh`.
 
 ---
 

--- a/docs/plans/2026-06-09-public-reviews-api.md
+++ b/docs/plans/2026-06-09-public-reviews-api.md
@@ -1,7 +1,7 @@
 # Public Reviews API — Recommendation & Design
 
 **Date:** 2026-06-09
-**Status:** Proposed (recommendation) · revised after code review (Codex, PR #61)
+**Status:** Phases 1–3 implemented & emulator-verified (`reviews-api-implementation` branch) · remaining: Phase 4 hardening (Firestore rules tightening, service star distribution), the dashboard "API Access" UI, and Phase 5 search · design revised after code review (Codex, PR #61)
 **Owner:** TBD
 
 > **Dependency / status:** the customer-name rule this design reuses (`resolveDisplayName()`) was added to the website in **PR #60**, now **merged** — `app/src/lib/format/customer.ts` is on `main`, so the base dependency is satisfied. (This `reviews-public-api` branch was cut before #60, so it won't contain that file until it's synced with `main`; that doesn't affect the design.)

--- a/firebase.json
+++ b/firebase.json
@@ -17,6 +17,10 @@
     "cleanUrls": true,
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [
+      {
+        "source": "/api/**",
+        "function": { "functionId": "reviewsApi", "region": "us-central1" }
+      },
       { "source": "**", "destination": "/index.html" }
     ],
     "headers": [

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -4,360 +4,1072 @@
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "themes.positive", "arrayConfig": "CONTAINS" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "themes.positive",
+          "arrayConfig": "CONTAINS"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "themes.negative", "arrayConfig": "CONTAINS" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "themes.negative",
+          "arrayConfig": "CONTAINS"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "ratings.product", "order": "ASCENDING" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "ratings.product",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "ratings.product", "order": "ASCENDING" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "ratings.product",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "summaries",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "scope", "order": "ASCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "scope",
+          "order": "ASCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "monthly_summaries",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "month", "order": "ASCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "month",
+          "order": "ASCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "tags.tour", "order": "ASCENDING" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "tags.tour",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "tags.tour", "order": "ASCENDING" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "tags.tour",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "tags.tour", "order": "ASCENDING" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.tour",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "tags.tour", "order": "ASCENDING" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.tour",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "ship", "order": "ASCENDING" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "ship",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "ship", "order": "ASCENDING" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "ship",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "ship", "order": "ASCENDING" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "ship",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "ship", "order": "ASCENDING" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "ship",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "tags.ship", "order": "ASCENDING" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "tags.ship",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "tags.ship", "order": "ASCENDING" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "tags.ship",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "tags.ship", "order": "ASCENDING" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.ship",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "tags.ship", "order": "ASCENDING" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.ship",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "tags.region", "order": "ASCENDING" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.region",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "tags.region", "order": "ASCENDING" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.region",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "tags.bookingType", "order": "ASCENDING" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.bookingType",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "tags.bookingType", "order": "ASCENDING" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.bookingType",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "tags.loyalty", "order": "ASCENDING" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.loyalty",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "tags.loyalty", "order": "ASCENDING" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.loyalty",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "themes.positive", "arrayConfig": "CONTAINS" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "themes.positive",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "themes.positive", "arrayConfig": "CONTAINS" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "themes.positive",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "themes.negative", "arrayConfig": "CONTAINS" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "themes.negative",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "themes.negative", "arrayConfig": "CONTAINS" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "themes.negative",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "themes.positive", "arrayConfig": "CONTAINS" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "themes.positive",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "themes.positive", "arrayConfig": "CONTAINS" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "themes.positive",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "themes.negative", "arrayConfig": "CONTAINS" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "themes.negative",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "themes.negative", "arrayConfig": "CONTAINS" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "themes.negative",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "hasMedia", "order": "ASCENDING" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "hasMedia",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "hasMedia", "order": "ASCENDING" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "hasMedia",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "hasMedia", "order": "ASCENDING" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "hasMedia",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "hasMedia", "order": "ASCENDING" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "hasMedia",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "product.sku", "order": "ASCENDING" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "product.sku",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "product.sku", "order": "ASCENDING" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "product.sku",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "product.parentSku", "order": "ASCENDING" },
-        { "fieldPath": "dates.created", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "product.parentSku",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "DESCENDING"
+        }
       ]
     },
     {
       "collectionGroup": "reviews",
       "queryScope": "COLLECTION",
       "fields": [
-        { "fieldPath": "brand", "order": "ASCENDING" },
-        { "fieldPath": "product.parentSku", "order": "ASCENDING" },
-        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "product.parentSku",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "DESCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.ship",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.tour",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.region",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.bookingType",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.loyalty",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "product.sku",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "product.parentSku",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "hasMedia",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "themes.positive",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "themes.negative",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "dates.created",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.ship",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.tour",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.region",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.bookingType",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "tags.loyalty",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "product.sku",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "product.parentSku",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "hasMedia",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "themes.positive",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "brand",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "themes.negative",
+          "arrayConfig": "CONTAINS"
+        },
+        {
+          "fieldPath": "dates.lastUpdated",
+          "order": "ASCENDING"
+        }
       ]
     }
   ],

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -323,6 +323,42 @@
         { "fieldPath": "hasMedia", "order": "ASCENDING" },
         { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "brand", "order": "ASCENDING" },
+        { "fieldPath": "product.sku", "order": "ASCENDING" },
+        { "fieldPath": "dates.created", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "brand", "order": "ASCENDING" },
+        { "fieldPath": "product.sku", "order": "ASCENDING" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "brand", "order": "ASCENDING" },
+        { "fieldPath": "product.parentSku", "order": "ASCENDING" },
+        { "fieldPath": "dates.created", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "reviews",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "brand", "order": "ASCENDING" },
+        { "fieldPath": "product.parentSku", "order": "ASCENDING" },
+        { "fieldPath": "dates.lastUpdated", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/firestore.rules
+++ b/firestore.rules
@@ -21,6 +21,18 @@ service cloud.firestore {
       allow read: if true;
       allow write: if false;
     }
+    // Public reviews API credential store — Admin SDK only. The catch-all
+    // below already denies these; the explicit blocks make the intent
+    // auditable and survive future rule refactors.
+    match /api_clients/{clientId} {
+      allow read, write: if false;
+    }
+    match /api_tokens/{tokenHash} {
+      allow read, write: if false;
+    }
+    match /api_rate_limits/{key} {
+      allow read, write: if false;
+    }
     match /{document=**} {
       allow read, write: if false;
     }

--- a/functions/.env.example
+++ b/functions/.env.example
@@ -23,3 +23,10 @@ REQUIRE_ADMIN_CLAIM=false
 # Optional shared token for non-interactive service calls (sent as x-sync-token header).
 # Browser users signed in through Firebase Auth do not need this.
 SYNC_API_TOKEN=
+
+# Public reviews API (reviewsApi function).
+# Pepper for the HMAC-SHA256 verifier of API client secrets (api_clients
+# collection). Long random value (32+ chars); store the production value in
+# Secret Manager / CI secrets, never in source. Rotating it invalidates every
+# existing client secret.
+REVIEWS_API_SECRET_PEPPER=

--- a/functions/src/api/api-clients.ts
+++ b/functions/src/api/api-clients.ts
@@ -3,6 +3,7 @@ import { isMerchantIdentifier } from "@feefo/shared";
 import {
   ALL_SCOPES,
   API_CLIENTS_COLLECTION,
+  API_TOKENS_COLLECTION,
   ApiClientRecord,
   computeSecretVerifier,
   generateClientId,
@@ -12,6 +13,28 @@ import {
   loadApiClient,
 } from "./auth";
 import { ApiError } from "./http";
+
+/**
+ * Delete every outstanding access token for a client. Revocation must be
+ * immediate, and the in-memory client cache in auth.ts is per-instance —
+ * invalidating it here cannot reach the reviewsApi instances. Removing the
+ * token documents makes the per-request token lookup fail everywhere at
+ * once, regardless of any instance's cache.
+ */
+async function deleteOutstandingTokens(clientId: string): Promise<number> {
+  const db = getFirestore();
+  const snapshot = await db
+    .collection(API_TOKENS_COLLECTION)
+    .where("clientId", "==", clientId)
+    .get();
+  if (snapshot.empty) return 0;
+  const writer = db.bulkWriter();
+  for (const doc of snapshot.docs) {
+    writer.delete(doc.ref);
+  }
+  await writer.close();
+  return snapshot.size;
+}
 
 /**
  * Management operations for API credentials, called by the authenticated
@@ -144,8 +167,9 @@ async function requireClient(clientId: unknown): Promise<ApiClientRecord> {
   return record;
 }
 
-/** Revoke a client: blocks new tokens AND invalidates every outstanding
- * token immediately (the per-request check sees status/tokenVersion). */
+/** Revoke a client: blocks new token exchanges AND kills every outstanding
+ * token immediately (their api_tokens docs are deleted, so validation fails
+ * on the next request from any instance). */
 export async function revokeApiClient(clientId: unknown): Promise<PublicApiClient> {
   const record = await requireClient(clientId);
   const db = getFirestore();
@@ -155,12 +179,14 @@ export async function revokeApiClient(clientId: unknown): Promise<PublicApiClien
     tokenVersion: record.tokenVersion + 1,
     updatedAt: now,
   });
+  await deleteOutstandingTokens(record.clientId);
   invalidateClientCache(record.clientId);
   return sanitize({ ...record, status: "revoked", tokenVersion: record.tokenVersion + 1, updatedAt: now });
 }
 
-/** Rotate a client's secret. Outstanding tokens are invalidated via the
- * tokenVersion bump; the new secret is returned exactly once. */
+/** Rotate a client's secret. Outstanding tokens are killed immediately
+ * (token docs deleted + tokenVersion bump); the new secret is returned
+ * exactly once. */
 export async function rotateApiClient(
   clientId: unknown
 ): Promise<{ client: PublicApiClient; clientSecret: string }> {
@@ -178,6 +204,7 @@ export async function rotateApiClient(
     tokenVersion: record.tokenVersion + 1,
     updatedAt: now,
   });
+  await deleteOutstandingTokens(record.clientId);
   invalidateClientCache(record.clientId);
 
   return {

--- a/functions/src/api/api-clients.ts
+++ b/functions/src/api/api-clients.ts
@@ -1,0 +1,187 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { isMerchantIdentifier } from "@feefo/shared";
+import {
+  ALL_SCOPES,
+  API_CLIENTS_COLLECTION,
+  ApiClientRecord,
+  computeSecretVerifier,
+  generateClientId,
+  generateClientSecret,
+  getSecretPepper,
+  invalidateClientCache,
+  loadApiClient,
+} from "./auth";
+import { ApiError } from "./http";
+
+/**
+ * Management operations for API credentials, called by the authenticated
+ * `apiClients` admin endpoint (manageApiClients permission). The plain
+ * client secret is returned exactly once, at create/rotate time; only the
+ * peppered HMAC verifier is stored.
+ */
+
+export type PublicApiClient = Omit<ApiClientRecord, "secretVerifier">;
+
+function sanitize(record: ApiClientRecord): PublicApiClient {
+  const { secretVerifier: _verifier, ...rest } = record;
+  return rest;
+}
+
+function validateLabel(label: unknown): string {
+  if (typeof label !== "string" || !label.trim() || label.trim().length > 100) {
+    throw new ApiError(400, "invalid_label", "label is required (max 100 characters).");
+  }
+  return label.trim();
+}
+
+function validateMerchants(merchants: unknown): string[] {
+  if (!Array.isArray(merchants) || merchants.length === 0) {
+    throw new ApiError(
+      400,
+      "invalid_merchants",
+      'merchants must be a non-empty array of merchant identifiers, or ["*"].'
+    );
+  }
+  if (merchants.length === 1 && merchants[0] === "*") {
+    return ["*"];
+  }
+  const unique = [...new Set(merchants)];
+  for (const merchant of unique) {
+    if (!isMerchantIdentifier(merchant)) {
+      throw new ApiError(400, "invalid_merchants", `Unknown merchant identifier: ${merchant}`);
+    }
+  }
+  return unique as string[];
+}
+
+function validateScopes(scopes: unknown): string[] {
+  if (scopes === undefined || scopes === null) {
+    return [...ALL_SCOPES];
+  }
+  if (!Array.isArray(scopes) || scopes.length === 0) {
+    throw new ApiError(400, "invalid_scopes", "scopes must be a non-empty array when provided.");
+  }
+  const unique = [...new Set(scopes)];
+  for (const scope of unique) {
+    if (!(ALL_SCOPES as readonly string[]).includes(scope as string)) {
+      throw new ApiError(400, "invalid_scopes", `Unknown scope: ${scope}`);
+    }
+  }
+  return unique as string[];
+}
+
+export async function createApiClient(input: {
+  label: unknown;
+  merchants: unknown;
+  scopes?: unknown;
+  createdBy: string | null;
+}): Promise<{ client: PublicApiClient; clientSecret: string }> {
+  const pepper = getSecretPepper();
+  const label = validateLabel(input.label);
+  const merchants = validateMerchants(input.merchants);
+  const scopes = validateScopes(input.scopes);
+
+  const clientId = generateClientId();
+  const clientSecret = generateClientSecret();
+  const now = new Date().toISOString();
+
+  const record: ApiClientRecord = {
+    clientId,
+    secretVerifier: computeSecretVerifier(clientSecret, pepper),
+    label,
+    merchants,
+    scopes,
+    status: "active",
+    tokenVersion: 1,
+    createdBy: input.createdBy,
+    createdAt: now,
+    updatedAt: now,
+    lastUsedAt: null,
+  };
+
+  const db = getFirestore();
+  await db.collection(API_CLIENTS_COLLECTION).doc(clientId).create(record);
+
+  return { client: sanitize(record), clientSecret };
+}
+
+export async function listApiClients(): Promise<PublicApiClient[]> {
+  const db = getFirestore();
+  const snapshot = await db.collection(API_CLIENTS_COLLECTION).get();
+  return snapshot.docs
+    .map((doc) => {
+      const data = doc.data() ?? {};
+      return sanitize({
+        clientId: doc.id,
+        secretVerifier: "",
+        label: typeof data.label === "string" ? data.label : "",
+        merchants: Array.isArray(data.merchants) ? data.merchants : [],
+        scopes: Array.isArray(data.scopes) ? data.scopes : [],
+        status: data.status === "revoked" ? "revoked" : "active",
+        tokenVersion: typeof data.tokenVersion === "number" ? data.tokenVersion : 1,
+        rateLimitPerMinute:
+          typeof data.rateLimitPerMinute === "number" ? data.rateLimitPerMinute : undefined,
+        createdBy: typeof data.createdBy === "string" ? data.createdBy : null,
+        createdAt: typeof data.createdAt === "string" ? data.createdAt : "",
+        updatedAt: typeof data.updatedAt === "string" ? data.updatedAt : undefined,
+        lastUsedAt:
+          typeof data.lastUsedAt === "string" || data.lastUsedAt === null
+            ? data.lastUsedAt
+            : undefined,
+      });
+    })
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+async function requireClient(clientId: unknown): Promise<ApiClientRecord> {
+  if (typeof clientId !== "string" || !clientId.trim()) {
+    throw new ApiError(400, "invalid_client_id", "clientId is required.");
+  }
+  const record = await loadApiClient(clientId.trim());
+  if (!record) {
+    throw new ApiError(404, "client_not_found", "No API client with that id.");
+  }
+  return record;
+}
+
+/** Revoke a client: blocks new tokens AND invalidates every outstanding
+ * token immediately (the per-request check sees status/tokenVersion). */
+export async function revokeApiClient(clientId: unknown): Promise<PublicApiClient> {
+  const record = await requireClient(clientId);
+  const db = getFirestore();
+  const now = new Date().toISOString();
+  await db.collection(API_CLIENTS_COLLECTION).doc(record.clientId).update({
+    status: "revoked",
+    tokenVersion: record.tokenVersion + 1,
+    updatedAt: now,
+  });
+  invalidateClientCache(record.clientId);
+  return sanitize({ ...record, status: "revoked", tokenVersion: record.tokenVersion + 1, updatedAt: now });
+}
+
+/** Rotate a client's secret. Outstanding tokens are invalidated via the
+ * tokenVersion bump; the new secret is returned exactly once. */
+export async function rotateApiClient(
+  clientId: unknown
+): Promise<{ client: PublicApiClient; clientSecret: string }> {
+  const pepper = getSecretPepper();
+  const record = await requireClient(clientId);
+  if (record.status !== "active") {
+    throw new ApiError(400, "client_revoked", "Cannot rotate a revoked client.");
+  }
+
+  const clientSecret = generateClientSecret();
+  const now = new Date().toISOString();
+  const db = getFirestore();
+  await db.collection(API_CLIENTS_COLLECTION).doc(record.clientId).update({
+    secretVerifier: computeSecretVerifier(clientSecret, pepper),
+    tokenVersion: record.tokenVersion + 1,
+    updatedAt: now,
+  });
+  invalidateClientCache(record.clientId);
+
+  return {
+    client: sanitize({ ...record, tokenVersion: record.tokenVersion + 1, updatedAt: now }),
+    clientSecret,
+  };
+}

--- a/functions/src/api/auth.ts
+++ b/functions/src/api/auth.ts
@@ -129,8 +129,11 @@ export async function loadApiClient(clientId: string): Promise<ApiClientRecord |
 }
 
 /** Per-instance cache so token validation doesn't read the client document
- * on every request. 60s staleness bound on revocation is acceptable; rotate
- * + revoke also delete the token docs' validity via tokenVersion. */
+ * on every request. This cache is NOT the revocation mechanism — it is
+ * per-instance, so other instances never see invalidateClientCache().
+ * Revoke/rotate are immediate because they DELETE the client's outstanding
+ * api_tokens docs (see api-clients.ts); the cached client record only
+ * backs the status/tokenVersion sanity check. */
 const clientCache = new Map<string, { record: ApiClientRecord | null; fetchedAt: number }>();
 const CLIENT_CACHE_TTL_MS = 60_000;
 

--- a/functions/src/api/auth.ts
+++ b/functions/src/api/auth.ts
@@ -152,20 +152,46 @@ export function invalidateClientCache(clientId: string): void {
   clientCache.delete(clientId);
 }
 
+/**
+ * Mint an access token for a client whose secret has just been verified.
+ *
+ * The token document is written inside a TRANSACTION that re-reads the
+ * client and aborts if its status, tokenVersion, or secretVerifier changed
+ * since verification. This closes the race where an admin revokes/rotates
+ * between the secret check and the token write: either the mint commits
+ * first (and the admin's outstanding-token sweep deletes it), or the
+ * transaction observes the change and refuses — a stale-version token can
+ * never be created after the sweep ran.
+ */
 export async function mintAccessToken(
   client: ApiClientRecord
 ): Promise<{ accessToken: string; expiresIn: number }> {
   const db = getFirestore();
   const token = generateAccessToken();
-  await db.collection(API_TOKENS_COLLECTION).doc(hashAccessToken(token)).set({
-    clientId: client.clientId,
-    merchants: client.merchants,
-    scopes: client.scopes,
-    tokenVersion: client.tokenVersion,
-    createdAt: new Date().toISOString(),
-    // Stored as a Timestamp so a Firestore TTL policy on `expiresAt` can
-    // garbage-collect expired tokens.
-    expiresAt: Timestamp.fromMillis(Date.now() + TOKEN_TTL_SECONDS * 1000),
+  const tokenRef = db.collection(API_TOKENS_COLLECTION).doc(hashAccessToken(token));
+  const clientRef = db.collection(API_CLIENTS_COLLECTION).doc(client.clientId);
+
+  await db.runTransaction(async (txn) => {
+    const snap = await txn.get(clientRef);
+    const current = snap.exists ? recordFromSnapshot(snap.id, snap.data() ?? {}) : null;
+    if (
+      !current ||
+      current.status !== "active" ||
+      current.tokenVersion !== client.tokenVersion ||
+      current.secretVerifier !== client.secretVerifier
+    ) {
+      throw new ApiError(401, "invalid_client", "Invalid client credentials.");
+    }
+    txn.create(tokenRef, {
+      clientId: current.clientId,
+      merchants: current.merchants,
+      scopes: current.scopes,
+      tokenVersion: current.tokenVersion,
+      createdAt: new Date().toISOString(),
+      // Stored as a Timestamp so a Firestore TTL policy on `expiresAt` can
+      // garbage-collect expired tokens.
+      expiresAt: Timestamp.fromMillis(Date.now() + TOKEN_TTL_SECONDS * 1000),
+    });
   });
 
   db.collection(API_CLIENTS_COLLECTION)
@@ -211,13 +237,25 @@ export async function authenticateRequest(req: any): Promise<AuthContext> {
   }
 
   const clientId = typeof data.clientId === "string" ? data.clientId : "";
-  const client = await loadApiClientCached(clientId);
+  let client = await loadApiClientCached(clientId);
   if (
     !client ||
     client.status !== "active" ||
     client.tokenVersion !== data.tokenVersion
   ) {
-    throw INVALID_TOKEN;
+    // The cached record may be stale in EITHER direction (e.g. a token
+    // minted right after a rotate, validated on an instance still caching
+    // the pre-rotate record). Re-read once before rejecting so freshly
+    // minted tokens never 401 on instances with a stale cache.
+    client = await loadApiClient(clientId);
+    clientCache.set(clientId, { record: client, fetchedAt: Date.now() });
+    if (
+      !client ||
+      client.status !== "active" ||
+      client.tokenVersion !== data.tokenVersion
+    ) {
+      throw INVALID_TOKEN;
+    }
   }
 
   return {

--- a/functions/src/api/auth.ts
+++ b/functions/src/api/auth.ts
@@ -1,0 +1,236 @@
+import { createHash, createHmac, randomBytes, timingSafeEqual } from "crypto";
+import { getFirestore, Timestamp } from "firebase-admin/firestore";
+import { ApiError } from "./http";
+
+/**
+ * OAuth client-credentials for the public reviews API, mirroring Feefo's
+ * model: a confidential client exchanges client_id + client_secret at
+ * POST /v1/oauth/token for a short-lived bearer token.
+ *
+ * Design decisions (docs/plans/2026-06-09-public-reviews-api.md):
+ *  - Secrets are server-generated high-entropy values, shown once. We store
+ *    only a peppered HMAC-SHA256 verifier (pepper lives in
+ *    REVIEWS_API_SECRET_PEPPER, outside Firestore), compared in constant time.
+ *  - Access tokens are OPAQUE (not JWTs): the token's SHA-256 hash is the
+ *    api_tokens doc id, so revocation is immediate — bumping the client's
+ *    tokenVersion (or flipping status) invalidates every outstanding token
+ *    at the per-request re-check.
+ */
+
+export const TOKEN_TTL_SECONDS = 3600;
+export const API_CLIENTS_COLLECTION = "api_clients";
+export const API_TOKENS_COLLECTION = "api_tokens";
+
+export const ALL_SCOPES = ["reviews:read", "summary:read", "meta:read"] as const;
+export type ApiScope = (typeof ALL_SCOPES)[number];
+
+export const DEFAULT_RATE_LIMIT_PER_MINUTE = 120;
+
+export interface ApiClientRecord {
+  clientId: string;
+  /** HMAC-SHA256(secret, pepper), hex. Never returned to callers. */
+  secretVerifier: string;
+  label: string;
+  /** Allowed merchant identifiers, or ["*"] for all. */
+  merchants: string[];
+  scopes: string[];
+  status: "active" | "revoked";
+  /** Bumped on rotate/revoke; outstanding tokens carry the version they were
+   * minted with and fail validation on mismatch. */
+  tokenVersion: number;
+  rateLimitPerMinute?: number;
+  createdBy: string | null;
+  createdAt: string;
+  updatedAt?: string;
+  lastUsedAt?: string | null;
+}
+
+export interface AuthContext {
+  clientId: string;
+  merchants: string[];
+  scopes: string[];
+  rateLimitPerMinute: number;
+}
+
+export function getSecretPepper(): string {
+  const pepper = process.env.REVIEWS_API_SECRET_PEPPER;
+  if (!pepper || pepper.trim().length < 16) {
+    throw new ApiError(
+      500,
+      "not_configured",
+      "The reviews API is not configured (missing REVIEWS_API_SECRET_PEPPER)."
+    );
+  }
+  return pepper.trim();
+}
+
+export function computeSecretVerifier(secret: string, pepper: string): string {
+  return createHmac("sha256", pepper).update(secret).digest("hex");
+}
+
+export function verifyClientSecret(
+  presentedSecret: string,
+  storedVerifier: string,
+  pepper: string
+): boolean {
+  const presented = Buffer.from(computeSecretVerifier(presentedSecret, pepper), "hex");
+  const stored = Buffer.from(storedVerifier, "hex");
+  return presented.length === stored.length && timingSafeEqual(presented, stored);
+}
+
+export function generateClientId(): string {
+  return `uw_live_${randomBytes(6).toString("hex")}`;
+}
+
+export function generateClientSecret(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+function generateAccessToken(): string {
+  return `uwt_${randomBytes(32).toString("base64url")}`;
+}
+
+function hashAccessToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+function recordFromSnapshot(
+  id: string,
+  data: FirebaseFirestore.DocumentData
+): ApiClientRecord {
+  return {
+    clientId: id,
+    secretVerifier: typeof data.secretVerifier === "string" ? data.secretVerifier : "",
+    label: typeof data.label === "string" ? data.label : "",
+    merchants: Array.isArray(data.merchants) ? data.merchants.filter((m: unknown) => typeof m === "string") : [],
+    scopes: Array.isArray(data.scopes) ? data.scopes.filter((s: unknown) => typeof s === "string") : [],
+    status: data.status === "revoked" ? "revoked" : "active",
+    tokenVersion: typeof data.tokenVersion === "number" ? data.tokenVersion : 1,
+    rateLimitPerMinute:
+      typeof data.rateLimitPerMinute === "number" && data.rateLimitPerMinute > 0
+        ? data.rateLimitPerMinute
+        : undefined,
+    createdBy: typeof data.createdBy === "string" ? data.createdBy : null,
+    createdAt: typeof data.createdAt === "string" ? data.createdAt : "",
+    updatedAt: typeof data.updatedAt === "string" ? data.updatedAt : undefined,
+    lastUsedAt:
+      typeof data.lastUsedAt === "string" || data.lastUsedAt === null
+        ? data.lastUsedAt
+        : undefined,
+  };
+}
+
+export async function loadApiClient(clientId: string): Promise<ApiClientRecord | null> {
+  if (!clientId || !/^[a-zA-Z0-9_-]{4,80}$/.test(clientId)) return null;
+  const db = getFirestore();
+  const snap = await db.collection(API_CLIENTS_COLLECTION).doc(clientId).get();
+  if (!snap.exists) return null;
+  return recordFromSnapshot(snap.id, snap.data() ?? {});
+}
+
+/** Per-instance cache so token validation doesn't read the client document
+ * on every request. 60s staleness bound on revocation is acceptable; rotate
+ * + revoke also delete the token docs' validity via tokenVersion. */
+const clientCache = new Map<string, { record: ApiClientRecord | null; fetchedAt: number }>();
+const CLIENT_CACHE_TTL_MS = 60_000;
+
+async function loadApiClientCached(clientId: string): Promise<ApiClientRecord | null> {
+  const cached = clientCache.get(clientId);
+  if (cached && Date.now() - cached.fetchedAt < CLIENT_CACHE_TTL_MS) {
+    return cached.record;
+  }
+  const record = await loadApiClient(clientId);
+  clientCache.set(clientId, { record, fetchedAt: Date.now() });
+  return record;
+}
+
+/** Invalidate the per-instance cache after management operations. */
+export function invalidateClientCache(clientId: string): void {
+  clientCache.delete(clientId);
+}
+
+export async function mintAccessToken(
+  client: ApiClientRecord
+): Promise<{ accessToken: string; expiresIn: number }> {
+  const db = getFirestore();
+  const token = generateAccessToken();
+  await db.collection(API_TOKENS_COLLECTION).doc(hashAccessToken(token)).set({
+    clientId: client.clientId,
+    merchants: client.merchants,
+    scopes: client.scopes,
+    tokenVersion: client.tokenVersion,
+    createdAt: new Date().toISOString(),
+    // Stored as a Timestamp so a Firestore TTL policy on `expiresAt` can
+    // garbage-collect expired tokens.
+    expiresAt: Timestamp.fromMillis(Date.now() + TOKEN_TTL_SECONDS * 1000),
+  });
+
+  db.collection(API_CLIENTS_COLLECTION)
+    .doc(client.clientId)
+    .set({ lastUsedAt: new Date().toISOString() }, { merge: true })
+    .catch(() => {});
+
+  return { accessToken: token, expiresIn: TOKEN_TTL_SECONDS };
+}
+
+const INVALID_TOKEN = new ApiError(
+  401,
+  "invalid_token",
+  "Invalid or expired access token."
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function authenticateRequest(req: any): Promise<AuthContext> {
+  const header = req.headers?.authorization;
+  if (typeof header !== "string" || !header.startsWith("Bearer ")) {
+    throw new ApiError(401, "unauthorized", "Missing bearer token.");
+  }
+  const token = header.slice("Bearer ".length).trim();
+  if (!token.startsWith("uwt_") || token.length > 200) {
+    throw INVALID_TOKEN;
+  }
+
+  const db = getFirestore();
+  const tokenSnap = await db
+    .collection(API_TOKENS_COLLECTION)
+    .doc(hashAccessToken(token))
+    .get();
+  if (!tokenSnap.exists) {
+    throw INVALID_TOKEN;
+  }
+
+  const data = tokenSnap.data() ?? {};
+  const expiresAtMs =
+    data.expiresAt instanceof Timestamp ? data.expiresAt.toMillis() : 0;
+  if (expiresAtMs <= Date.now()) {
+    tokenSnap.ref.delete().catch(() => {});
+    throw INVALID_TOKEN;
+  }
+
+  const clientId = typeof data.clientId === "string" ? data.clientId : "";
+  const client = await loadApiClientCached(clientId);
+  if (
+    !client ||
+    client.status !== "active" ||
+    client.tokenVersion !== data.tokenVersion
+  ) {
+    throw INVALID_TOKEN;
+  }
+
+  return {
+    clientId: client.clientId,
+    merchants: client.merchants,
+    scopes: client.scopes,
+    rateLimitPerMinute: client.rateLimitPerMinute ?? DEFAULT_RATE_LIMIT_PER_MINUTE,
+  };
+}
+
+export function requireScope(auth: AuthContext, scope: ApiScope): void {
+  if (!auth.scopes.includes(scope)) {
+    throw new ApiError(
+      403,
+      "insufficient_scope",
+      `This endpoint requires the "${scope}" scope.`
+    );
+  }
+}

--- a/functions/src/api/http.ts
+++ b/functions/src/api/http.ts
@@ -1,0 +1,87 @@
+import { createHash, randomUUID } from "crypto";
+
+/** Error carrying an HTTP status + machine-readable code for the uniform
+ * `{ error: { code, message, request_id } }` envelope. */
+export class ApiError extends Error {
+  constructor(
+    readonly status: number,
+    readonly code: string,
+    message: string,
+    readonly headers?: Record<string, string>
+  ) {
+    super(message);
+  }
+}
+
+export function newRequestId(): string {
+  return randomUUID();
+}
+
+/**
+ * Send a JSON response with the standard headers. Successful GET responses
+ * get `Cache-Control: private` + a weak ETag (honouring If-None-Match with
+ * 304) so a consuming backend's HTTP cache can avoid re-downloading; auth
+ * and error responses are `no-store`.
+ */
+export function sendJson(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  res: any,
+  requestId: string,
+  status: number,
+  body: unknown,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  opts: { cacheSeconds?: number; noStore?: boolean; req?: any } = {}
+): void {
+  const payload = JSON.stringify(body);
+  res.set("X-Request-Id", requestId);
+  res.set("Content-Type", "application/json; charset=utf-8");
+
+  if (opts.noStore) {
+    res.set("Cache-Control", "no-store");
+  } else {
+    res.set("Cache-Control", `private, max-age=${opts.cacheSeconds ?? 300}`);
+    const etag = `W/"${createHash("sha1").update(payload).digest("hex")}"`;
+    res.set("ETag", etag);
+    const ifNoneMatch = opts.req?.headers?.["if-none-match"];
+    if (typeof ifNoneMatch === "string" && ifNoneMatch === etag) {
+      res.status(304).end();
+      return;
+    }
+  }
+
+  res.status(status).send(payload);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function sendError(res: any, requestId: string, error: unknown): void {
+  if (error instanceof ApiError) {
+    if (error.headers) {
+      for (const [key, value] of Object.entries(error.headers)) {
+        res.set(key, value);
+      }
+    }
+    sendJson(
+      res,
+      requestId,
+      error.status,
+      { error: { code: error.code, message: error.message, request_id: requestId } },
+      { noStore: true }
+    );
+    return;
+  }
+
+  console.error("reviewsApi unhandled error:", error);
+  sendJson(
+    res,
+    requestId,
+    500,
+    {
+      error: {
+        code: "internal",
+        message: "Internal server error.",
+        request_id: requestId,
+      },
+    },
+    { noStore: true }
+  );
+}

--- a/functions/src/api/merchant-registry.ts
+++ b/functions/src/api/merchant-registry.ts
@@ -1,0 +1,93 @@
+import { Brand, MERCHANT_IDENTIFIERS, isMerchantIdentifier } from "@feefo/shared";
+import { ApiError } from "./http";
+
+/**
+ * Resolves a public `merchant_identifier` to where that merchant's data
+ * lives. Today every merchant maps to the top-level collections; after the
+ * multi-tenant migration only this resolver changes (orgId + collection
+ * paths), keeping the /v1 contract stable.
+ */
+
+export interface MerchantInfo {
+  identifier: Brand;
+  label: string;
+  reviewsCollection: string;
+  summariesCollection: string;
+  mappingsCollection: string;
+}
+
+const REGISTRY: Record<Brand, MerchantInfo> = {
+  uniworld: {
+    identifier: "uniworld",
+    label: "Uniworld",
+    reviewsCollection: "reviews",
+    summariesCollection: "summaries",
+    mappingsCollection: "itinerary_mappings",
+  },
+  "luxury-gold": {
+    identifier: "luxury-gold",
+    label: "Luxury Gold",
+    reviewsCollection: "reviews",
+    summariesCollection: "summaries",
+    mappingsCollection: "itinerary_mappings",
+  },
+};
+
+export function listMerchants(): MerchantInfo[] {
+  return MERCHANT_IDENTIFIERS.map((id) => REGISTRY[id]);
+}
+
+export function getMerchant(identifier: string): MerchantInfo | null {
+  return isMerchantIdentifier(identifier) ? REGISTRY[identifier] : null;
+}
+
+function isAllowed(identifier: string, allowedMerchants: string[]): boolean {
+  return allowedMerchants.includes("*") || allowedMerchants.includes(identifier);
+}
+
+/** Merchants visible to a credential (for /v1/meta/merchants). */
+export function listMerchantsForScope(allowedMerchants: string[]): MerchantInfo[] {
+  return listMerchants().filter((m) => isAllowed(m.identifier, allowedMerchants));
+}
+
+/**
+ * Resolve the `merchant_identifier` request parameter against the caller's
+ * credential scope. `all` (or an omitted parameter) fans out to every
+ * merchant the credential may read; a comma list selects specific merchants.
+ *
+ * Unknown identifier → 400. Known but outside the credential's scope → 403.
+ */
+export function resolveMerchants(
+  param: string | undefined,
+  allowedMerchants: string[]
+): MerchantInfo[] {
+  const value = (param ?? "all").trim();
+
+  if (value === "all" || value === "") {
+    const merchants = listMerchantsForScope(allowedMerchants);
+    if (merchants.length === 0) {
+      throw new ApiError(403, "merchant_not_allowed", "This credential has no merchant access.");
+    }
+    return merchants;
+  }
+
+  const identifiers = [...new Set(value.split(",").map((v) => v.trim()).filter(Boolean))];
+  if (identifiers.length === 0) {
+    throw new ApiError(400, "invalid_merchant", "merchant_identifier must not be empty.");
+  }
+
+  return identifiers.map((id) => {
+    const merchant = getMerchant(id);
+    if (!merchant) {
+      throw new ApiError(400, "invalid_merchant", `Unknown merchant_identifier: ${id}`);
+    }
+    if (!isAllowed(id, allowedMerchants)) {
+      throw new ApiError(
+        403,
+        "merchant_not_allowed",
+        `This credential cannot access merchant_identifier: ${id}`
+      );
+    }
+    return merchant;
+  });
+}

--- a/functions/src/api/rate-limit.ts
+++ b/functions/src/api/rate-limit.ts
@@ -1,0 +1,54 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { ApiError } from "./http";
+
+/**
+ * Fixed-window per-client rate limiting backed by one Firestore doc per key
+ * (api_rate_limits/{key}: { windowStart: epoch-minute, count }). A
+ * transaction resets the window or increments the count, so the limit holds
+ * across function instances. Exceeding it returns 429 with Retry-After.
+ */
+
+export const TOKEN_RATE_LIMIT_PER_MINUTE = 30;
+
+const COLLECTION = "api_rate_limits";
+
+export async function checkRateLimit(
+  key: string,
+  limitPerMinute: number
+): Promise<{ allowed: boolean; retryAfterSeconds: number }> {
+  const db = getFirestore();
+  const ref = db.collection(COLLECTION).doc(key);
+  const nowMs = Date.now();
+  const windowStart = Math.floor(nowMs / 60_000);
+
+  let allowed = true;
+  await db.runTransaction(async (txn) => {
+    const snap = await txn.get(ref);
+    const data = snap.data();
+    if (data && data.windowStart === windowStart && typeof data.count === "number") {
+      if (data.count >= limitPerMinute) {
+        allowed = false;
+        return;
+      }
+      txn.update(ref, { count: data.count + 1 });
+    } else {
+      txn.set(ref, { windowStart, count: 1 });
+    }
+  });
+
+  return {
+    allowed,
+    retryAfterSeconds: allowed
+      ? 0
+      : Math.max(1, Math.ceil(((windowStart + 1) * 60_000 - nowMs) / 1000)),
+  };
+}
+
+export async function enforceRateLimit(key: string, limitPerMinute: number): Promise<void> {
+  const { allowed, retryAfterSeconds } = await checkRateLimit(key, limitPerMinute);
+  if (!allowed) {
+    throw new ApiError(429, "rate_limited", "Rate limit exceeded.", {
+      "Retry-After": String(retryAfterSeconds),
+    });
+  }
+}

--- a/functions/src/api/reviews-api.ts
+++ b/functions/src/api/reviews-api.ts
@@ -387,15 +387,37 @@ const INVALID_CURSOR = new ApiError(
   "The cursor is invalid, expired, or was issued for a different query."
 );
 
+const MAX_CURSOR_LENGTH = 2048;
+const DOC_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+/** Decode and STRICTLY validate an attacker-suppliable cursor: bounded
+ * length, bound to the query hash, `m` a plain non-null object, and every
+ * position either null, "done", or a doc-id-safe string — nothing else may
+ * ever reach a Firestore document path. */
 function decodeCursor(raw: string, expectedKey: string): Record<string, string | null> {
+  if (raw.length > MAX_CURSOR_LENGTH) throw INVALID_CURSOR;
   let payload: CursorPayload;
   try {
     payload = JSON.parse(Buffer.from(raw, "base64url").toString("utf8")) as CursorPayload;
   } catch {
     throw INVALID_CURSOR;
   }
-  if (payload?.v !== 1 || payload.q !== expectedKey || typeof payload.m !== "object") {
+  if (
+    payload === null ||
+    typeof payload !== "object" ||
+    Array.isArray(payload) ||
+    payload.v !== 1 ||
+    payload.q !== expectedKey ||
+    payload.m === null ||
+    typeof payload.m !== "object" ||
+    Array.isArray(payload.m)
+  ) {
     throw INVALID_CURSOR;
+  }
+  for (const value of Object.values(payload.m)) {
+    if (value !== null && value !== "done" && !(typeof value === "string" && DOC_ID_PATTERN.test(value))) {
+      throw INVALID_CURSOR;
+    }
   }
   return payload.m;
 }
@@ -769,10 +791,17 @@ async function handleToken(
   if (!clientId || !clientSecret) {
     throw new ApiError(400, "invalid_request", "client_id and client_secret are required.");
   }
+  // Reject malformed ids BEFORE any Firestore access: untrusted strings must
+  // never reach a document path (a "/" would address a nested path or throw).
+  if (!/^[A-Za-z0-9_-]{4,80}$/.test(clientId) || clientSecret.length > 200) {
+    throw new ApiError(400, "invalid_request", "client_id or client_secret is malformed.");
+  }
 
   // Brute-force guard: failed and successful exchanges both count against a
-  // per-client_id budget, checked before any secret verification.
-  await enforceRateLimit(`token:${clientId.slice(0, 80)}`, TOKEN_RATE_LIMIT_PER_MINUTE);
+  // per-client_id budget, checked before any secret verification. The key is
+  // hashed so the rate-limit doc id never embeds caller-controlled bytes.
+  const rateKey = `token_${createHash("sha256").update(clientId).digest("hex").slice(0, 40)}`;
+  await enforceRateLimit(rateKey, TOKEN_RATE_LIMIT_PER_MINUTE);
 
   const invalidClient = new ApiError(401, "invalid_client", "Invalid client credentials.");
   const client = await loadApiClient(clientId);

--- a/functions/src/api/reviews-api.ts
+++ b/functions/src/api/reviews-api.ts
@@ -1,0 +1,897 @@
+import { createHash } from "crypto";
+import {
+  getFirestore,
+  Query,
+  QueryDocumentSnapshot,
+} from "firebase-admin/firestore";
+import {
+  NEGATIVE_THEMES,
+  POSITIVE_THEMES,
+  ReviewDocument,
+  SummaryDocLike,
+  toPublicReview,
+  toPublicSummary,
+} from "@feefo/shared";
+import { ApiError, newRequestId, sendError, sendJson } from "./http";
+import {
+  AuthContext,
+  authenticateRequest,
+  getSecretPepper,
+  loadApiClient,
+  mintAccessToken,
+  requireScope,
+  verifyClientSecret,
+} from "./auth";
+import { TOKEN_RATE_LIMIT_PER_MINUTE, enforceRateLimit } from "./rate-limit";
+import {
+  MerchantInfo,
+  listMerchantsForScope,
+  resolveMerchants,
+} from "./merchant-registry";
+
+/**
+ * The public reviews API (design: docs/plans/2026-06-09-public-reviews-api.md).
+ *
+ * Routes (all under an optional /api prefix added by the Hosting rewrite):
+ *   POST /v1/oauth/token           — client-credentials → opaque bearer token
+ *   GET  /v1/reviews/all           — paginated, filtered review list
+ *   GET  /v1/reviews/summary/all   — precomputed aggregates
+ *   GET  /v1/reviews/{id}          — single review (uniform 404 out of scope)
+ *   GET  /v1/meta/themes           — AI theme taxonomy
+ *   GET  /v1/meta/merchants        — merchants visible to the credential
+ */
+
+const PAGE_SIZE_DEFAULT = 20;
+const PAGE_SIZE_MAX = 100;
+/** page-mode window may not reach past this many results — use cursors. */
+const PAGE_MODE_MAX_WINDOW = 1000;
+/** Per-request scan budget for post-filtered cursor iteration. */
+const MAX_SCANNED_DOCS = 3000;
+const FETCH_BATCH = 100;
+
+const SINCE_PERIOD_DAYS: Record<string, number | null> = {
+  week: 7,
+  month: 30,
+  quarter: 90,
+  half_year: 182,
+  year: 365,
+  all: null,
+};
+
+// ── Param parsing ───────────────────────────────────────────────────────────
+
+type SortDirection = "asc" | "desc";
+
+interface AttributeFilter {
+  param: string;
+  field: string;
+  op: "==" | "array-contains";
+  value: string | boolean;
+}
+
+interface ListParams {
+  merchantParam: string | undefined;
+  page: number | null;
+  pageSize: number;
+  cursor: string | null;
+  dateField: "dates.created" | "dates.lastUpdated";
+  dateFrom: string | null;
+  dateTo: string | null;
+  direction: SortDirection;
+  attribute: AttributeFilter | null;
+  rating: number | null;
+  reviewType: "service" | "product" | null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function queryParam(req: any, name: string): string | undefined {
+  const value = req.query?.[name];
+  if (typeof value === "string") return value;
+  if (Array.isArray(value) && typeof value[0] === "string") return value[0];
+  return undefined;
+}
+
+function parsePositiveInt(raw: string, name: string, max: number): number {
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1 || value > max) {
+    throw new ApiError(400, "invalid_parameter", `${name} must be an integer between 1 and ${max}.`);
+  }
+  return value;
+}
+
+function parseIsoDate(raw: string, name: string): string {
+  const ms = Date.parse(raw);
+  if (Number.isNaN(ms)) {
+    throw new ApiError(400, "invalid_parameter", `${name} must be an ISO 8601 timestamp.`);
+  }
+  return new Date(ms).toISOString();
+}
+
+function parseSincePeriod(raw: string, name: string): number | null {
+  if (!(raw in SINCE_PERIOD_DAYS)) {
+    throw new ApiError(
+      400,
+      "invalid_parameter",
+      `${name} must be one of: ${Object.keys(SINCE_PERIOD_DAYS).join(", ")}.`
+    );
+  }
+  return SINCE_PERIOD_DAYS[raw];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function parseListParams(req: any): ListParams {
+  if (queryParam(req, "search") !== undefined) {
+    throw new ApiError(
+      400,
+      "search_not_supported",
+      "Free-text search is not available yet (planned; see the API docs)."
+    );
+  }
+
+  const pageRaw = queryParam(req, "page");
+  const page = pageRaw === undefined ? null : parsePositiveInt(pageRaw, "page", 100000);
+  const pageSizeRaw = queryParam(req, "page_size");
+  const pageSize =
+    pageSizeRaw === undefined
+      ? PAGE_SIZE_DEFAULT
+      : parsePositiveInt(pageSizeRaw, "page_size", PAGE_SIZE_MAX);
+  const cursor = queryParam(req, "cursor") ?? null;
+  if (cursor && page !== null) {
+    throw new ApiError(400, "invalid_parameter", "page cannot be combined with cursor.");
+  }
+
+  const sortRaw = queryParam(req, "sort") ?? "newest";
+  if (sortRaw !== "newest" && sortRaw !== "oldest") {
+    throw new ApiError(400, "invalid_parameter", "sort must be 'newest' or 'oldest'.");
+  }
+
+  // Date window. since_updated_period filters/sorts on dates.lastUpdated and
+  // cannot combine with created-date filters (one range field per query).
+  const sincePeriod = queryParam(req, "since_period");
+  const sinceUpdatedPeriod = queryParam(req, "since_updated_period");
+  const dateTimeFrom = queryParam(req, "date_time_from");
+  const dateTimeTo = queryParam(req, "date_time_to");
+
+  let dateField: ListParams["dateField"] = "dates.created";
+  let dateFrom: string | null = null;
+  let dateTo: string | null = null;
+
+  if (sinceUpdatedPeriod !== undefined) {
+    if (sincePeriod !== undefined || dateTimeFrom !== undefined || dateTimeTo !== undefined) {
+      throw new ApiError(
+        400,
+        "invalid_parameter",
+        "since_updated_period cannot be combined with since_period or date_time_from/to."
+      );
+    }
+    dateField = "dates.lastUpdated";
+    const days = parseSincePeriod(sinceUpdatedPeriod, "since_updated_period");
+    if (days !== null) dateFrom = new Date(Date.now() - days * 86_400_000).toISOString();
+  } else {
+    if (sincePeriod !== undefined) {
+      const days = parseSincePeriod(sincePeriod, "since_period");
+      if (days !== null) dateFrom = new Date(Date.now() - days * 86_400_000).toISOString();
+    }
+    if (dateTimeFrom !== undefined) {
+      const from = parseIsoDate(dateTimeFrom, "date_time_from");
+      dateFrom = dateFrom && dateFrom > from ? dateFrom : from;
+    }
+    if (dateTimeTo !== undefined) dateTo = parseIsoDate(dateTimeTo, "date_time_to");
+  }
+
+  // Attribute filters map to indexed equality/array-contains constraints.
+  // v1 allows at most ONE per request so every query stays inside the
+  // composite indexes we actually have (brand + attribute + date).
+  const attributeCandidates: AttributeFilter[] = [];
+  const pushAttr = (param: string, field: string, op: AttributeFilter["op"]) => {
+    const value = queryParam(req, param);
+    if (value !== undefined) {
+      if (!value.trim()) {
+        throw new ApiError(400, "invalid_parameter", `${param} must not be empty.`);
+      }
+      attributeCandidates.push({ param, field, op, value });
+    }
+  };
+  pushAttr("ship", "tags.ship", "==");
+  pushAttr("tour", "tags.tour", "==");
+  pushAttr("region", "tags.region", "==");
+  pushAttr("booking_type", "tags.bookingType", "==");
+  pushAttr("loyalty", "tags.loyalty", "==");
+  pushAttr("product_sku", "product.sku", "==");
+  pushAttr("parent_product_sku", "product.parentSku", "==");
+  pushAttr("positive_theme", "themes.positive", "array-contains");
+  pushAttr("negative_theme", "themes.negative", "array-contains");
+
+  const hasMediaRaw = queryParam(req, "has_media");
+  if (hasMediaRaw !== undefined) {
+    if (hasMediaRaw !== "true" && hasMediaRaw !== "false") {
+      throw new ApiError(400, "invalid_parameter", "has_media must be 'true' or 'false'.");
+    }
+    if (hasMediaRaw === "true") {
+      attributeCandidates.push({ param: "has_media", field: "hasMedia", op: "==", value: true });
+    }
+  }
+
+  if (attributeCandidates.length > 1) {
+    throw new ApiError(
+      400,
+      "filters_not_combinable",
+      `Combine at most one of these filters per request: ${attributeCandidates
+        .map((a) => a.param)
+        .join(", ")}.`
+    );
+  }
+
+  // Post-filters (applied in memory while scanning, because Firestore can't
+  // express them alongside the indexed constraints).
+  const ratingRaw = queryParam(req, "rating");
+  const rating = ratingRaw === undefined ? null : parsePositiveInt(ratingRaw, "rating", 5);
+
+  const reviewTypeRaw = queryParam(req, "review_type") ?? "all";
+  if (!["all", "service", "product"].includes(reviewTypeRaw)) {
+    throw new ApiError(400, "invalid_parameter", "review_type must be all, service, or product.");
+  }
+  const reviewType = reviewTypeRaw === "all" ? null : (reviewTypeRaw as "service" | "product");
+
+  const hasPostFilters = rating !== null || reviewType !== null;
+  if (hasPostFilters && page !== null && page > 1) {
+    throw new ApiError(
+      400,
+      "use_cursor",
+      "rating/review_type filters require cursor pagination beyond the first page."
+    );
+  }
+
+  const window = ((page ?? 1) - 1) * pageSize + pageSize;
+  if (window > PAGE_MODE_MAX_WINDOW) {
+    throw new ApiError(
+      400,
+      "use_cursor",
+      `page * page_size cannot exceed ${PAGE_MODE_MAX_WINDOW}; use cursor pagination for deep iteration.`
+    );
+  }
+
+  return {
+    merchantParam: queryParam(req, "merchant_identifier"),
+    page,
+    pageSize,
+    cursor,
+    dateField,
+    dateFrom,
+    dateTo,
+    direction: sortRaw === "oldest" ? "asc" : "desc",
+    attribute: attributeCandidates[0] ?? null,
+    rating,
+    reviewType,
+  };
+}
+
+function hasPostFilters(p: ListParams): boolean {
+  return p.rating !== null || p.reviewType !== null;
+}
+
+// ── Query building & merge pagination ───────────────────────────────────────
+
+function buildBaseQuery(merchant: MerchantInfo, p: ListParams): Query {
+  const db = getFirestore();
+  let q: Query = db
+    .collection(merchant.reviewsCollection)
+    .where("brand", "==", merchant.identifier);
+  if (p.attribute) {
+    q = q.where(p.attribute.field, p.attribute.op, p.attribute.value);
+  }
+  if (p.dateFrom) q = q.where(p.dateField, ">=", p.dateFrom);
+  if (p.dateTo) q = q.where(p.dateField, "<=", p.dateTo);
+  return q.orderBy(p.dateField, p.direction);
+}
+
+function matchesPostFilters(snap: QueryDocumentSnapshot, p: ListParams): boolean {
+  if (p.rating !== null) {
+    const ratings = snap.get("ratings") as { product?: number; service?: number } | undefined;
+    const headline = ratings?.product ?? ratings?.service ?? null;
+    if (typeof headline !== "number" || Math.round(headline) !== p.rating) return false;
+  }
+  if (p.reviewType !== null) {
+    const reviews = snap.get("reviews") as
+      | { serviceText?: string | null; productText?: string | null }
+      | undefined;
+    const text = p.reviewType === "service" ? reviews?.serviceText : reviews?.productText;
+    if (typeof text !== "string" || !text.trim()) return false;
+  }
+  return true;
+}
+
+interface MerchantStream {
+  merchant: MerchantInfo;
+  buffer: QueryDocumentSnapshot[];
+  bufferIndex: number;
+  lastFetched: QueryDocumentSnapshot | null;
+  /** Doc id of the last doc handed to the merge (the cursor position). */
+  lastConsumedId: string | null;
+  /** True once Firestore has no more docs beyond the current buffer. */
+  noMoreAfterBuffer: boolean;
+  /** True when a cursor marked this stream finished in a prior request. */
+  done: boolean;
+}
+
+async function fillStream(stream: MerchantStream, p: ListParams): Promise<void> {
+  if (stream.done || stream.noMoreAfterBuffer || stream.bufferIndex < stream.buffer.length) {
+    return;
+  }
+  let q = buildBaseQuery(stream.merchant, p);
+  if (stream.lastFetched) q = q.startAfter(stream.lastFetched);
+  const snap = await q.limit(FETCH_BATCH).get();
+  stream.buffer = snap.docs;
+  stream.bufferIndex = 0;
+  if (snap.docs.length > 0) stream.lastFetched = snap.docs[snap.docs.length - 1];
+  if (snap.docs.length < FETCH_BATCH) stream.noMoreAfterBuffer = true;
+}
+
+function streamHead(stream: MerchantStream): QueryDocumentSnapshot | null {
+  if (stream.done) return null;
+  return stream.bufferIndex < stream.buffer.length ? stream.buffer[stream.bufferIndex] : null;
+}
+
+function streamFinished(stream: MerchantStream): boolean {
+  return (
+    stream.done || (stream.noMoreAfterBuffer && stream.bufferIndex >= stream.buffer.length)
+  );
+}
+
+function compareDocs(
+  a: QueryDocumentSnapshot,
+  b: QueryDocumentSnapshot,
+  p: ListParams
+): number {
+  const aDate = (a.get(p.dateField) as string | undefined) ?? "";
+  const bDate = (b.get(p.dateField) as string | undefined) ?? "";
+  const byDate = p.direction === "desc" ? bDate.localeCompare(aDate) : aDate.localeCompare(bDate);
+  if (byDate !== 0) return byDate;
+  // Mirror Firestore's implicit __name__ tiebreaker (follows the last
+  // orderBy direction) so the merged order matches per-stream order.
+  return p.direction === "desc" ? b.id.localeCompare(a.id) : a.id.localeCompare(b.id);
+}
+
+// ── Cursor encoding ─────────────────────────────────────────────────────────
+
+interface CursorPayload {
+  v: 1;
+  /** Hash of the canonical query (merchants + filters + sort); a cursor is
+   * only valid for the exact query it was issued for. */
+  q: string;
+  /** merchant id → last consumed doc id, null (start), or "done". */
+  m: Record<string, string | null>;
+}
+
+function queryKeyHash(merchants: MerchantInfo[], p: ListParams): string {
+  const canonical = JSON.stringify({
+    merchants: merchants.map((m) => m.identifier).sort(),
+    dateField: p.dateField,
+    dateFrom: p.dateFrom,
+    dateTo: p.dateTo,
+    direction: p.direction,
+    attribute: p.attribute ? [p.attribute.field, p.attribute.op, p.attribute.value] : null,
+    rating: p.rating,
+    reviewType: p.reviewType,
+  });
+  return createHash("sha1").update(canonical).digest("hex").slice(0, 16);
+}
+
+function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+}
+
+const INVALID_CURSOR = new ApiError(
+  400,
+  "invalid_cursor",
+  "The cursor is invalid, expired, or was issued for a different query."
+);
+
+function decodeCursor(raw: string, expectedKey: string): Record<string, string | null> {
+  let payload: CursorPayload;
+  try {
+    payload = JSON.parse(Buffer.from(raw, "base64url").toString("utf8")) as CursorPayload;
+  } catch {
+    throw INVALID_CURSOR;
+  }
+  if (payload?.v !== 1 || payload.q !== expectedKey || typeof payload.m !== "object") {
+    throw INVALID_CURSOR;
+  }
+  return payload.m;
+}
+
+function captureCursorState(streams: MerchantStream[]): Record<string, string | null> {
+  const state: Record<string, string | null> = {};
+  for (const stream of streams) {
+    state[stream.merchant.identifier] = streamFinished(stream)
+      ? "done"
+      : stream.lastConsumedId;
+  }
+  return state;
+}
+
+// ── Itinerary mapping lookups (per-instance cache) ──────────────────────────
+
+const mappingCache = new Map<string, { lookup: Map<string, string>; fetchedAt: number }>();
+const MAPPING_CACHE_TTL_MS = 300_000;
+
+async function getGroupLookup(merchant: MerchantInfo): Promise<Map<string, string>> {
+  const cached = mappingCache.get(merchant.identifier);
+  if (cached && Date.now() - cached.fetchedAt < MAPPING_CACHE_TTL_MS) {
+    return cached.lookup;
+  }
+  const db = getFirestore();
+  const snap = await db
+    .collection(merchant.mappingsCollection)
+    .where("brand", "==", merchant.identifier)
+    .get();
+  const lookup = new Map<string, string>();
+  for (const doc of snap.docs) {
+    const data = doc.data();
+    if (typeof data.rawName === "string" && typeof data.effectiveParentName === "string") {
+      lookup.set(data.rawName, data.effectiveParentName);
+    }
+  }
+  mappingCache.set(merchant.identifier, { lookup, fetchedAt: Date.now() });
+  return lookup;
+}
+
+// ── Handlers ────────────────────────────────────────────────────────────────
+
+async function handleListReviews(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  req: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  res: any,
+  requestId: string,
+  auth: AuthContext,
+  log: Record<string, unknown>
+): Promise<void> {
+  const p = parseListParams(req);
+  const merchants = resolveMerchants(p.merchantParam, auth.merchants);
+  log.merchants = merchants.map((m) => m.identifier);
+
+  const key = queryKeyHash(merchants, p);
+  const streams: MerchantStream[] = merchants.map((merchant) => ({
+    merchant,
+    buffer: [],
+    bufferIndex: 0,
+    lastFetched: null,
+    lastConsumedId: null,
+    noMoreAfterBuffer: false,
+    done: false,
+  }));
+
+  // Resume from a cursor: position each stream after its last consumed doc.
+  if (p.cursor) {
+    const state = decodeCursor(p.cursor, key);
+    const db = getFirestore();
+    for (const stream of streams) {
+      const position = state[stream.merchant.identifier];
+      if (position === undefined) throw INVALID_CURSOR;
+      if (position === "done") {
+        stream.done = true;
+      } else if (position !== null) {
+        const snap = await db
+          .collection(stream.merchant.reviewsCollection)
+          .doc(position)
+          .get();
+        if (!snap.exists) throw INVALID_CURSOR;
+        stream.lastFetched = snap as unknown as QueryDocumentSnapshot;
+        stream.lastConsumedId = position;
+      }
+    }
+  }
+
+  const targetSkip = ((p.page ?? 1) - 1) * p.pageSize;
+  const needed = targetSkip + p.pageSize + 1;
+
+  const matches: Array<{ snap: QueryDocumentSnapshot; merchant: MerchantInfo }> = [];
+  let scanned = 0;
+  let cursorAtWindowEnd: Record<string, string | null> | null = null;
+
+  while (matches.length < needed && scanned < MAX_SCANNED_DOCS) {
+    // Pick the next doc across streams in merged date order.
+    let best: MerchantStream | null = null;
+    for (const stream of streams) {
+      await fillStream(stream, p);
+      const head = streamHead(stream);
+      if (!head) continue;
+      if (!best) {
+        best = stream;
+      } else {
+        const bestHead = streamHead(best);
+        if (bestHead && compareDocs(head, bestHead, p) < 0) best = stream;
+      }
+    }
+    if (!best) break; // every stream exhausted
+
+    const snap = best.buffer[best.bufferIndex];
+    best.bufferIndex += 1;
+    best.lastConsumedId = snap.id;
+    scanned += 1;
+
+    if (matchesPostFilters(snap, p)) {
+      matches.push({ snap, merchant: best.merchant });
+      if (matches.length === targetSkip + p.pageSize) {
+        cursorAtWindowEnd = captureCursorState(streams);
+      }
+    }
+  }
+
+  const allFinished = streams.every(streamFinished);
+  const windowMatches = matches.slice(targetSkip, targetSkip + p.pageSize);
+  const hasMore = matches.length > targetSkip + p.pageSize || !allFinished;
+
+  // Exact totals are only knowable when every filter ran server-side.
+  let count: number | null = null;
+  let pages: number | null = null;
+  if (!hasPostFilters(p)) {
+    count = 0;
+    for (const merchant of merchants) {
+      const agg = await buildBaseQuery(merchant, p).count().get();
+      count += agg.data().count;
+    }
+    pages = Math.max(1, Math.ceil(count / p.pageSize));
+  }
+
+  const nextCursor = hasMore
+    ? encodeCursor({ v: 1, q: key, m: cursorAtWindowEnd ?? captureCursorState(streams) })
+    : null;
+
+  const reviews = [];
+  for (const match of windowMatches) {
+    const lookup = await getGroupLookup(match.merchant);
+    reviews.push(
+      toPublicReview(match.snap.data() as ReviewDocument, { itineraryGroupLookup: lookup })
+    );
+  }
+  log.resultCount = reviews.length;
+  log.scanned = scanned;
+
+  sendJson(
+    res,
+    requestId,
+    200,
+    {
+      summary: {
+        meta: {
+          count,
+          pages,
+          page_size: p.pageSize,
+          current_page: p.cursor ? null : p.page ?? 1,
+        },
+        next_cursor: nextCursor,
+      },
+      reviews,
+    },
+    { req }
+  );
+}
+
+async function handleGetReview(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  req: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  res: any,
+  requestId: string,
+  auth: AuthContext,
+  reviewId: string,
+  log: Record<string, unknown>
+): Promise<void> {
+  const merchants = resolveMerchants("all", auth.merchants);
+  const db = getFirestore();
+
+  // Identical 404 for "doesn't exist" and "outside the credential's merchant
+  // scope" so review ids can't be probed across merchants.
+  const notFound = new ApiError(404, "review_not_found", "No review with that id.");
+
+  const collections = [...new Set(merchants.map((m) => m.reviewsCollection))];
+  let snap: FirebaseFirestore.DocumentSnapshot | null = null;
+  for (const collection of collections) {
+    const candidate = await db.collection(collection).doc(reviewId).get();
+    if (candidate.exists) {
+      snap = candidate;
+      break;
+    }
+  }
+  if (!snap) throw notFound;
+
+  const brand = snap.get("brand");
+  const merchant = merchants.find((m) => m.identifier === brand);
+  if (!merchant) throw notFound;
+
+  const lookup = await getGroupLookup(merchant);
+  log.merchants = [merchant.identifier];
+  log.resultCount = 1;
+  sendJson(
+    res,
+    requestId,
+    200,
+    toPublicReview(snap.data() as ReviewDocument, { itineraryGroupLookup: lookup }),
+    { req }
+  );
+}
+
+function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 100);
+}
+
+function asSummaryDoc(data: FirebaseFirestore.DocumentData): SummaryDocLike {
+  return {
+    scope: data.scope === "ship" || data.scope === "itinerary" ? data.scope : "fleet",
+    scopeValue: typeof data.scopeValue === "string" ? data.scopeValue : null,
+    totalReviews: typeof data.totalReviews === "number" ? data.totalReviews : 0,
+    reviewsWithComments:
+      typeof data.reviewsWithComments === "number" ? data.reviewsWithComments : 0,
+    avgRating: typeof data.avgRating === "number" ? data.avgRating : 0,
+    starDistribution:
+      typeof data.starDistribution === "object" && data.starDistribution !== null
+        ? (data.starDistribution as Record<string, number>)
+        : {},
+    topPositiveThemes: Array.isArray(data.topPositiveThemes) ? data.topPositiveThemes : [],
+    topNegativeThemes: Array.isArray(data.topNegativeThemes) ? data.topNegativeThemes : [],
+    ships: Array.isArray(data.ships) ? data.ships : [],
+    itineraries: Array.isArray(data.itineraries) ? data.itineraries : [],
+    lastUpdated: typeof data.lastUpdated === "string" ? data.lastUpdated : undefined,
+  };
+}
+
+function mergeSummaries(docs: SummaryDocLike[]): SummaryDocLike {
+  const merged: SummaryDocLike = {
+    scope: docs[0].scope,
+    scopeValue: docs[0].scopeValue,
+    totalReviews: 0,
+    reviewsWithComments: 0,
+    avgRating: 0,
+    starDistribution: {},
+    topPositiveThemes: [],
+    topNegativeThemes: [],
+    ships: [],
+    itineraries: [],
+    lastUpdated: undefined,
+  };
+
+  let ratingWeight = 0;
+  const positive: Record<string, number> = {};
+  const negative: Record<string, number> = {};
+  const ships = new Set<string>();
+  const itineraries = new Set<string>();
+
+  for (const doc of docs) {
+    merged.totalReviews += doc.totalReviews;
+    merged.reviewsWithComments += doc.reviewsWithComments;
+    ratingWeight += doc.avgRating * doc.totalReviews;
+    for (const [star, value] of Object.entries(doc.starDistribution)) {
+      if (typeof value === "number") {
+        merged.starDistribution[star] = (merged.starDistribution[star] ?? 0) + value;
+      }
+    }
+    for (const t of doc.topPositiveThemes) positive[t.theme] = (positive[t.theme] ?? 0) + t.count;
+    for (const t of doc.topNegativeThemes) negative[t.theme] = (negative[t.theme] ?? 0) + t.count;
+    for (const ship of doc.ships) ships.add(ship);
+    for (const itinerary of doc.itineraries) itineraries.add(itinerary);
+    if (doc.lastUpdated && (!merged.lastUpdated || doc.lastUpdated > merged.lastUpdated)) {
+      merged.lastUpdated = doc.lastUpdated;
+    }
+  }
+
+  merged.avgRating =
+    merged.totalReviews > 0 ? Math.round((ratingWeight / merged.totalReviews) * 100) / 100 : 0;
+  merged.topPositiveThemes = Object.entries(positive)
+    .map(([theme, count]) => ({ theme, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+  merged.topNegativeThemes = Object.entries(negative)
+    .map(([theme, count]) => ({ theme, count }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+  merged.ships = [...ships].sort();
+  merged.itineraries = [...itineraries].sort();
+  return merged;
+}
+
+async function handleSummary(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  req: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  res: any,
+  requestId: string,
+  auth: AuthContext,
+  log: Record<string, unknown>
+): Promise<void> {
+  const scope = queryParam(req, "scope") ?? "fleet";
+  if (!["fleet", "ship", "itinerary"].includes(scope)) {
+    throw new ApiError(400, "invalid_parameter", "scope must be fleet, ship, or itinerary.");
+  }
+  const scopeValue = queryParam(req, "scope_value");
+  if (scope !== "fleet" && (!scopeValue || !scopeValue.trim())) {
+    throw new ApiError(400, "invalid_parameter", `scope_value is required when scope=${scope}.`);
+  }
+
+  const merchants = resolveMerchants(queryParam(req, "merchant_identifier"), auth.merchants);
+  log.merchants = merchants.map((m) => m.identifier);
+
+  const db = getFirestore();
+  const found: Array<{ merchant: MerchantInfo; doc: SummaryDocLike }> = [];
+  for (const merchant of merchants) {
+    const docId =
+      scope === "fleet"
+        ? merchant.identifier
+        : `${merchant.identifier}_${scope}_${slugify(scopeValue!.trim())}`;
+    const snap = await db.collection(merchant.summariesCollection).doc(docId).get();
+    if (snap.exists) {
+      found.push({ merchant, doc: asSummaryDoc(snap.data() ?? {}) });
+    }
+  }
+
+  if (found.length === 0) {
+    throw new ApiError(404, "summary_not_found", "No summary for that merchant/scope.");
+  }
+
+  const body =
+    found.length === 1 && merchants.length === 1
+      ? toPublicSummary(found[0].doc, {
+          identifier: found[0].merchant.identifier,
+          name: found[0].merchant.label,
+        })
+      : toPublicSummary(mergeSummaries(found.map((f) => f.doc)), {
+          identifier: "all",
+          name: "All merchants",
+        });
+
+  log.resultCount = 1;
+  sendJson(res, requestId, 200, body, { req, cacheSeconds: 600 });
+}
+
+async function handleToken(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  req: any,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  res: any,
+  requestId: string,
+  log: Record<string, unknown>
+): Promise<void> {
+  const pepper = getSecretPepper();
+
+  const body = typeof req.body === "object" && req.body !== null ? req.body : {};
+  const clientId = typeof body.client_id === "string" ? body.client_id.trim() : "";
+  const clientSecret = typeof body.client_secret === "string" ? body.client_secret : "";
+  const grantType = typeof body.grant_type === "string" ? body.grant_type : "";
+
+  if (grantType !== "client_credentials") {
+    throw new ApiError(400, "unsupported_grant_type", "grant_type must be client_credentials.");
+  }
+  if (!clientId || !clientSecret) {
+    throw new ApiError(400, "invalid_request", "client_id and client_secret are required.");
+  }
+
+  // Brute-force guard: failed and successful exchanges both count against a
+  // per-client_id budget, checked before any secret verification.
+  await enforceRateLimit(`token:${clientId.slice(0, 80)}`, TOKEN_RATE_LIMIT_PER_MINUTE);
+
+  const invalidClient = new ApiError(401, "invalid_client", "Invalid client credentials.");
+  const client = await loadApiClient(clientId);
+  if (!client || client.status !== "active" || !client.secretVerifier) {
+    throw invalidClient;
+  }
+  if (!verifyClientSecret(clientSecret, client.secretVerifier, pepper)) {
+    throw invalidClient;
+  }
+
+  const { accessToken, expiresIn } = await mintAccessToken(client);
+  log.clientId = client.clientId;
+  sendJson(
+    res,
+    requestId,
+    200,
+    { access_token: accessToken, token_type: "Bearer", expires_in: expiresIn },
+    { noStore: true }
+  );
+}
+
+// ── Router ──────────────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function handleApiRequest(req: any, res: any): Promise<void> {
+  const requestId = newRequestId();
+  const startedAt = Date.now();
+  const log: Record<string, unknown> = {};
+
+  try {
+    let path = typeof req.path === "string" && req.path ? req.path : "/";
+    path = path.replace(/\/+$/, "") || "/";
+    // Behind the Hosting rewrite the function sees the original /api/... path;
+    // called directly (emulator, cloudfunctions.net) there is no prefix.
+    if (path === "/api" || path.startsWith("/api/")) path = path.slice(4) || "/";
+
+    if (path === "/v1/oauth/token") {
+      if (req.method !== "POST") {
+        throw new ApiError(405, "method_not_allowed", "Use POST for the token endpoint.");
+      }
+      await handleToken(req, res, requestId, log);
+      return;
+    }
+
+    if (req.method !== "GET") {
+      throw new ApiError(405, "method_not_allowed", "Use GET.");
+    }
+
+    const auth = await authenticateRequest(req);
+    log.clientId = auth.clientId;
+    await enforceRateLimit(`api:${auth.clientId}`, auth.rateLimitPerMinute);
+
+    if (path === "/v1/reviews/all") {
+      requireScope(auth, "reviews:read");
+      await handleListReviews(req, res, requestId, auth, log);
+      return;
+    }
+
+    if (path === "/v1/reviews/summary/all") {
+      requireScope(auth, "summary:read");
+      await handleSummary(req, res, requestId, auth, log);
+      return;
+    }
+
+    if (path === "/v1/meta/themes") {
+      requireScope(auth, "meta:read");
+      sendJson(
+        res,
+        requestId,
+        200,
+        {
+          themes: {
+            positive: POSITIVE_THEMES.map((t) => ({ name: t.name, description: t.description })),
+            negative: NEGATIVE_THEMES.map((t) => ({ name: t.name, description: t.description })),
+          },
+        },
+        { req, cacheSeconds: 3600 }
+      );
+      return;
+    }
+
+    if (path === "/v1/meta/merchants") {
+      requireScope(auth, "meta:read");
+      sendJson(
+        res,
+        requestId,
+        200,
+        {
+          merchants: listMerchantsForScope(auth.merchants).map((m) => ({
+            merchant_identifier: m.identifier,
+            label: m.label,
+          })),
+        },
+        { req, cacheSeconds: 3600 }
+      );
+      return;
+    }
+
+    const idMatch = path.match(/^\/v1\/reviews\/([A-Za-z0-9_-]{1,128})$/);
+    if (idMatch) {
+      requireScope(auth, "reviews:read");
+      await handleGetReview(req, res, requestId, auth, idMatch[1], log);
+      return;
+    }
+
+    throw new ApiError(404, "not_found", "Unknown endpoint.");
+  } catch (error) {
+    sendError(res, requestId, error);
+  } finally {
+    console.log(
+      JSON.stringify({
+        msg: "reviewsApi",
+        requestId,
+        method: req.method,
+        path: req.path,
+        status: res.statusCode,
+        latencyMs: Date.now() - startedAt,
+        ...log,
+      })
+    );
+  }
+}

--- a/functions/src/auth/access-control.ts
+++ b/functions/src/auth/access-control.ts
@@ -4,7 +4,8 @@ export type AccessPermission =
   | "sync"
   | "batchClassify"
   | "manageMappings"
-  | "manageUsers";
+  | "manageUsers"
+  | "manageApiClients";
 
 export type AdminRole = "owner" | "admin" | "sync";
 
@@ -98,6 +99,7 @@ export function hasPermission(
     case "batchClassify":
       return user.role === "admin" || user.role === "sync";
     case "manageMappings":
+    case "manageApiClients":
       return user.role === "admin";
     case "manageUsers":
       return false;

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -32,6 +32,15 @@ import {
   writeOperationLog,
   type OperationLogSource,
 } from "./ops/operation-logs";
+import { isMerchantIdentifier } from "@feefo/shared";
+import { handleApiRequest } from "./api/reviews-api";
+import {
+  createApiClient,
+  listApiClients,
+  revokeApiClient,
+  rotateApiClient,
+} from "./api/api-clients";
+import { ApiError } from "./api/http";
 
 initializeApp();
 
@@ -46,11 +55,8 @@ const ALLOWED_ORIGINS = process.env.CORS_ALLOWED_ORIGINS
     ? true // allow all origins in the local emulator
     : DEFAULT_ORIGINS; // restrict to known Firebase Hosting domains
 
-const VALID_BRANDS = new Set(["uniworld", "luxury-gold"]);
-
-function isValidBrand(value: unknown): value is "uniworld" | "luxury-gold" {
-  return typeof value === "string" && VALID_BRANDS.has(value);
-}
+// Single source of truth for merchant identifiers lives in @feefo/shared.
+const isValidBrand = isMerchantIdentifier;
 
 interface AuthorizedCaller {
   uid: string;
@@ -154,6 +160,8 @@ function getEffectivePermissions(
       allowedByLegacyEmailList || hasPermission(adminUser, "manageMappings"),
     manageUsers:
       allowedByLegacyEmailList || hasPermission(adminUser, "manageUsers"),
+    manageApiClients:
+      allowedByLegacyEmailList || hasPermission(adminUser, "manageApiClients"),
   };
 }
 
@@ -800,5 +808,104 @@ export const adminUsers = onRequest(
       .json({
         error: "Invalid action. Use 'current', 'list', 'known', 'upsert', or 'remove'.",
       });
+  }
+);
+
+// Public reviews API — Feefo-emulating, read-only, bearer-token auth.
+// Routed via the Firebase Hosting rewrite /api/** so consumers see a stable
+// same-domain base URL. Design: docs/plans/2026-06-09-public-reviews-api.md.
+export const reviewsApi = onRequest(
+  { timeoutSeconds: 60, memory: "512MiB", invoker: "public" },
+  handleApiRequest
+);
+
+// Manage API credentials for the public reviews API (dashboard admin action).
+export const apiClients = onRequest(
+  { timeoutSeconds: 60, memory: "512MiB", invoker: "public", cors: ALLOWED_ORIGINS },
+  async (req, res) => {
+    if (!ensurePost(req, res)) return;
+    const caller = await authorizeRequest(req, res, "manageApiClients");
+    if (!caller) return;
+
+    const action = req.body?.action ?? "list";
+
+    try {
+      if (action === "list") {
+        res.json({ clients: await listApiClients() });
+        return;
+      }
+
+      if (action === "create") {
+        const result = await createApiClient({
+          label: req.body?.label,
+          merchants: req.body?.merchants,
+          scopes: req.body?.scopes,
+          createdBy: caller.email ?? caller.uid,
+        });
+        await writeOperationLog({
+          type: "apiClient",
+          level: "success",
+          action: "client_created",
+          message: `API client created: ${result.client.label}`,
+          source: "manual",
+          actorEmail: caller.email,
+          actorUid: caller.uid,
+          details: {
+            clientId: result.client.clientId,
+            merchants: result.client.merchants,
+            scopes: result.client.scopes,
+          },
+        });
+        console.log(`apiClients create by ${caller.source}:${caller.email ?? caller.uid}`);
+        // The plain secret appears in this response ONLY — never persisted.
+        res.json({ success: true, client: result.client, clientSecret: result.clientSecret });
+        return;
+      }
+
+      if (action === "revoke") {
+        const client = await revokeApiClient(req.body?.clientId);
+        await writeOperationLog({
+          type: "apiClient",
+          level: "warning",
+          action: "client_revoked",
+          message: `API client revoked: ${client.label}`,
+          source: "manual",
+          actorEmail: caller.email,
+          actorUid: caller.uid,
+          details: { clientId: client.clientId },
+        });
+        console.log(`apiClients revoke by ${caller.source}:${caller.email ?? caller.uid}`);
+        res.json({ success: true, client });
+        return;
+      }
+
+      if (action === "rotate") {
+        const result = await rotateApiClient(req.body?.clientId);
+        await writeOperationLog({
+          type: "apiClient",
+          level: "success",
+          action: "client_rotated",
+          message: `API client secret rotated: ${result.client.label}`,
+          source: "manual",
+          actorEmail: caller.email,
+          actorUid: caller.uid,
+          details: { clientId: result.client.clientId },
+        });
+        console.log(`apiClients rotate by ${caller.source}:${caller.email ?? caller.uid}`);
+        res.json({ success: true, client: result.client, clientSecret: result.clientSecret });
+        return;
+      }
+
+      res
+        .status(400)
+        .json({ error: "Invalid action. Use 'create', 'list', 'revoke', or 'rotate'." });
+    } catch (error) {
+      if (error instanceof ApiError) {
+        res.status(error.status).json({ error: error.message });
+        return;
+      }
+      console.error("apiClients error:", error);
+      res.status(500).json({ error: "Internal error." });
+    }
   }
 );

--- a/functions/src/ops/operation-logs.ts
+++ b/functions/src/ops/operation-logs.ts
@@ -1,6 +1,6 @@
 import { getFirestore, type Query } from "firebase-admin/firestore";
 
-export type OperationLogType = "sync" | "classification" | "summary";
+export type OperationLogType = "sync" | "classification" | "summary" | "apiClient";
 export type OperationLogLevel = "info" | "success" | "warning" | "error";
 export type OperationLogSource = "scheduled" | "manual" | "system";
 
@@ -75,7 +75,10 @@ export async function listOperationLogs(options?: {
     const data = doc.data() ?? {};
     return {
       id: doc.id,
-      type: data.type === "classification" || data.type === "summary" ? data.type : "sync",
+      type:
+        data.type === "classification" || data.type === "summary" || data.type === "apiClient"
+          ? data.type
+          : "sync",
       level:
         data.level === "success" ||
         data.level === "warning" ||

--- a/scripts/seed-emulator.js
+++ b/scripts/seed-emulator.js
@@ -1,0 +1,232 @@
+/**
+ * Seed the Firestore EMULATOR with sample data for exercising the public
+ * reviews API locally (reviews, summaries, itinerary mappings, and one API
+ * client whose credentials are printed at the end).
+ *
+ * Usage:
+ *   FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 node scripts/seed-emulator.js
+ *
+ * The API client's secret verifier is computed with the same peppered HMAC
+ * as functions/src/api/auth.ts, using REVIEWS_API_SECRET_PEPPER (defaults to
+ * the local-test pepper below — keep it in sync with functions/.env.local).
+ */
+
+const { createHmac } = require("crypto");
+const path = require("path");
+
+if (!process.env.FIRESTORE_EMULATOR_HOST) {
+  console.error("Refusing to run: FIRESTORE_EMULATOR_HOST is not set (emulator only).");
+  process.exit(1);
+}
+
+// Reuse the functions package's firebase-admin install.
+const admin = require(path.join(__dirname, "..", "functions", "node_modules", "firebase-admin"));
+
+admin.initializeApp({ projectId: process.env.GCLOUD_PROJECT || "feefo-reviews" });
+const db = admin.firestore();
+
+const PEPPER = process.env.REVIEWS_API_SECRET_PEPPER || "local-test-pepper-0123456789abcdef";
+const CLIENT_ID = "uw_live_local0test01";
+const CLIENT_SECRET = "local-test-secret-not-for-production-1234";
+
+function isoDaysAgo(days) {
+  return new Date(Date.now() - days * 86_400_000).toISOString();
+}
+
+function review({ id, brand, displayName, ship, tour, region, serviceRating, productRating, serviceText, productText, positive, negative, media, daysAgo, sku, parentSku }) {
+  return {
+    id,
+    feedbackUrl: `https://www.feefo.com/en-US/reviews/${brand}/${id}`,
+    brand,
+    customer: {
+      name: "SEED_PII_FULL_NAME",
+      displayName: displayName ?? null,
+      location: "SEED_PII_LOCATION",
+      email: "seed-pii@example.com",
+      orderRef: "SEED_PII_ORDER",
+      customerRef: "SEED_PII_CUSTOMER",
+    },
+    product: {
+      title: tour,
+      sku: sku ?? `${brand.toUpperCase()}-SKU-${id.slice(-2)}`,
+      parentSku: parentSku ?? null,
+      url: null,
+      imageUrl: null,
+    },
+    ratings: { service: serviceRating ?? null, product: productRating ?? null },
+    reviews: {
+      serviceTitle: serviceText ? "Service headline" : null,
+      serviceText: serviceText ?? null,
+      productText: productText ?? null,
+    },
+    tags: {
+      ship: ship ?? null,
+      tour,
+      tourDirector: "SEED_PII_TOUR_DIRECTOR",
+      bookingType: "Direct",
+      region: region ?? null,
+      loyalty: "Returning Guest",
+      clientType: "Couple",
+      package: null,
+    },
+    themes: {
+      positive: positive ?? [],
+      negative: negative ?? [],
+      classifiedAt: isoDaysAgo(daysAgo - 0.5),
+    },
+    media: media ?? [],
+    dates: {
+      created: isoDaysAgo(daysAgo),
+      lastUpdated: isoDaysAgo(daysAgo - 0.25),
+      synced: new Date().toISOString(),
+    },
+    hasComment: Boolean(serviceText || productText),
+    hasMedia: (media ?? []).length > 0,
+    moderationStatus: "published",
+    verified: true,
+  };
+}
+
+const REVIEWS = [
+  review({
+    id: "aaaaaaaaaaaaaaaaaaaaaa01", brand: "uniworld", displayName: "Jane D.",
+    ship: "S.S. Beatrice", tour: "Enchanting Danube (8 Days)", region: "Central Europe",
+    serviceRating: 5, productRating: 5,
+    serviceText: "Booking was effortless.", productText: "The Danube was breathtaking.",
+    positive: ["Staff", "Excursions"], negative: [],
+    media: [{ type: "PHOTO", url: "https://example.com/p1.jpg" }],
+    daysAgo: 2, sku: "UW-DAN-8", parentSku: "UW-DAN",
+  }),
+  review({
+    id: "aaaaaaaaaaaaaaaaaaaaaa02", brand: "uniworld", displayName: null,
+    ship: "S.S. Beatrice", tour: "Enchanting Danube (8 Days)", region: "Central Europe",
+    serviceRating: 4, productRating: 4,
+    serviceText: null, productText: "Lovely ship, food could improve.",
+    positive: ["Ship"], negative: ["Food Quality"],
+    daysAgo: 5, sku: "UW-DAN-8", parentSku: "UW-DAN",
+  }),
+  review({
+    id: "aaaaaaaaaaaaaaaaaaaaaa03", brand: "uniworld", displayName: "Robert K.",
+    ship: "S.S. Maria Theresa", tour: "Castles along the Rhine", region: "Western Europe",
+    serviceRating: 3, productRating: null,
+    serviceText: "Itinerary changed twice before sailing.", productText: null,
+    positive: [], negative: ["Itinerary Changes"],
+    daysAgo: 40, sku: "UW-RHI-10",
+  }),
+  review({
+    id: "bbbbbbbbbbbbbbbbbbbbbb01", brand: "luxury-gold", displayName: "Amelia P.",
+    ship: null, tour: "Majestic Switzerland", region: "Alps",
+    serviceRating: 5, productRating: 5,
+    serviceText: "White-glove from start to finish.", productText: "Hotels were superb.",
+    positive: ["Service", "Accommodation"], negative: [],
+    media: [{ type: "PHOTO", url: "https://example.com/p2.jpg" }],
+    daysAgo: 3, sku: "LG-SWI-9",
+  }),
+  review({
+    id: "bbbbbbbbbbbbbbbbbbbbbb02", brand: "luxury-gold", displayName: null,
+    ship: null, tour: "Majestic Switzerland", region: "Alps",
+    serviceRating: 2, productRating: 2,
+    serviceText: null, productText: "Not worth the price.",
+    positive: [], negative: ["Value"],
+    daysAgo: 10, sku: "LG-SWI-9",
+  }),
+];
+
+function summary({ brand, scope, scopeValue, reviews }) {
+  const ratings = reviews.map((r) => r.ratings.product).filter((r) => typeof r === "number");
+  const dist = { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 };
+  for (const r of ratings) dist[Math.round(r)] += 1;
+  const positive = {};
+  const negative = {};
+  for (const r of reviews) {
+    for (const t of r.themes.positive) positive[t] = (positive[t] || 0) + 1;
+    for (const t of r.themes.negative) negative[t] = (negative[t] || 0) + 1;
+  }
+  const top = (counts) =>
+    Object.entries(counts).map(([theme, count]) => ({ theme, count })).sort((a, b) => b.count - a.count).slice(0, 10);
+  return {
+    id: scopeValue ? `${brand}_${scope}_${scopeValue.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")}` : brand,
+    brand,
+    scope,
+    scopeValue: scopeValue ?? null,
+    totalReviews: reviews.length,
+    reviewsWithComments: reviews.filter((r) => r.hasComment).length,
+    avgRating: ratings.length ? Math.round((ratings.reduce((a, b) => a + b, 0) / ratings.length) * 100) / 100 : 0,
+    starDistribution: { 1: dist[1], 2: dist[2], 3: dist[3], 4: dist[4], 5: dist[5] },
+    topPositiveThemes: top(positive),
+    topNegativeThemes: top(negative),
+    ships: [...new Set(reviews.map((r) => r.tags.ship).filter(Boolean))],
+    itineraries: [...new Set(reviews.map((r) => r.tags.tour).filter(Boolean))],
+    childItineraries: [],
+    lastUpdated: new Date().toISOString(),
+  };
+}
+
+async function main() {
+  for (const r of REVIEWS) {
+    await db.collection("reviews").doc(r.id).set(r);
+  }
+
+  const uniworld = REVIEWS.filter((r) => r.brand === "uniworld");
+  const luxuryGold = REVIEWS.filter((r) => r.brand === "luxury-gold");
+  const summaries = [
+    summary({ brand: "uniworld", scope: "fleet", scopeValue: null, reviews: uniworld }),
+    summary({ brand: "luxury-gold", scope: "fleet", scopeValue: null, reviews: luxuryGold }),
+    summary({ brand: "uniworld", scope: "ship", scopeValue: "S.S. Beatrice", reviews: uniworld.filter((r) => r.tags.ship === "S.S. Beatrice") }),
+  ];
+  for (const s of summaries) {
+    await db.collection("summaries").doc(s.id).set(s);
+  }
+
+  await db.collection("itinerary_mappings").doc("uniworld_enchanting-danube-8-days").set({
+    rawName: "Enchanting Danube (8 Days)",
+    autoParentName: "Enchanting Danube",
+    manualParentName: null,
+    effectiveParentName: "Enchanting Danube",
+    brand: "uniworld",
+    reviewCount: 2,
+    lastUpdated: new Date().toISOString(),
+  });
+
+  const verifier = createHmac("sha256", PEPPER).update(CLIENT_SECRET).digest("hex");
+  await db.collection("api_clients").doc(CLIENT_ID).set({
+    clientId: CLIENT_ID,
+    secretVerifier: verifier,
+    label: "Local emulator test client",
+    merchants: ["*"],
+    scopes: ["reviews:read", "summary:read", "meta:read"],
+    status: "active",
+    tokenVersion: 1,
+    createdBy: "seed-script",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    lastUsedAt: null,
+  });
+  // A second client scoped to luxury-gold only, for scope-enforcement checks.
+  await db.collection("api_clients").doc("uw_live_lgonly00001").set({
+    clientId: "uw_live_lgonly00001",
+    secretVerifier: createHmac("sha256", PEPPER).update("lg-only-secret").digest("hex"),
+    label: "LG-scoped test client",
+    merchants: ["luxury-gold"],
+    scopes: ["reviews:read", "summary:read", "meta:read"],
+    status: "active",
+    tokenVersion: 1,
+    createdBy: "seed-script",
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    lastUsedAt: null,
+  });
+
+  console.log(`Seeded ${REVIEWS.length} reviews, ${summaries.length} summaries, 1 mapping, 2 api_clients.`);
+  console.log(`client_id:     ${CLIENT_ID}`);
+  console.log(`client_secret: ${CLIENT_SECRET}`);
+  console.log(`lg-only client: uw_live_lgonly00001 / lg-only-secret`);
+}
+
+main().then(
+  () => process.exit(0),
+  (err) => {
+    console.error(err);
+    process.exit(1);
+  }
+);

--- a/scripts/smoke-api.sh
+++ b/scripts/smoke-api.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Smoke-test the public reviews API against the local Firebase emulators.
+# Prereqs: emulators running (functions + firestore), scripts/seed-emulator.js applied.
+# Usage: bash scripts/smoke-api.sh
+set -u
+
+BASE="${BASE:-http://127.0.0.1:5001/feefo-reviews/us-central1/reviewsApi}"
+NODE="${NODE:-node}"
+PASS=0
+FAIL=0
+
+check() { # check <name> <expected> <actual>
+  if [ "$2" = "$3" ]; then
+    PASS=$((PASS+1)); echo "PASS  $1"
+  else
+    FAIL=$((FAIL+1)); echo "FAIL  $1  (expected: $2, got: $3)"
+  fi
+}
+
+json() { # json <file> <node-expression over `b`>
+  "$NODE" -e "const b=JSON.parse(require('fs').readFileSync('$1','utf8'));console.log($2)" 2>/dev/null || echo "PARSE_ERROR"
+}
+
+# Repo-relative scratch dir: git-bash's /tmp is invisible to Windows node.exe.
+T=".tools/smoke"
+rm -rf "$T" && mkdir -p "$T"
+
+# ── Token endpoint ──────────────────────────────────────────────────────────
+code=$(curl -s -o "$T/r" -w "%{http_code}" -X POST "$BASE/v1/oauth/token" -H "Content-Type: application/json" \
+  -d '{"client_id":"uw_live_local0test01","client_secret":"local-test-secret-not-for-production-1234","grant_type":"password"}')
+check "token: wrong grant_type -> 400" "400:unsupported_grant_type" "$code:$(json "$T/r" 'b.error.code')"
+
+code=$(curl -s -o "$T/r" -w "%{http_code}" -X POST "$BASE/v1/oauth/token" -H "Content-Type: application/json" \
+  -d '{"client_id":"uw_live_local0test01","client_secret":"WRONG","grant_type":"client_credentials"}')
+check "token: bad secret -> 401 invalid_client" "401:invalid_client" "$code:$(json "$T/r" 'b.error.code')"
+
+code=$(curl -s -o "$T/tok" -w "%{http_code}" -X POST "$BASE/v1/oauth/token" -H "Content-Type: application/json" \
+  -d '{"client_id":"uw_live_local0test01","client_secret":"local-test-secret-not-for-production-1234","grant_type":"client_credentials"}')
+check "token: valid -> 200 Bearer 3600" "200:Bearer:3600" "$code:$(json "$T/tok" 'b.token_type')":"$(json "$T/tok" 'b.expires_in')"
+TOKEN=$(json "$T/tok" 'b.access_token')
+
+code=$(curl -s -o "$T/r" -w "%{http_code}" "$BASE/v1/oauth/token")
+check "token: GET -> 405" "405" "$code"
+
+# ── Auth required ───────────────────────────────────────────────────────────
+code=$(curl -s -o "$T/r" -w "%{http_code}" "$BASE/v1/reviews/all")
+check "reviews/all: no token -> 401" "401" "$code"
+
+code=$(curl -s -o "$T/r" -w "%{http_code}" -H "Authorization: Bearer uwt_bogus" "$BASE/v1/reviews/all")
+check "reviews/all: bogus token -> 401 invalid_token" "401:invalid_token" "$code:$(json "$T/r" 'b.error.code')"
+
+AUTH=(-H "Authorization: Bearer $TOKEN")
+
+# ── List reviews ────────────────────────────────────────────────────────────
+code=$(curl -s -o "$T/all" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/all")
+check "reviews/all: 200, count=5 across merchants" "200:5:5" "$code:$(json "$T/all" 'b.summary.meta.count')":"$(json "$T/all" 'b.reviews.length')"
+check "reviews/all: newest-first order" "true" "$(json "$T/all" 'String(b.reviews[0].last_updated_date >= b.reviews[4].last_updated_date)')"
+check "reviews/all: no PII in payload" "0" "$(grep -c -E 'SEED_PII|seed-pii@' "$T/all")"
+check "reviews/all: enrichment block present" "Staff" "$(json "$T/all" 'b.reviews.map(r=>r.enrichment.themes.positive).flat().includes("Staff")?"Staff":"missing"')"
+check "reviews/all: display-name rule (fallback present)" "true" "$(json "$T/all" 'String(b.reviews.some(r=>r.customer.display_name==="Trusted Customer"))')"
+check "reviews/all: itinerary group resolved" "Enchanting Danube" "$(json "$T/all" 'b.reviews.find(r=>r.enrichment.itinerary.raw==="Enchanting Danube (8 Days)").enrichment.itinerary.group')"
+
+code=$(curl -s -o "$T/uw" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/all?merchant_identifier=uniworld")
+check "reviews/all: uniworld only -> 3" "200:3" "$code:$(json "$T/uw" 'b.summary.meta.count')"
+check "reviews/all: uniworld merchant field" "uniworld" "$(json "$T/uw" '[...new Set(b.reviews.map(r=>r.merchant.identifier))].join()')"
+
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/all?has_media=true")
+check "reviews/all: has_media=true -> 2" "200:2" "$code:$(json "$T/r" 'b.summary.meta.count')"
+
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/all?positive_theme=Staff")
+check "reviews/all: positive_theme=Staff -> 1" "200:1" "$code:$(json "$T/r" 'b.summary.meta.count')"
+
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/all?rating=5")
+check "reviews/all: rating=5 post-filter, count null, 2 results" "200:null:2" "$code:$(json "$T/r" 'String(b.summary.meta.count)')":"$(json "$T/r" 'b.reviews.length')"
+
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/all?ship=S.S.%20Beatrice&region=Alps")
+check "reviews/all: two attribute filters -> 400" "400:filters_not_combinable" "$code:$(json "$T/r" 'b.error.code')"
+
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/all?search=danube")
+check "reviews/all: search -> 400 search_not_supported" "400:search_not_supported" "$code:$(json "$T/r" 'b.error.code')"
+
+# ── Cursor pagination ───────────────────────────────────────────────────────
+curl -s -o "$T/p1" "${AUTH[@]}" "$BASE/v1/reviews/all?page_size=2" >/dev/null
+CUR=$(json "$T/p1" 'b.summary.next_cursor')
+check "pagination: page 1 of 2 has next_cursor" "true" "$(json "$T/p1" 'String(typeof b.summary.next_cursor==="string" && b.reviews.length===2)')"
+curl -s -o "$T/p2" "${AUTH[@]}" "$BASE/v1/reviews/all?page_size=2&cursor=$CUR" >/dev/null
+check "pagination: page 2 returns 2 more, no overlap" "2:0" "$(json "$T/p2" 'b.reviews.length')":"$("$NODE" -e "
+const a=JSON.parse(require('fs').readFileSync('$T/p1','utf8')).reviews.map(r=>r.id);
+const b=JSON.parse(require('fs').readFileSync('$T/p2','utf8')).reviews.map(r=>r.id);
+console.log(b.filter(id=>a.includes(id)).length)")"
+CUR2=$(json "$T/p2" 'b.summary.next_cursor')
+curl -s -o "$T/p3" "${AUTH[@]}" "$BASE/v1/reviews/all?page_size=2&cursor=$CUR2" >/dev/null
+check "pagination: final page has 1, no next_cursor" "1:null" "$(json "$T/p3" 'b.reviews.length')":"$(json "$T/p3" 'String(b.summary.next_cursor)')"
+
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/all?cursor=garbage")
+check "pagination: garbage cursor -> 400 invalid_cursor" "400:invalid_cursor" "$code:$(json "$T/r" 'b.error.code')"
+
+# page mode
+curl -s -o "$T/pg2" "${AUTH[@]}" "$BASE/v1/reviews/all?page=2&page_size=2" >/dev/null
+check "pagination: page=2 window matches cursor page 2" "true" "$("$NODE" -e "
+const a=JSON.parse(require('fs').readFileSync('$T/p2','utf8')).reviews.map(r=>r.id);
+const b=JSON.parse(require('fs').readFileSync('$T/pg2','utf8')).reviews.map(r=>r.id);
+console.log(String(JSON.stringify(a)===JSON.stringify(b)))")"
+
+# ── Single review ───────────────────────────────────────────────────────────
+RID=$(json "$T/uw" 'b.reviews[0].id')
+code=$(curl -s -o "$T/one" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/$RID")
+check "reviews/{id}: 200 + same id" "200:$RID" "$code:$(json "$T/one" 'b.id')"
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/ffffffffffffffffffffffff")
+check "reviews/{id}: unknown -> 404" "404:review_not_found" "$code:$(json "$T/r" 'b.error.code')"
+
+# ── Merchant scope enforcement (luxury-gold-only client) ────────────────────
+curl -s -o "$T/lgtok" -X POST "$BASE/v1/oauth/token" -H "Content-Type: application/json" \
+  -d '{"client_id":"uw_live_lgonly00001","client_secret":"lg-only-secret","grant_type":"client_credentials"}' >/dev/null
+LGTOKEN=$(json "$T/lgtok" 'b.access_token')
+LGAUTH=(-H "Authorization: Bearer $LGTOKEN")
+
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${LGAUTH[@]}" "$BASE/v1/reviews/all?merchant_identifier=uniworld")
+check "scope: LG client requesting uniworld -> 403" "403:merchant_not_allowed" "$code:$(json "$T/r" 'b.error.code')"
+
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${LGAUTH[@]}" "$BASE/v1/reviews/all")
+check "scope: LG client default 'all' -> only LG (2)" "200:2:luxury-gold" "$code:$(json "$T/r" 'b.summary.meta.count')":"$(json "$T/r" '[...new Set(b.reviews.map(r=>r.merchant.identifier))].join()')"
+
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${LGAUTH[@]}" "$BASE/v1/reviews/$RID")
+check "scope: LG client fetching uniworld review id -> uniform 404" "404:review_not_found" "$code:$(json "$T/r" 'b.error.code')"
+
+# ── Summary ────────────────────────────────────────────────────────────────
+code=$(curl -s -o "$T/sum" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/summary/all?merchant_identifier=uniworld")
+check "summary: uniworld fleet 200" "200:uniworld:3" "$code:$(json "$T/sum" 'b.merchant.identifier')":"$(json "$T/sum" 'b.meta.count')"
+check "summary: service distribution is null (product-only caveat)" "null" "$(json "$T/sum" 'String(b.rating.service)')"
+code=$(curl -s -o "$T/suma" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/summary/all")
+check "summary: all -> merged across merchants" "200:all:5" "$code:$(json "$T/suma" 'b.merchant.identifier')":"$(json "$T/suma" 'b.meta.count')"
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/summary/all?merchant_identifier=uniworld&scope=ship&scope_value=S.S.%20Beatrice")
+check "summary: ship scope 200" "200:ship" "$code:$(json "$T/r" 'b.enrichment.scope')"
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/summary/all?merchant_identifier=uniworld&scope=ship")
+check "summary: ship scope without scope_value -> 400" "400" "$code"
+
+# ── Meta ────────────────────────────────────────────────────────────────────
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/meta/themes")
+check "meta/themes: 200 with 10+10" "200:10:10" "$code:$(json "$T/r" 'b.themes.positive.length')":"$(json "$T/r" 'b.themes.negative.length')"
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${LGAUTH[@]}" "$BASE/v1/meta/merchants")
+check "meta/merchants: scoped to credential" "200:luxury-gold" "$code:$(json "$T/r" 'b.merchants.map(m=>m.merchant_identifier).join()')"
+
+# ── Misc behaviour ─────────────────────────────────────────────────────────
+code=$(curl -s -o "$T/r" -w "%{http_code}" -X POST "${AUTH[@]}" "$BASE/v1/reviews/all")
+check "method: POST reviews/all -> 405" "405" "$code"
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/nope")
+check "router: unknown path -> 404" "404:not_found" "$code:$(json "$T/r" 'b.error.code')"
+
+ETAG=$(curl -s -D - -o /dev/null "${AUTH[@]}" "$BASE/v1/meta/themes" | grep -i "^etag:" | tr -d '\r' | cut -d' ' -f2)
+code=$(curl -s -o /dev/null -w "%{http_code}" "${AUTH[@]}" -H "If-None-Match: $ETAG" "$BASE/v1/meta/themes")
+check "caching: If-None-Match -> 304" "304" "$code"
+
+echo
+echo "RESULT: $PASS passed, $FAIL failed"
+exit $FAIL

--- a/scripts/smoke-api.sh
+++ b/scripts/smoke-api.sh
@@ -141,6 +141,87 @@ check "meta/themes: 200 with 10+10" "200:10:10" "$code:$(json "$T/r" 'b.themes.p
 code=$(curl -s -o "$T/r" -w "%{http_code}" "${LGAUTH[@]}" "$BASE/v1/meta/merchants")
 check "meta/merchants: scoped to credential" "200:luxury-gold" "$code:$(json "$T/r" 'b.merchants.map(m=>m.merchant_identifier).join()')"
 
+# ── Input hardening (untrusted values must never reach Firestore paths) ────
+code=$(curl -s -o "$T/r" -w "%{http_code}" -X POST "$BASE/v1/oauth/token" -H "Content-Type: application/json" \
+  -d '{"client_id":"evil/../../path","client_secret":"x","grant_type":"client_credentials"}')
+check "hardening: client_id with slash -> 400 (not 500)" "400:invalid_request" "$code:$(json "$T/r" 'b.error.code')"
+
+# Tamper a REAL cursor (valid query hash) so validation must fail on the
+# position value itself, not just the hash binding.
+TAMPERED=$("$NODE" -e "
+const c=JSON.parse(require('fs').readFileSync('$T/p1','utf8')).summary.next_cursor;
+const p=JSON.parse(Buffer.from(c,'base64url').toString('utf8'));
+for (const k of Object.keys(p.m)) p.m[k]='a/b/../c';
+console.log(Buffer.from(JSON.stringify(p)).toString('base64url'))")
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/all?page_size=2&cursor=$TAMPERED")
+check "hardening: tampered cursor position -> 400 invalid_cursor" "400:invalid_cursor" "$code:$(json "$T/r" 'b.error.code')"
+
+ARRCUR=$("$NODE" -e "
+const c=JSON.parse(require('fs').readFileSync('$T/p1','utf8')).summary.next_cursor;
+const p=JSON.parse(Buffer.from(c,'base64url').toString('utf8'));
+p.m=[];
+console.log(Buffer.from(JSON.stringify(p)).toString('base64url'))")
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/all?page_size=2&cursor=$ARRCUR")
+check "hardening: array cursor map -> 400 invalid_cursor" "400:invalid_cursor" "$code:$(json "$T/r" 'b.error.code')"
+
+LONGCUR=$("$NODE" -e "console.log('A'.repeat(3000))")
+code=$(curl -s -o "$T/r" -w "%{http_code}" "${AUTH[@]}" "$BASE/v1/reviews/all?cursor=$LONGCUR")
+check "hardening: oversized cursor -> 400 invalid_cursor" "400:invalid_cursor" "$code:$(json "$T/r" 'b.error.code')"
+
+# ── sort=oldest ─────────────────────────────────────────────────────────────
+curl -s -o "$T/old" "${AUTH[@]}" "$BASE/v1/reviews/all?sort=oldest" >/dev/null
+check "sort=oldest: ascending order, exact reverse of newest" "true" "$("$NODE" -e "
+const n=JSON.parse(require('fs').readFileSync('$T/all','utf8')).reviews.map(r=>r.id);
+const o=JSON.parse(require('fs').readFileSync('$T/old','utf8')).reviews.map(r=>r.id);
+console.log(String(JSON.stringify(o)===JSON.stringify([...n].reverse())))")"
+
+# ── Multi-page post-filter cursor walk ──────────────────────────────────────
+curl -s -o "$T/r1" "${AUTH[@]}" "$BASE/v1/reviews/all?rating=5&page_size=1" >/dev/null
+RC1=$(json "$T/r1" 'b.summary.next_cursor')
+curl -s -o "$T/r2" "${AUTH[@]}" "$BASE/v1/reviews/all?rating=5&page_size=1&cursor=$RC1" >/dev/null
+check "post-filter walk: 2 pages, distinct ids, both rating 5" "1:1:true:true" \
+  "$(json "$T/r1" 'b.reviews.length')":"$(json "$T/r2" 'b.reviews.length')":"$("$NODE" -e "
+const a=JSON.parse(require('fs').readFileSync('$T/r1','utf8')).reviews[0];
+const b=JSON.parse(require('fs').readFileSync('$T/r2','utf8')).reviews[0];
+console.log(String(a.id!==b.id))")":"$("$NODE" -e "
+const head=r=>r.products[0].rating.rating ?? (r.service&&r.service.rating.rating);
+const a=JSON.parse(require('fs').readFileSync('$T/r1','utf8')).reviews[0];
+const b=JSON.parse(require('fs').readFileSync('$T/r2','utf8')).reviews[0];
+console.log(String(Math.round(head(a))===5&&Math.round(head(b))===5))")"
+
+# ── Credential lifecycle (requires apiClients mgmt endpoint + sync token) ───
+MGMT="${MGMT:-${BASE%/*}/apiClients}"
+SYNC_TOKEN="${SYNC_TOKEN:-local-test-sync-token}"
+code=$(curl -s -o "$T/lc" -w "%{http_code}" -X POST "$MGMT" -H "Content-Type: application/json" \
+  -H "x-sync-token: $SYNC_TOKEN" -d '{"action":"create","label":"Smoke lifecycle","merchants":["uniworld"]}')
+if [ "$code" = "200" ]; then
+  LCID=$(json "$T/lc" 'b.client.clientId'); LCSEC=$(json "$T/lc" 'b.clientSecret')
+  curl -s -o "$T/lct" -X POST "$BASE/v1/oauth/token" -H "Content-Type: application/json" \
+    -d "{\"client_id\":\"$LCID\",\"client_secret\":\"$LCSEC\",\"grant_type\":\"client_credentials\"}" >/dev/null
+  LCTOK=$(json "$T/lct" 'b.access_token')
+  code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $LCTOK" "$BASE/v1/reviews/all?merchant_identifier=uniworld")
+  check "lifecycle: fresh client token reads its merchant" "200" "$code"
+  curl -s -o "$T/lcr" -X POST "$MGMT" -H "Content-Type: application/json" -H "x-sync-token: $SYNC_TOKEN" \
+    -d "{\"action\":\"rotate\",\"clientId\":\"$LCID\"}" >/dev/null
+  code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $LCTOK" "$BASE/v1/reviews/all")
+  check "lifecycle: old token 401s IMMEDIATELY after rotate" "401" "$code"
+  NEWSEC=$(json "$T/lcr" 'b.clientSecret')
+  curl -s -o "$T/lct2" -X POST "$BASE/v1/oauth/token" -H "Content-Type: application/json" \
+    -d "{\"client_id\":\"$LCID\",\"client_secret\":\"$NEWSEC\",\"grant_type\":\"client_credentials\"}" >/dev/null
+  LCTOK2=$(json "$T/lct2" 'b.access_token')
+  code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $LCTOK2" "$BASE/v1/reviews/all")
+  check "lifecycle: rotated secret's token works" "200" "$code"
+  curl -s -o /dev/null -X POST "$MGMT" -H "Content-Type: application/json" -H "x-sync-token: $SYNC_TOKEN" \
+    -d "{\"action\":\"revoke\",\"clientId\":\"$LCID\"}"
+  code=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $LCTOK2" "$BASE/v1/reviews/all")
+  check "lifecycle: token 401s IMMEDIATELY after revoke" "401" "$code"
+  code=$(curl -s -o "$T/r" -w "%{http_code}" -X POST "$BASE/v1/oauth/token" -H "Content-Type: application/json" \
+    -d "{\"client_id\":\"$LCID\",\"client_secret\":\"$NEWSEC\",\"grant_type\":\"client_credentials\"}")
+  check "lifecycle: exchange after revoke -> 401 invalid_client" "401:invalid_client" "$code:$(json "$T/r" 'b.error.code')"
+else
+  echo "SKIP  lifecycle checks (apiClients mgmt endpoint unavailable: $code — set SYNC_TOKEN/MGMT)"
+fi
+
 # ── Misc behaviour ─────────────────────────────────────────────────────────
 code=$(curl -s -o "$T/r" -w "%{http_code}" -X POST "${AUTH[@]}" "$BASE/v1/reviews/all")
 check "method: POST reviews/all -> 405" "405" "$code"

--- a/shared/src/feefo/brands.ts
+++ b/shared/src/feefo/brands.ts
@@ -1,0 +1,21 @@
+import { Brand } from "./types";
+
+/**
+ * Single source of truth for valid Feefo merchant identifiers.
+ *
+ * `ReviewDocument.brand` stores exactly these values and the public reviews
+ * API's `merchant_identifier` parameter accepts exactly these values, so the
+ * three layers (Feefo API, Firestore, public API) need no translation.
+ *
+ * Previously both functions/src/index.ts and feefo/transform.ts kept their
+ * own private VALID_BRANDS sets; this constant replaces them so a new
+ * merchant is added in one place.
+ */
+export const MERCHANT_IDENTIFIERS = ["uniworld", "luxury-gold"] as const satisfies readonly Brand[];
+
+export function isMerchantIdentifier(value: unknown): value is Brand {
+  return (
+    typeof value === "string" &&
+    (MERCHANT_IDENTIFIERS as readonly string[]).includes(value)
+  );
+}

--- a/shared/src/feefo/transform.ts
+++ b/shared/src/feefo/transform.ts
@@ -1,8 +1,7 @@
-import { FeefoReview, Brand, FeefoMedia } from "./types";
+import { FeefoReview, FeefoMedia } from "./types";
 import { ReviewDocument } from "../types/review";
 import { parseTags } from "./parse-tags";
-
-const VALID_BRANDS: Set<string> = new Set(["uniworld", "luxury-gold"]);
+import { isMerchantIdentifier } from "./brands";
 
 /** What `transformReview` actually consumes from each media item. The full
  * `FeefoMedia` type also has an `id` (which we drop on the way to Firestore),
@@ -35,10 +34,10 @@ export function transformReview(
     `url-${Date.now()}`;
 
   const merchantId = raw.merchant.identifier;
-  if (!VALID_BRANDS.has(merchantId)) {
+  if (!isMerchantIdentifier(merchantId)) {
     throw new Error(`Unknown merchant identifier: ${merchantId}`);
   }
-  const brand = merchantId as Brand;
+  const brand = merchantId;
 
   const serviceText = raw.service?.review ?? null;
   const productText = product?.review ?? null;

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -1,9 +1,12 @@
 export * from "./feefo/types";
+export * from "./feefo/brands";
 export * from "./feefo/client";
 export * from "./feefo/parse-tags";
 export * from "./feefo/normalize-itinerary";
 export * from "./types/review";
 export * from "./feefo/transform";
 export * from "./themes/definitions";
+export * from "./reviews/display-name";
+export * from "./reviews/public";
 // classifier is NOT re-exported here to avoid eagerly loading @anthropic-ai/sdk
 // Import directly from "@feefo/shared/dist/themes/classifier" when needed

--- a/shared/src/reviews/__tests__/public.test.ts
+++ b/shared/src/reviews/__tests__/public.test.ts
@@ -1,0 +1,252 @@
+import { ReviewDocument } from "../../types/review";
+import { toPublicReview, toPublicSummary, SummaryDocLike } from "../public";
+import { resolveDisplayName } from "../display-name";
+
+/** Fixture with sentinel PII values — the tests assert none of these strings
+ * ever appear anywhere in serialized public output. */
+const PII = {
+  name: "PII_FULL_NAME_Jane_Doe",
+  email: "PII_EMAIL_jane.doe@example.com",
+  orderRef: "PII_ORDER_REF_12345",
+  customerRef: "PII_CUSTOMER_REF_67890",
+  location: "PII_LOCATION_London_UK",
+  tourDirector: "PII_STAFF_NAME_Markus_W",
+};
+
+function fixture(overrides: Partial<ReviewDocument> = {}): ReviewDocument {
+  return {
+    id: "60a3f2c1e4b0a1b2c3d4e5f6",
+    feedbackUrl: "https://www.feefo.com/en-US/reviews/uniworld/abc",
+    brand: "uniworld",
+    customer: {
+      name: PII.name,
+      displayName: "Jane D.",
+      location: PII.location,
+      email: PII.email,
+      orderRef: PII.orderRef,
+      customerRef: PII.customerRef,
+    },
+    product: {
+      title: "Enchanting Danube",
+      sku: "UW-DAN-8",
+      parentSku: "UW-DAN",
+      url: "https://www.uniworld.com/danube",
+      imageUrl: "https://www.uniworld.com/danube.jpg",
+    },
+    ratings: { service: 5, product: 4 },
+    reviews: {
+      serviceTitle: "A wonderful trip",
+      serviceText: "The booking team were responsive.",
+      productText: "The Danube itinerary was breathtaking.",
+    },
+    tags: {
+      ship: "S.S. Beatrice",
+      tour: "Enchanting Danube (8 Days)",
+      tourDirector: PII.tourDirector,
+      bookingType: "Direct",
+      region: "Central Europe",
+      loyalty: "Returning Guest",
+      clientType: "Couple",
+      package: "All-Inclusive",
+    },
+    themes: {
+      positive: ["Staff", "Excursions"],
+      negative: ["Value"],
+      classifiedAt: "2026-05-21T03:00:00Z",
+    },
+    media: [{ type: "PHOTO", url: "https://media.feefo.com/photo.jpg" }],
+    dates: {
+      created: "2026-05-20T09:15:00Z",
+      lastUpdated: "2026-05-21T11:02:00Z",
+      synced: "2026-05-21T12:00:00Z",
+    },
+    hasComment: true,
+    hasMedia: true,
+    moderationStatus: "published",
+    verified: true,
+    ...overrides,
+  };
+}
+
+describe("resolveDisplayName", () => {
+  it("returns the trimmed consented display name", () => {
+    expect(resolveDisplayName({ displayName: "  Jane D.  " })).toBe("Jane D.");
+  });
+
+  it("falls back when the display name is missing or blank", () => {
+    expect(resolveDisplayName({ displayName: null })).toBe("Trusted Customer");
+    expect(resolveDisplayName({ displayName: "   " })).toBe("Trusted Customer");
+    expect(resolveDisplayName(undefined)).toBe("Trusted Customer");
+  });
+
+  it("never reads any property other than displayName", () => {
+    // A customer object with ONLY PII set must still produce the fallback.
+    expect(
+      resolveDisplayName({ name: PII.name, email: PII.email } as never)
+    ).toBe("Trusted Customer");
+  });
+});
+
+describe("toPublicReview — PII firewall", () => {
+  it("never serializes any PII sentinel value", () => {
+    const serialized = JSON.stringify(toPublicReview(fixture()));
+    for (const value of Object.values(PII)) {
+      expect(serialized).not.toContain(value);
+    }
+  });
+
+  it("emits exactly the allowlisted top-level keys", () => {
+    const pub = toPublicReview(fixture());
+    expect(Object.keys(pub).sort()).toEqual(
+      [
+        "customer",
+        "enrichment",
+        "id",
+        "last_updated_date",
+        "merchant",
+        "products",
+        "service",
+        "url",
+        "verified",
+      ].sort()
+    );
+  });
+
+  it("customer contains ONLY display_name (no location, no name)", () => {
+    const pub = toPublicReview(fixture());
+    expect(Object.keys(pub.customer)).toEqual(["display_name"]);
+    expect(pub.customer.display_name).toBe("Jane D.");
+  });
+
+  it("attributes exclude tour_director", () => {
+    const pub = toPublicReview(fixture());
+    expect(Object.keys(pub.enrichment.attributes).sort()).toEqual(
+      [
+        "booking_type",
+        "client_type",
+        "loyalty",
+        "package",
+        "region",
+        "ship",
+        "tour",
+      ].sort()
+    );
+  });
+
+  it("uses the site name rule (Trusted Customer fallback)", () => {
+    const pub = toPublicReview(
+      fixture({
+        customer: {
+          name: PII.name,
+          displayName: null,
+          location: null,
+          email: PII.email,
+          orderRef: null,
+          customerRef: null,
+        },
+      })
+    );
+    expect(pub.customer.display_name).toBe("Trusted Customer");
+  });
+});
+
+describe("toPublicReview — shape mapping", () => {
+  it("wraps ratings in Feefo's {min,max,rating} envelope", () => {
+    const pub = toPublicReview(fixture());
+    expect(pub.service?.rating).toEqual({ min: 1, max: 5, rating: 5 });
+    expect(pub.products[0].rating).toEqual({ min: 1, max: 5, rating: 4 });
+  });
+
+  it("emits service: null when there is no service rating, title, or text", () => {
+    const pub = toPublicReview(
+      fixture({
+        ratings: { service: null, product: 4 },
+        reviews: { serviceTitle: null, serviceText: null, productText: "Great." },
+      })
+    );
+    expect(pub.service).toBeNull();
+  });
+
+  it("always emits exactly one products[] element with snake_case product fields", () => {
+    const pub = toPublicReview(fixture());
+    expect(pub.products).toHaveLength(1);
+    expect(pub.products[0].product).toEqual({
+      title: "Enchanting Danube",
+      sku: "UW-DAN-8",
+      parent_sku: "UW-DAN",
+      url: "https://www.uniworld.com/danube",
+      image_url: "https://www.uniworld.com/danube.jpg",
+    });
+  });
+
+  it("resolves the itinerary group through the mapping lookup", () => {
+    const lookup = new Map([["Enchanting Danube (8 Days)", "Enchanting Danube"]]);
+    const pub = toPublicReview(fixture(), { itineraryGroupLookup: lookup });
+    expect(pub.enrichment.itinerary).toEqual({
+      raw: "Enchanting Danube (8 Days)",
+      group: "Enchanting Danube",
+    });
+  });
+
+  it("falls back to the raw name when no mapping exists", () => {
+    const pub = toPublicReview(fixture());
+    expect(pub.enrichment.itinerary.group).toBe("Enchanting Danube (8 Days)");
+  });
+
+  it("maps themes and flags", () => {
+    const pub = toPublicReview(fixture());
+    expect(pub.enrichment.themes).toEqual({
+      positive: ["Staff", "Excursions"],
+      negative: ["Value"],
+      classified_at: "2026-05-21T03:00:00Z",
+    });
+    expect(pub.enrichment.flags).toEqual({ has_media: true, has_comment: true });
+  });
+});
+
+describe("toPublicSummary", () => {
+  const summaryDoc: SummaryDocLike = {
+    scope: "fleet",
+    scopeValue: null,
+    totalReviews: 1842,
+    reviewsWithComments: 1203,
+    avgRating: 4.81,
+    starDistribution: { "1": 10, "2": 20, "3": 50, "4": 210, "5": 1500 },
+    topPositiveThemes: [{ theme: "Staff", count: 980 }],
+    topNegativeThemes: [{ theme: "Value", count: 88 }],
+    ships: ["S.S. Beatrice"],
+    itineraries: ["Enchanting Danube"],
+    lastUpdated: "2026-06-09T00:00:00Z",
+  };
+
+  it("maps the Feefo-shaped envelope with service: null", () => {
+    const pub = toPublicSummary(summaryDoc, {
+      identifier: "uniworld",
+      name: "Uniworld",
+    });
+    expect(pub.merchant).toEqual({ identifier: "uniworld", name: "Uniworld" });
+    expect(pub.meta).toEqual({ count: 1842 });
+    expect(pub.rating.rating).toBe(4.81);
+    expect(pub.rating.product).toEqual({
+      count: 1790,
+      "5_star": 1500,
+      "4_star": 210,
+      "3_star": 50,
+      "2_star": 20,
+      "1_star": 10,
+    });
+    expect(pub.rating.service).toBeNull();
+  });
+
+  it("carries scope and enrichment fields", () => {
+    const pub = toPublicSummary(
+      { ...summaryDoc, scope: "ship", scopeValue: "S.S. Beatrice" },
+      { identifier: "uniworld", name: "Uniworld" }
+    );
+    expect(pub.enrichment.scope).toBe("ship");
+    expect(pub.enrichment.scope_value).toBe("S.S. Beatrice");
+    expect(pub.enrichment.top_positive_themes).toEqual([
+      { theme: "Staff", count: 980 },
+    ]);
+  });
+});

--- a/shared/src/reviews/display-name.ts
+++ b/shared/src/reviews/display-name.ts
@@ -1,0 +1,23 @@
+/**
+ * Resolve the customer name we are allowed to display publicly.
+ *
+ * The ONLY name we ever surface is Feefo's `display_name` — the value the
+ * reviewer consented to show publicly. We deliberately do NOT fall back to
+ * `customer.name` (the unmasked full name), which is PII and must never reach
+ * a rendered surface or the public API.
+ *
+ * This mirrors app/src/lib/format/customer.ts (PR #60) exactly. The two
+ * copies exist because the app does not consume the shared package; the
+ * public API uses this one so the API can never display a name the website
+ * wouldn't.
+ *
+ * @param customer  The review's customer object (loosely typed; may be absent).
+ * @param fallback  Placeholder shown when no consented display name exists.
+ */
+export function resolveDisplayName(
+  customer: { displayName?: string | null } | null | undefined,
+  fallback = "Trusted Customer"
+): string {
+  const name = customer?.displayName;
+  return typeof name === "string" && name.trim() ? name.trim() : fallback;
+}

--- a/shared/src/reviews/public.ts
+++ b/shared/src/reviews/public.ts
@@ -1,0 +1,277 @@
+import { ReviewDocument } from "../types/review";
+import { resolveDisplayName } from "./display-name";
+
+/**
+ * Public projections for the reviews API.
+ *
+ * These mappers are the PII firewall: they are the ONLY code allowed to
+ * construct public API output, and they build it field-by-field (never by
+ * spreading the raw document), so a field added to ReviewDocument later
+ * cannot leak until someone deliberately maps it here.
+ *
+ * Intentionally omitted from the public shape (see the design doc's open
+ * decisions in docs/plans/2026-06-09-public-reviews-api.md):
+ *  - customer.name / email / orderRef / customerRef  (PII, never public)
+ *  - customer.location                               (the dashboard never
+ *    renders customer location, so the API omits it to match the site)
+ *  - tags.tourDirector                               (a staff member's name)
+ *  - moderationStatus                                (internal)
+ */
+
+export interface PublicRating {
+  min: number;
+  max: number;
+  rating: number | null;
+}
+
+export interface PublicReviewService {
+  rating: PublicRating;
+  title: string | null;
+  review: string | null;
+  created_at: string;
+}
+
+export interface PublicReviewProduct {
+  rating: PublicRating;
+  review: string | null;
+  media: { type: string; url: string }[];
+  product: {
+    title: string;
+    sku: string;
+    parent_sku: string | null;
+    url: string | null;
+    image_url: string | null;
+  };
+  created_at: string;
+}
+
+export interface PublicReviewEnrichment {
+  themes: {
+    positive: string[];
+    negative: string[];
+    classified_at: string | null;
+  };
+  attributes: {
+    ship: string | null;
+    tour: string | null;
+    booking_type: string | null;
+    region: string | null;
+    loyalty: string | null;
+    client_type: string | null;
+    package: string | null;
+  };
+  itinerary: {
+    raw: string | null;
+    group: string | null;
+  };
+  flags: {
+    has_media: boolean;
+    has_comment: boolean;
+  };
+}
+
+export interface PublicReview {
+  merchant: { identifier: string };
+  id: string;
+  url: string;
+  customer: { display_name: string };
+  service: PublicReviewService | null;
+  products: PublicReviewProduct[];
+  last_updated_date: string;
+  verified: boolean;
+  enrichment: PublicReviewEnrichment;
+}
+
+export interface ToPublicReviewOptions {
+  /**
+   * rawName → effectiveParentName lookup from the itinerary_mappings
+   * collection. When provided, enrichment.itinerary.group resolves the raw
+   * tour name to its parent group exactly like the dashboard does; when
+   * absent, group falls back to the raw name.
+   */
+  itineraryGroupLookup?: Map<string, string>;
+}
+
+function wrapRating(rating: number | null | undefined): PublicRating {
+  return {
+    min: 1,
+    max: 5,
+    rating: typeof rating === "number" && Number.isFinite(rating) ? rating : null,
+  };
+}
+
+function nonEmpty(value: string | null | undefined): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+export function toPublicReview(
+  d: ReviewDocument,
+  options: ToPublicReviewOptions = {}
+): PublicReview {
+  const serviceRating = d.ratings?.service ?? null;
+  const serviceTitle = nonEmpty(d.reviews?.serviceTitle);
+  const serviceText = nonEmpty(d.reviews?.serviceText);
+  const hasServiceSection =
+    serviceRating !== null || serviceTitle !== null || serviceText !== null;
+
+  const rawItinerary = nonEmpty(d.tags?.tour) ?? nonEmpty(d.product?.title);
+  const group = rawItinerary
+    ? options.itineraryGroupLookup?.get(rawItinerary) ?? rawItinerary
+    : null;
+
+  return {
+    merchant: { identifier: d.brand },
+    id: d.id,
+    url: d.feedbackUrl,
+    customer: {
+      display_name: resolveDisplayName(d.customer),
+    },
+    service: hasServiceSection
+      ? {
+          rating: wrapRating(serviceRating),
+          title: serviceTitle,
+          review: serviceText,
+          created_at: d.dates?.created ?? "",
+        }
+      : null,
+    products: [
+      {
+        rating: wrapRating(d.ratings?.product ?? null),
+        review: nonEmpty(d.reviews?.productText),
+        media: Array.isArray(d.media)
+          ? d.media.map((m) => ({ type: m.type, url: m.url }))
+          : [],
+        product: {
+          title: d.product?.title ?? "Unknown",
+          sku: d.product?.sku ?? "",
+          parent_sku: d.product?.parentSku ?? null,
+          url: d.product?.url ?? null,
+          image_url: d.product?.imageUrl ?? null,
+        },
+        created_at: d.dates?.created ?? "",
+      },
+    ],
+    last_updated_date: d.dates?.lastUpdated ?? "",
+    verified: d.verified === true,
+    enrichment: {
+      themes: {
+        positive: Array.isArray(d.themes?.positive) ? [...d.themes.positive] : [],
+        negative: Array.isArray(d.themes?.negative) ? [...d.themes.negative] : [],
+        classified_at: d.themes?.classifiedAt ?? null,
+      },
+      attributes: {
+        ship: d.tags?.ship ?? null,
+        tour: d.tags?.tour ?? null,
+        booking_type: d.tags?.bookingType ?? null,
+        region: d.tags?.region ?? null,
+        loyalty: d.tags?.loyalty ?? null,
+        client_type: d.tags?.clientType ?? null,
+        package: d.tags?.package ?? null,
+      },
+      itinerary: {
+        raw: rawItinerary,
+        group,
+      },
+      flags: {
+        has_media: d.hasMedia === true,
+        has_comment: d.hasComment === true,
+      },
+    },
+  };
+}
+
+// ── Summary projection ──────────────────────────────────────────────────────
+
+/** The subset of a `summaries` collection document the public mapper reads.
+ * Matches the Summary interface in functions/src/sync/compute-summaries.ts;
+ * also accepts merged synthetic input for merchant_identifier=all. */
+export interface SummaryDocLike {
+  scope: "fleet" | "ship" | "itinerary";
+  scopeValue: string | null;
+  totalReviews: number;
+  reviewsWithComments: number;
+  avgRating: number;
+  starDistribution: Record<string, number>;
+  topPositiveThemes: { theme: string; count: number }[];
+  topNegativeThemes: { theme: string; count: number }[];
+  ships: string[];
+  itineraries: string[];
+  lastUpdated?: string;
+}
+
+export interface PublicStarDistribution {
+  count: number;
+  "5_star": number;
+  "4_star": number;
+  "3_star": number;
+  "2_star": number;
+  "1_star": number;
+}
+
+export interface PublicSummary {
+  merchant: { identifier: string; name: string };
+  meta: { count: number };
+  rating: {
+    min: number;
+    max: number;
+    rating: number;
+    product: PublicStarDistribution;
+    /** Always null until the sync computes a service-rating distribution —
+     * compute-summaries.ts currently builds starDistribution from the
+     * product rating only. Never faked. */
+    service: null;
+  };
+  enrichment: {
+    scope: "fleet" | "ship" | "itinerary";
+    scope_value: string | null;
+    reviews_with_comments: number;
+    top_positive_themes: { theme: string; count: number }[];
+    top_negative_themes: { theme: string; count: number }[];
+    ships: string[];
+    itineraries: string[];
+    last_updated: string | null;
+  };
+}
+
+export function toPublicSummary(
+  doc: SummaryDocLike,
+  merchant: { identifier: string; name: string }
+): PublicSummary {
+  const dist = doc.starDistribution ?? {};
+  const star = (key: string): number =>
+    typeof dist[key] === "number" ? dist[key] : 0;
+  const ratedCount = star("1") + star("2") + star("3") + star("4") + star("5");
+
+  return {
+    merchant: { identifier: merchant.identifier, name: merchant.name },
+    meta: { count: doc.totalReviews ?? 0 },
+    rating: {
+      min: 1,
+      max: 5,
+      rating: doc.avgRating ?? 0,
+      product: {
+        count: ratedCount,
+        "5_star": star("5"),
+        "4_star": star("4"),
+        "3_star": star("3"),
+        "2_star": star("2"),
+        "1_star": star("1"),
+      },
+      service: null,
+    },
+    enrichment: {
+      scope: doc.scope,
+      scope_value: doc.scopeValue ?? null,
+      reviews_with_comments: doc.reviewsWithComments ?? 0,
+      top_positive_themes: Array.isArray(doc.topPositiveThemes)
+        ? doc.topPositiveThemes.map((t) => ({ theme: t.theme, count: t.count }))
+        : [],
+      top_negative_themes: Array.isArray(doc.topNegativeThemes)
+        ? doc.topNegativeThemes.map((t) => ({ theme: t.theme, count: t.count }))
+        : [],
+      ships: Array.isArray(doc.ships) ? [...doc.ships] : [],
+      itineraries: Array.isArray(doc.itineraries) ? [...doc.itineraries] : [],
+      last_updated: doc.lastUpdated ?? null,
+    },
+  };
+}


### PR DESCRIPTION
Implements **Phases 1–3** of the [public reviews API design](docs/plans/2026-06-09-public-reviews-api.md) (merged in #61), building on the name-rule privacy fix (#60). Six commits, one per concern.

## What's in here

**Phase 1 — PII firewall (`shared/`)**
- `toPublicReview()` / `toPublicSummary()` allowlist mappers + `PublicReview`/`PublicSummary` types. Output is built field-by-field (never spread) — `customer.name`/`email`/`orderRef`/`customerRef` cannot serialize; `display_location` and `tour_director` omitted per the v1 conservative defaults.
- `resolveDisplayName()` mirroring the site rule from #60 exactly.
- One exported `MERCHANT_IDENTIFIERS` constant replaces the two private `VALID_BRANDS` sets (transform + functions index).
- Jest: **56/56 passing** (new firewall suite asserts the exact public key set and that PII sentinel values never appear in serialized output).

**Phase 3 — auth & credentials (`functions/src/api/`)**
- `POST /v1/oauth/token` — Feefo-style client-credentials. Server-generated secrets stored only as a peppered HMAC-SHA256 verifier (`REVIEWS_API_SECRET_PEPPER`), constant-time compare. **Opaque** access tokens (sha256 hash = `api_tokens` doc id, 1h TTL, Timestamp field ready for a Firestore TTL policy).
- `apiClients` admin endpoint (create/list/revoke/rotate) gated by a new `manageApiClients` permission; audit-logged via `operation_logs`. The plain secret is returned exactly once.
- **Revocation is immediate**: revoke/rotate delete the client's outstanding token docs (the per-instance client cache is explicitly not the revocation mechanism — see the fix commit, caught by the emulator lifecycle test).
- Per-client fixed-window rate limiting (Firestore transaction, `429` + `Retry-After`), tighter budget on the token endpoint.
- `firestore.rules`: explicit deny-all for `api_clients` / `api_tokens` / `api_rate_limits`.

**Phase 2 — endpoints (`reviewsApi` function)**
- `GET /v1/reviews/all` — Feefo envelope (`summary.meta` + `reviews[]`) with the namespaced `enrichment` block (AI themes, normalized attributes, itinerary grouping via `itinerary_mappings`, media/comment flags). Feefo params (`merchant_identifier`, `page`/`page_size`, `since_period`, `since_updated_period`, `date_time_from/to`, `product_sku`, `parent_product_sku`, `rating`, `sort`) + our extensions (`cursor`, `has_media`, `ship`/`tour`/`region`/`booking_type`/`loyalty`, `positive_theme`/`negative_theme`, `review_type`).
- `merchant_identifier=all` = per-merchant **fan-out** with a k-way date-ordered merge — every query stays on existing brand-scoped composite indexes; cursors encode per-merchant scan positions bound to a query hash.
- `GET /v1/reviews/{id}` — uniform 404 for missing vs out-of-scope (no id probing).
- `GET /v1/reviews/summary/all` — from precomputed `summaries` (fleet/ship/itinerary; merged for `all`); `rating.service: null` per the product-only caveat.
- `GET /v1/meta/themes` / `GET /v1/meta/merchants` (credential-scoped).
- Uniform `{ error: { code, message, request_id } }` envelope, `X-Request-Id`, structured per-request logs, `Cache-Control` + weak ETag with 304.
- Hosting rewrite `/api/** → reviewsApi`; 4 new composite indexes for the SKU filters.

## Verification

- `shared`: tsc clean, jest **56/56**.
- `functions`: tsc clean.
- **Emulator end-to-end** (functions + firestore): seeded 5 reviews across both merchants with PII sentinel values, 3 summaries, mappings, 2 scoped clients → **39/39 smoke checks pass** (`scripts/smoke-api.sh`): token flow, scope enforcement (403 + uniform 404), PII absence in live payloads, filters/post-filters, cursor↔page pagination equivalence (incl. no-overlap and final-page), summary shapes, meta, 405/404, ETag/304.
- **Credential lifecycle verified live**: create → exchange → scoped reads → rotate (old token 401s *immediately*, new secret works) → revoke (token + exchange both die). The initial implementation had rotate leaving old tokens alive up to 60s (cross-instance cache) — caught by this test and fixed in `7cb6415`.

## Postman

The collection in [`docs/api/`](docs/api/README.md) works as-is against the emulator (`baseUrl` → `http://127.0.0.1:5001/feefo-reviews/us-central1/reviewsApi`) and against production once deployed. Local workflow documented in the README.

## Deliberate v1 limits (documented in the design doc)

- At most **one** indexed attribute filter per request (`filters_not_combinable`) — keeps every query on existing composites.
- `rating` / `review_type` are scan-time post-filters → `meta.count: null`; deep paging with them requires cursors.
- `search` returns `400 search_not_supported` (Phase 5 — Algolia, pending its privacy pass).
- `page × page_size ≤ 1000`; beyond that, cursors.

## Not in this PR (follow-ups)

- **Dashboard "API Access" UI** (self-service credential creation) — the `apiClients` endpoint is ready for it; UI lands next.
- **Phase 4 hardening**: tightening the five world-readable Firestore collections to `request.auth != null`, service-rating star distribution in the sync, `merchant_registry` Firestore collection (today an in-code registry behind the same interface).
- Firestore **TTL policy** on `api_tokens.expiresAt` (one-time console/CLI setup, noted in code).
- Deploy-time setup: set `REVIEWS_API_SECRET_PEPPER` in CI secrets / `functions/.env.feefo-reviews` before first deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
