### PR TITLE
docs(api): Postman Admin folder — create/rotate/revoke API clients

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -18,11 +18,18 @@ A Postman collection for the public, read-only **Reviews API** described in
 
 1. In Postman: **Import** → drop both files in.
 2. Select the **Uniworld Reviews API** environment (top-right).
-3. Set `clientId` and `clientSecret` (from the dashboard's **API Access** page).
+3. Get credentials, either:
+   - **Create them in Postman** (owners/admins): set the `syncToken` variable to
+     the `SYNC_API_TOKEN` value, then run **Admin → Create API client**. Its test
+     script auto-saves `clientId`/`clientSecret` into the collection — **copy the
+     secret from the response to a password manager; it is shown exactly once.**
+   - Or paste an existing `clientId`/`clientSecret` into the variables.
 4. Run **Auth → Get access token**. Its test script saves `accessToken` automatically.
 5. Run anything under **Reviews** / **Meta** — they inherit the bearer token.
 
 When you get a `401`, the token expired (default 1h) — re-run **Get access token**.
+**Admin** also has List / Rotate / Revoke; rotate and revoke kill the client's
+outstanding tokens immediately.
 
 ### Variables
 

--- a/docs/api/reviews-api.postman_collection.json
+++ b/docs/api/reviews-api.postman_collection.json
@@ -14,9 +14,124 @@
     { "key": "clientId", "value": "", "type": "string" },
     { "key": "clientSecret", "value": "", "type": "string" },
     { "key": "accessToken", "value": "", "type": "string" },
-    { "key": "merchantIdentifier", "value": "uniworld", "type": "string" }
+    { "key": "merchantIdentifier", "value": "uniworld", "type": "string" },
+    { "key": "managementUrl", "value": "https://us-central1-feefo-reviews.cloudfunctions.net/apiClients", "type": "string" },
+    { "key": "syncToken", "value": "", "type": "string" }
   ],
   "item": [
+    {
+      "name": "Admin — manage API clients",
+      "description": "Credential management (create / list / rotate / revoke), for dashboard owners/admins. These hit the `apiClients` admin function directly (set `managementUrl`), NOT the public /v1 API, and authenticate with the `x-sync-token` header — set the `syncToken` variable to your SYNC_API_TOKEN value. (A Firebase ID bearer token from a signed-in admin works too.)\n\n'Create API client' auto-saves the returned clientId/clientSecret into the collection variables, so you can run Auth > Get access token immediately after. THE SECRET IS SHOWN ONCE — copy it to a password manager.",
+      "item": [
+        {
+          "name": "Create API client",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('status is 200', () => pm.response.to.have.status(200));",
+                  "const body = pm.response.json();",
+                  "if (body && body.client && body.clientSecret) {",
+                  "  pm.collectionVariables.set('clientId', body.client.clientId);",
+                  "  pm.collectionVariables.set('clientSecret', body.clientSecret);",
+                  "  console.log('Saved clientId=' + body.client.clientId);",
+                  "  console.warn('clientSecret saved to collection vars AND shown in this response ONLY — copy it to a password manager now; it cannot be retrieved again.');",
+                  "} else {",
+                  "  console.warn('No client/clientSecret in response — check syncToken and request body.');",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-sync-token", "value": "{{syncToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"action\": \"create\",\n  \"label\": \"Marketing website (prod)\",\n  \"merchants\": [\"*\"]\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": { "raw": "{{managementUrl}}", "host": ["{{managementUrl}}"] },
+            "description": "Creates a credential. `merchants`: [\"*\"] for all, or e.g. [\"uniworld\"] to scope it. Optional `scopes` (defaults to all of reviews:read, summary:read, meta:read). The response's clientSecret appears ONCE."
+          }
+        },
+        {
+          "name": "List API clients",
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-sync-token", "value": "{{syncToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"action\": \"list\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": { "raw": "{{managementUrl}}", "host": ["{{managementUrl}}"] },
+            "description": "All clients with label, merchants, scopes, status, lastUsedAt. Secrets/verifiers are never returned."
+          }
+        },
+        {
+          "name": "Rotate client secret",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const body = pm.response.json();",
+                  "if (body && body.clientSecret) {",
+                  "  pm.collectionVariables.set('clientSecret', body.clientSecret);",
+                  "  console.warn('New clientSecret saved — the old secret and ALL outstanding tokens are dead. Copy the new secret now; it is shown once.');",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-sync-token", "value": "{{syncToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"action\": \"rotate\",\n  \"clientId\": \"{{clientId}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": { "raw": "{{managementUrl}}", "host": ["{{managementUrl}}"] },
+            "description": "Issues a new secret and immediately invalidates the old secret AND every outstanding access token for this client."
+          }
+        },
+        {
+          "name": "Revoke API client",
+          "request": {
+            "auth": { "type": "noauth" },
+            "method": "POST",
+            "header": [
+              { "key": "Content-Type", "value": "application/json" },
+              { "key": "x-sync-token", "value": "{{syncToken}}" }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"action\": \"revoke\",\n  \"clientId\": \"{{clientId}}\"\n}",
+              "options": { "raw": { "language": "json" } }
+            },
+            "url": { "raw": "{{managementUrl}}", "host": ["{{managementUrl}}"] },
+            "description": "Permanently disables the client: token exchanges fail and every outstanding access token dies immediately."
+          }
+        }
+      ]
+    },
     {
       "name": "Auth",
       "item": [

--- a/docs/api/reviews-api.postman_environment.json
+++ b/docs/api/reviews-api.postman_environment.json
@@ -6,7 +6,9 @@
     { "key": "clientId", "value": "", "type": "default", "enabled": true },
     { "key": "clientSecret", "value": "", "type": "secret", "enabled": true },
     { "key": "accessToken", "value": "", "type": "secret", "enabled": true },
-    { "key": "merchantIdentifier", "value": "uniworld", "type": "default", "enabled": true }
+    { "key": "merchantIdentifier", "value": "uniworld", "type": "default", "enabled": true },
+    { "key": "managementUrl", "value": "https://us-central1-feefo-reviews.cloudfunctions.net/apiClients", "type": "default", "enabled": true },
+    { "key": "syncToken", "value": "", "type": "secret", "enabled": true }
   ],
   "_postman_variable_scope": "environment"
 }


### PR DESCRIPTION
The collection covered the public /v1 API but not credential management, so minting the first client (rollout step 5) needed hand-written curl.

Adds an **Admin — manage API clients** folder (create / list / rotate / revoke) against the `apiClients` function using the `x-sync-token` header, with new `syncToken` + `managementUrl` variables in the collection and environment. **Create API client** auto-saves the returned `clientId`/`clientSecret` into collection variables so **Auth → Get access token** works immediately after, with a console warning that the secret is shown once. README quick-start updated to match.

Docs/tooling only — no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)