### PR TITLE
feat(admin): API Access page — self-service credentials for the reviews API

### DIFF
--- a/app/src/app/admin/api-access/page.tsx
+++ b/app/src/app/admin/api-access/page.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { onAuthStateChanged, type User } from "firebase/auth";
+import { useRouter } from "next/navigation";
+import { getClientAuth } from "@/lib/firebase";
+import {
+  getCurrentAdminAccess,
+  type CurrentAdminAccess,
+} from "@/lib/firestore/admin-queries";
+import ApiClientsManager from "@/components/admin/ApiClientsManager";
+
+export default function ApiAccessPage() {
+  const router = useRouter();
+  const [user, setUser] = useState<User | null>(null);
+  const [authResolved, setAuthResolved] = useState(false);
+  const [currentAccess, setCurrentAccess] = useState<CurrentAdminAccess | null>(null);
+  const [checkingAccess, setCheckingAccess] = useState(true);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const canManageApiClients = Boolean(currentAccess?.permissions.manageApiClients);
+
+  useEffect(() => {
+    try {
+      const auth = getClientAuth();
+      return onAuthStateChanged(auth, (nextUser) => {
+        setUser(nextUser);
+        setAuthResolved(true);
+      });
+    } catch {
+      queueMicrotask(() => setAuthResolved(true));
+      router.replace("/");
+      return;
+    }
+  }, [router]);
+
+  useEffect(() => {
+    if (!authResolved) {
+      return;
+    }
+
+    if (!user) {
+      queueMicrotask(() => {
+        setCurrentAccess(null);
+        setCheckingAccess(false);
+      });
+      router.replace("/");
+      return;
+    }
+
+    let cancelled = false;
+    queueMicrotask(() => setCheckingAccess(true));
+
+    getCurrentAdminAccess()
+      .then((access) => {
+        if (cancelled) return;
+        setCurrentAccess(access);
+        if (!access.permissions.manageApiClients) {
+          router.replace("/admin");
+        }
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setCurrentAccess(null);
+        router.replace("/");
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setCheckingAccess(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authResolved, router, user]);
+
+  useEffect(() => {
+    if (!toast) return;
+    const timeout = setTimeout(() => setToast(null), 4000);
+    return () => clearTimeout(timeout);
+  }, [toast]);
+
+  if (!authResolved || checkingAccess || !canManageApiClients) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-6">
+        <div className="mb-2 text-sm font-medium text-text-secondary">
+          <Link href="/admin" className="hover:text-text-primary hover:underline">
+            Admin
+          </Link>
+          <span className="mx-2 text-text-tertiary">/</span>
+          API Access
+        </div>
+        <h1 className="text-2xl font-semibold text-text-primary">API Access</h1>
+        <p className="mt-1 text-sm text-text-secondary">
+          Credentials for the public reviews API — server-to-server only. Consumers
+          exchange their client ID + secret for a bearer token, exactly like the Feefo
+          API. See the Postman collection in{" "}
+          <code className="rounded bg-surface-alt px-1 py-0.5 text-xs">docs/api/</code> for
+          the full contract.
+        </p>
+      </div>
+
+      <ApiClientsManager onToast={setToast} />
+
+      {toast ? (
+        <div className="fixed bottom-4 right-4 z-50 rounded-lg bg-gray-900 px-4 py-3 text-sm text-white shadow-lg">
+          {toast}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/src/app/admin/logs/page.tsx
+++ b/app/src/app/admin/logs/page.tsx
@@ -144,7 +144,7 @@ export default function AdminLogsPage() {
           </div>
           <h1 className="text-2xl font-semibold text-text-primary">Operational Logs</h1>
           <p className="mt-1 text-sm text-text-secondary">
-            Review sync, classification, and summary activity.
+            Review sync, classification, summary, and API credential activity.
           </p>
         </div>
 
@@ -168,6 +168,7 @@ export default function AdminLogsPage() {
             <option value="sync">Sync</option>
             <option value="classification">Classification</option>
             <option value="summary">Summary</option>
+            <option value="apiClient">API clients</option>
           </select>
           <button
             onClick={() => loadLogs(range)}

--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -123,6 +123,7 @@ export default function AdminPage() {
   const canManageUsers = Boolean(currentAccess?.permissions.manageUsers);
   const canManageMappings = Boolean(currentAccess?.permissions.manageMappings);
   const canViewLogs = Boolean(currentAccess?.permissions.sync);
+  const canManageApiClients = Boolean(currentAccess?.permissions.manageApiClients);
 
   const loadAdminAccess = useCallback(async () => {
     setAdminUsersLoading(true);
@@ -236,7 +237,8 @@ export default function AdminPage() {
         const canUseAdminPage =
           access.permissions.sync ||
           access.permissions.manageMappings ||
-          access.permissions.manageUsers;
+          access.permissions.manageUsers ||
+          access.permissions.manageApiClients;
         if (!canUseAdminPage) {
           router.replace("/");
         }
@@ -726,6 +728,25 @@ export default function AdminPage() {
           </div>
         </div>
       </div>
+      ) : null}
+
+      {canManageApiClients ? (
+        <div className="mb-8 rounded-xl border border-border bg-surface shadow-sm">
+          <div className="flex flex-wrap items-center justify-between gap-4 px-6 py-5">
+            <div>
+              <h2 className="text-xl font-semibold text-text-primary">API Access</h2>
+              <p className="mt-1 text-sm text-text-secondary">
+                Create and manage server-to-server credentials for the public reviews API.
+              </p>
+            </div>
+            <Link
+              href="/admin/api-access"
+              className="inline-flex items-center rounded-lg bg-header-bg px-4 py-2 text-sm font-medium text-header-text shadow-sm hover:opacity-90"
+            >
+              Manage API Clients
+            </Link>
+          </div>
+        </div>
       ) : null}
 
       {canViewLogs ? (

--- a/app/src/components/admin/ApiClientsManager.tsx
+++ b/app/src/components/admin/ApiClientsManager.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useBrand } from "@/contexts/BrandContext";
 import {
   createApiClient,
@@ -28,7 +28,15 @@ interface SecretReveal {
 
 type MerchantMode = "all" | "selected";
 
-function CopyButton({ value, what }: { value: string; what: string }) {
+function CopyButton({
+  value,
+  what,
+  autoFocus,
+}: {
+  value: string;
+  what: string;
+  autoFocus?: boolean;
+}) {
   const [copied, setCopied] = useState(false);
 
   async function copy() {
@@ -46,6 +54,7 @@ function CopyButton({ value, what }: { value: string; what: string }) {
     <button
       type="button"
       onClick={copy}
+      autoFocus={autoFocus}
       className="inline-flex shrink-0 items-center rounded-lg border border-input-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary shadow-sm hover:bg-surface-hover"
       aria-label={`Copy ${what}`}
     >
@@ -119,14 +128,28 @@ export default function ApiClientsManager({
   // One-time secret reveal
   const [reveal, setReveal] = useState<SecretReveal | null>(null);
 
+  // Guard async state updates against unmount (route change / permission
+  // redirect mid-request). Set true inside the effect so StrictMode's
+  // dev-time remount doesn't leave it permanently false.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   const loadClients = useCallback(async () => {
     setLoading(true);
     try {
-      setClients(await listApiClients());
+      const next = await listApiClients();
+      if (!mountedRef.current) return;
+      setClients(next);
     } catch (err) {
+      if (!mountedRef.current) return;
       onToast(err instanceof Error ? err.message : "Failed to load API clients");
     }
-    setLoading(false);
+    if (mountedRef.current) setLoading(false);
   }, [onToast]);
 
   useEffect(() => {
@@ -154,6 +177,7 @@ export default function ApiClientsManager({
     setCreating(true);
     try {
       const { client, clientSecret } = await createApiClient(trimmed, merchants);
+      if (!mountedRef.current) return;
       setReveal({
         kind: "created",
         label: client.label,
@@ -165,15 +189,17 @@ export default function ApiClientsManager({
       setSelectedMerchants([]);
       await loadClients();
     } catch (err) {
+      if (!mountedRef.current) return;
       onToast(err instanceof Error ? err.message : "Failed to create API client");
     }
-    setCreating(false);
+    if (mountedRef.current) setCreating(false);
   }
 
   async function handleRotate(client: ApiClient) {
     setBusyClientId(client.clientId);
     try {
       const { clientSecret } = await rotateApiClient(client.clientId);
+      if (!mountedRef.current) return;
       setReveal({
         kind: "rotated",
         label: client.label,
@@ -182,21 +208,24 @@ export default function ApiClientsManager({
       });
       await loadClients();
     } catch (err) {
+      if (!mountedRef.current) return;
       onToast(err instanceof Error ? err.message : "Failed to rotate secret");
     }
-    setBusyClientId(null);
+    if (mountedRef.current) setBusyClientId(null);
   }
 
   async function handleRevoke(client: ApiClient) {
     setBusyClientId(client.clientId);
     try {
       await revokeApiClient(client.clientId);
+      if (!mountedRef.current) return;
       onToast(`Revoked “${client.label}” — its tokens are dead immediately`);
       await loadClients();
     } catch (err) {
+      if (!mountedRef.current) return;
       onToast(err instanceof Error ? err.message : "Failed to revoke API client");
     }
-    setBusyClientId(null);
+    if (mountedRef.current) setBusyClientId(null);
   }
 
   return (
@@ -382,8 +411,13 @@ export default function ApiClientsManager({
       {/* Confirm rotate / revoke */}
       {confirmAction ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
-          <div className="w-full max-w-md rounded-xl border border-border bg-surface p-6 shadow-xl">
-            <h3 className="text-lg font-semibold text-text-primary">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="confirm-action-title"
+            className="w-full max-w-md rounded-xl border border-border bg-surface p-6 shadow-xl"
+          >
+            <h3 id="confirm-action-title" className="text-lg font-semibold text-text-primary">
               {confirmAction.kind === "rotate" ? "Rotate secret?" : "Revoke client?"}
             </h3>
             <p className="mt-2 text-sm text-text-secondary">
@@ -406,6 +440,7 @@ export default function ApiClientsManager({
             <div className="mt-5 flex justify-end gap-3">
               <button
                 onClick={() => setConfirmAction(null)}
+                autoFocus
                 className="rounded-lg border border-input-border bg-surface px-4 py-2 text-sm font-medium text-text-primary hover:bg-surface-hover"
               >
                 Cancel
@@ -431,8 +466,13 @@ export default function ApiClientsManager({
       {/* One-time secret reveal */}
       {reveal ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
-          <div className="w-full max-w-lg rounded-xl border border-border bg-surface p-6 shadow-xl">
-            <h3 className="text-lg font-semibold text-text-primary">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="secret-reveal-title"
+            className="w-full max-w-lg rounded-xl border border-border bg-surface p-6 shadow-xl"
+          >
+            <h3 id="secret-reveal-title" className="text-lg font-semibold text-text-primary">
               {reveal.kind === "created" ? "API client created" : "Secret rotated"}
             </h3>
             <p className="mt-1 text-sm text-text-secondary">
@@ -452,7 +492,10 @@ export default function ApiClientsManager({
                   <code className="min-w-0 flex-1 overflow-x-auto rounded-lg bg-surface-alt px-3 py-2 text-xs text-text-primary">
                     {reveal.clientId}
                   </code>
-                  <CopyButton value={reveal.clientId} what="client id" />
+                  {/* Initial focus lands on a safe action — copying — rather
+                   * than the close button, so Enter can't dismiss an
+                   * unstored secret. */}
+                  <CopyButton value={reveal.clientId} what="client id" autoFocus />
                 </div>
               </div>
               <div>

--- a/app/src/components/admin/ApiClientsManager.tsx
+++ b/app/src/components/admin/ApiClientsManager.tsx
@@ -1,0 +1,483 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useBrand } from "@/contexts/BrandContext";
+import {
+  createApiClient,
+  listApiClients,
+  revokeApiClient,
+  rotateApiClient,
+  type ApiClient,
+} from "@/lib/firestore/admin-queries";
+
+/**
+ * Create / list / rotate / revoke credentials for the public reviews API.
+ *
+ * The client secret exists in the browser exactly once — in the reveal
+ * dialog right after create/rotate. It is never persisted client-side and
+ * cannot be retrieved again (the backend stores only a hash), which is why
+ * the dialog refuses to close until the user confirms they stored it.
+ */
+
+interface SecretReveal {
+  kind: "created" | "rotated";
+  label: string;
+  clientId: string;
+  clientSecret: string;
+}
+
+type MerchantMode = "all" | "selected";
+
+function CopyButton({ value, what }: { value: string; what: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard unavailable (permissions / non-secure context); the value
+      // is visible in the adjacent box for manual selection.
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      className="inline-flex shrink-0 items-center rounded-lg border border-input-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary shadow-sm hover:bg-surface-hover"
+      aria-label={`Copy ${what}`}
+    >
+      {copied ? "Copied ✓" : "Copy"}
+    </button>
+  );
+}
+
+function MerchantChips({ merchants }: { merchants: string[] }) {
+  const { brand } = useBrand();
+  if (merchants.includes("*")) {
+    return (
+      <span className="inline-flex rounded-full bg-brand-primary-light px-2 py-0.5 text-xs font-medium text-text-primary">
+        All merchants
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex flex-wrap gap-1">
+      {merchants.map((id) => (
+        <span
+          key={id}
+          className="inline-flex rounded-full bg-surface-alt px-2 py-0.5 text-xs font-medium text-text-secondary"
+        >
+          {brand.merchants.find((m) => m.id === id)?.label ?? id}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function StatusBadge({ status }: { status: ApiClient["status"] }) {
+  return status === "active" ? (
+    <span className="inline-flex rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700">
+      Active
+    </span>
+  ) : (
+    <span className="inline-flex rounded-full bg-red-50 px-2 py-0.5 text-xs font-medium text-red-600">
+      Revoked
+    </span>
+  );
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? "—" : parsed.toLocaleString();
+}
+
+export default function ApiClientsManager({
+  onToast,
+}: {
+  onToast: (message: string) => void;
+}) {
+  const { brand } = useBrand();
+  const [clients, setClients] = useState<ApiClient[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // Create form
+  const [label, setLabel] = useState("");
+  const [merchantMode, setMerchantMode] = useState<MerchantMode>("all");
+  const [selectedMerchants, setSelectedMerchants] = useState<string[]>([]);
+  const [creating, setCreating] = useState(false);
+
+  // Row actions
+  const [busyClientId, setBusyClientId] = useState<string | null>(null);
+  const [confirmAction, setConfirmAction] = useState<
+    { kind: "rotate" | "revoke"; client: ApiClient } | null
+  >(null);
+
+  // One-time secret reveal
+  const [reveal, setReveal] = useState<SecretReveal | null>(null);
+
+  const loadClients = useCallback(async () => {
+    setLoading(true);
+    try {
+      setClients(await listApiClients());
+    } catch (err) {
+      onToast(err instanceof Error ? err.message : "Failed to load API clients");
+    }
+    setLoading(false);
+  }, [onToast]);
+
+  useEffect(() => {
+    Promise.resolve().then(() => loadClients());
+  }, [loadClients]);
+
+  function toggleMerchant(id: string) {
+    setSelectedMerchants((current) =>
+      current.includes(id) ? current.filter((m) => m !== id) : [...current, id]
+    );
+  }
+
+  async function handleCreate() {
+    const trimmed = label.trim();
+    if (!trimmed) {
+      onToast("Enter a label, e.g. “Marketing website (prod)”");
+      return;
+    }
+    const merchants = merchantMode === "all" ? ["*"] : selectedMerchants;
+    if (merchants.length === 0) {
+      onToast("Select at least one merchant");
+      return;
+    }
+
+    setCreating(true);
+    try {
+      const { client, clientSecret } = await createApiClient(trimmed, merchants);
+      setReveal({
+        kind: "created",
+        label: client.label,
+        clientId: client.clientId,
+        clientSecret,
+      });
+      setLabel("");
+      setMerchantMode("all");
+      setSelectedMerchants([]);
+      await loadClients();
+    } catch (err) {
+      onToast(err instanceof Error ? err.message : "Failed to create API client");
+    }
+    setCreating(false);
+  }
+
+  async function handleRotate(client: ApiClient) {
+    setBusyClientId(client.clientId);
+    try {
+      const { clientSecret } = await rotateApiClient(client.clientId);
+      setReveal({
+        kind: "rotated",
+        label: client.label,
+        clientId: client.clientId,
+        clientSecret,
+      });
+      await loadClients();
+    } catch (err) {
+      onToast(err instanceof Error ? err.message : "Failed to rotate secret");
+    }
+    setBusyClientId(null);
+  }
+
+  async function handleRevoke(client: ApiClient) {
+    setBusyClientId(client.clientId);
+    try {
+      await revokeApiClient(client.clientId);
+      onToast(`Revoked “${client.label}” — its tokens are dead immediately`);
+      await loadClients();
+    } catch (err) {
+      onToast(err instanceof Error ? err.message : "Failed to revoke API client");
+    }
+    setBusyClientId(null);
+  }
+
+  return (
+    <div className="space-y-8">
+      {/* Create */}
+      <div className="rounded-xl border border-border bg-surface shadow-sm">
+        <div className="border-b border-border px-6 py-5">
+          <h2 className="text-xl font-semibold text-text-primary">Create API Client</h2>
+          <p className="mt-1 text-sm text-text-secondary">
+            Issues a <span className="font-mono">client_id</span> +{" "}
+            <span className="font-mono">client_secret</span> for server-to-server access
+            to the public reviews API. The secret is shown once, right after creation.
+          </p>
+        </div>
+        <div className="grid gap-6 px-6 py-5 sm:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)_auto] sm:items-end">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-text-primary" htmlFor="api-client-label">
+              Label
+            </label>
+            <input
+              id="api-client-label"
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="Marketing website (prod)"
+              maxLength={100}
+              className="w-full rounded-lg border border-input-border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand-accent/30"
+            />
+            <p className="mt-1 text-xs text-text-secondary">
+              Who or what will use this credential.
+            </p>
+          </div>
+          <div>
+            <span className="mb-1 block text-sm font-medium text-text-primary">Merchant access</span>
+            <div className="flex flex-wrap items-center gap-3 rounded-lg border border-input-border bg-surface px-3 py-2">
+              <label className="inline-flex items-center gap-1.5 text-sm text-text-primary">
+                <input
+                  type="radio"
+                  name="merchant-mode"
+                  checked={merchantMode === "all"}
+                  onChange={() => setMerchantMode("all")}
+                />
+                All merchants
+              </label>
+              <label className="inline-flex items-center gap-1.5 text-sm text-text-primary">
+                <input
+                  type="radio"
+                  name="merchant-mode"
+                  checked={merchantMode === "selected"}
+                  onChange={() => setMerchantMode("selected")}
+                />
+                Only:
+              </label>
+              {brand.merchants.map((merchant) => (
+                <label
+                  key={merchant.id}
+                  className={`inline-flex items-center gap-1.5 text-sm ${
+                    merchantMode === "selected" ? "text-text-primary" : "text-text-tertiary"
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    disabled={merchantMode !== "selected"}
+                    checked={selectedMerchants.includes(merchant.id)}
+                    onChange={() => toggleMerchant(merchant.id)}
+                  />
+                  {merchant.label}
+                </label>
+              ))}
+            </div>
+          </div>
+          <button
+            onClick={handleCreate}
+            disabled={creating}
+            className="inline-flex items-center justify-center rounded-lg bg-header-bg px-4 py-2 text-sm font-medium text-header-text shadow-sm hover:opacity-90 disabled:opacity-50"
+          >
+            {creating ? "Creating..." : "Create Client"}
+          </button>
+        </div>
+      </div>
+
+      {/* List */}
+      <div className="rounded-xl border border-border bg-surface shadow-sm">
+        <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border px-6 py-5">
+          <div>
+            <h2 className="text-xl font-semibold text-text-primary">API Clients</h2>
+            <p className="mt-1 text-sm text-text-secondary">
+              Rotating a secret or revoking a client kills its outstanding tokens immediately.
+            </p>
+          </div>
+          <button
+            onClick={loadClients}
+            className="inline-flex items-center rounded-lg border border-input-border bg-surface px-4 py-2 text-sm font-medium text-text-primary shadow-sm hover:bg-surface-hover"
+          >
+            Refresh
+          </button>
+        </div>
+        <div className="overflow-x-auto">
+          {loading ? (
+            <div className="flex items-center justify-center py-16">
+              <div className="h-8 w-8 animate-spin rounded-full border-4 border-spinner-track border-t-spinner-accent" />
+            </div>
+          ) : clients.length === 0 ? (
+            <div className="px-6 py-12 text-center text-sm text-text-secondary">
+              No API clients yet. Create the first one above to give a consumer access to
+              the reviews API.
+            </div>
+          ) : (
+            <table className="w-full min-w-[820px] text-sm">
+              <thead>
+                <tr className="bg-surface-alt text-left text-text-secondary">
+                  <th className="px-4 py-3 font-medium">Label</th>
+                  <th className="px-4 py-3 font-medium">Client ID</th>
+                  <th className="px-4 py-3 font-medium">Merchants</th>
+                  <th className="px-4 py-3 font-medium">Status</th>
+                  <th className="px-4 py-3 font-medium">Last used</th>
+                  <th className="px-4 py-3 font-medium">Created</th>
+                  <th className="px-4 py-3 text-right font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {clients.map((client) => {
+                  const busy = busyClientId === client.clientId;
+                  const revoked = client.status === "revoked";
+                  return (
+                    <tr
+                      key={client.clientId}
+                      className={`border-t border-border ${revoked ? "opacity-60" : ""}`}
+                    >
+                      <td className="px-4 py-3 font-medium text-text-primary">{client.label}</td>
+                      <td className="px-4 py-3">
+                        <span className="inline-flex items-center gap-2">
+                          <code className="rounded bg-surface-alt px-1.5 py-0.5 text-xs text-text-primary">
+                            {client.clientId}
+                          </code>
+                          <CopyButton value={client.clientId} what="client id" />
+                        </span>
+                      </td>
+                      <td className="px-4 py-3">
+                        <MerchantChips merchants={client.merchants} />
+                      </td>
+                      <td className="px-4 py-3">
+                        <StatusBadge status={client.status} />
+                      </td>
+                      <td className="px-4 py-3 text-text-secondary">{formatDate(client.lastUsedAt)}</td>
+                      <td className="px-4 py-3 text-text-secondary">
+                        {formatDate(client.createdAt)}
+                        {client.createdBy ? (
+                          <div className="text-xs text-text-tertiary">by {client.createdBy}</div>
+                        ) : null}
+                      </td>
+                      <td className="px-4 py-3 text-right whitespace-nowrap">
+                        {revoked ? (
+                          <span className="text-xs text-text-tertiary">—</span>
+                        ) : (
+                          <div className="inline-flex items-center gap-3">
+                            <button
+                              onClick={() => setConfirmAction({ kind: "rotate", client })}
+                              disabled={busy}
+                              className="text-xs font-medium text-amber-600 hover:text-amber-800 disabled:opacity-50"
+                            >
+                              {busy ? "Working..." : "Rotate secret"}
+                            </button>
+                            <button
+                              onClick={() => setConfirmAction({ kind: "revoke", client })}
+                              disabled={busy}
+                              className="text-xs font-medium text-red-600 hover:text-red-700 disabled:opacity-50"
+                            >
+                              Revoke
+                            </button>
+                          </div>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+
+      {/* Confirm rotate / revoke */}
+      {confirmAction ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-md rounded-xl border border-border bg-surface p-6 shadow-xl">
+            <h3 className="text-lg font-semibold text-text-primary">
+              {confirmAction.kind === "rotate" ? "Rotate secret?" : "Revoke client?"}
+            </h3>
+            <p className="mt-2 text-sm text-text-secondary">
+              {confirmAction.kind === "rotate" ? (
+                <>
+                  The current secret for{" "}
+                  <strong className="text-text-primary">{confirmAction.client.label}</strong>{" "}
+                  stops working and every outstanding access token dies immediately. You&rsquo;ll
+                  get a new secret to hand to the consumer.
+                </>
+              ) : (
+                <>
+                  <strong className="text-text-primary">{confirmAction.client.label}</strong>{" "}
+                  is permanently disabled: token exchanges fail and every outstanding access
+                  token dies immediately. This cannot be undone — create a new client to
+                  restore access.
+                </>
+              )}
+            </p>
+            <div className="mt-5 flex justify-end gap-3">
+              <button
+                onClick={() => setConfirmAction(null)}
+                className="rounded-lg border border-input-border bg-surface px-4 py-2 text-sm font-medium text-text-primary hover:bg-surface-hover"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => {
+                  const action = confirmAction;
+                  setConfirmAction(null);
+                  if (action.kind === "rotate") handleRotate(action.client);
+                  else handleRevoke(action.client);
+                }}
+                className={`rounded-lg px-4 py-2 text-sm font-medium text-white shadow-sm hover:opacity-90 ${
+                  confirmAction.kind === "rotate" ? "bg-amber-600" : "bg-red-600"
+                }`}
+              >
+                {confirmAction.kind === "rotate" ? "Rotate secret" : "Revoke client"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {/* One-time secret reveal */}
+      {reveal ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-lg rounded-xl border border-border bg-surface p-6 shadow-xl">
+            <h3 className="text-lg font-semibold text-text-primary">
+              {reveal.kind === "created" ? "API client created" : "Secret rotated"}
+            </h3>
+            <p className="mt-1 text-sm text-text-secondary">
+              Credentials for <strong className="text-text-primary">{reveal.label}</strong>.
+            </p>
+            <div className="mt-4 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+              This is the <strong>only time the secret is shown</strong>. Store both values
+              in a password manager before closing — the secret cannot be retrieved again,
+              only rotated.
+            </div>
+            <div className="mt-4 space-y-3">
+              <div>
+                <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-text-secondary">
+                  Client ID
+                </div>
+                <div className="flex items-center gap-2">
+                  <code className="min-w-0 flex-1 overflow-x-auto rounded-lg bg-surface-alt px-3 py-2 text-xs text-text-primary">
+                    {reveal.clientId}
+                  </code>
+                  <CopyButton value={reveal.clientId} what="client id" />
+                </div>
+              </div>
+              <div>
+                <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-text-secondary">
+                  Client Secret
+                </div>
+                <div className="flex items-center gap-2">
+                  <code className="min-w-0 flex-1 overflow-x-auto rounded-lg bg-surface-alt px-3 py-2 text-xs text-text-primary">
+                    {reveal.clientSecret}
+                  </code>
+                  <CopyButton value={reveal.clientSecret} what="client secret" />
+                </div>
+              </div>
+            </div>
+            <div className="mt-5 flex justify-end">
+              <button
+                onClick={() => setReveal(null)}
+                className="rounded-lg bg-header-bg px-4 py-2 text-sm font-medium text-header-text shadow-sm hover:opacity-90"
+              >
+                I&rsquo;ve stored both — close
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/app/src/components/admin/OperationLogsTable.tsx
+++ b/app/src/components/admin/OperationLogsTable.tsx
@@ -258,8 +258,18 @@ function getDetailRows(log: OperationLogEntry): DetailRow[] {
   return rows.concat(fallbackRows);
 }
 
+function typeLabel(type: string): string {
+  return type === "apiClient" ? "API client" : type;
+}
+
 function actionLabel(action: string): string {
   switch (action) {
+    case "client_created":
+      return "API client created";
+    case "client_rotated":
+      return "API client secret rotated";
+    case "client_revoked":
+      return "API client revoked";
     case "cycle_started":
       return "Sync run started";
     case "cycle_complete":
@@ -339,7 +349,7 @@ export default function OperationLogsTable({
                 </td>
                 <td className="px-4 py-3">
                   <span className="inline-flex rounded-full bg-brand-primary-light px-2 py-0.5 text-xs font-medium capitalize text-text-primary">
-                    {log.type}
+                    {typeLabel(log.type)}
                   </span>
                 </td>
                 <td className="px-4 py-3">

--- a/app/src/lib/firestore/admin-queries.ts
+++ b/app/src/lib/firestore/admin-queries.ts
@@ -20,7 +20,8 @@ export type AdminAccessPermission =
   | "sync"
   | "batchClassify"
   | "manageMappings"
-  | "manageUsers";
+  | "manageUsers"
+  | "manageApiClients";
 
 export interface AdminUserAccess {
   email: string;
@@ -160,5 +161,64 @@ export async function listOperationalLogs(
     limit,
   });
   return response.logs ?? [];
+}
+
+// ── Public reviews API credentials (apiClients function) ────────────────────
+
+export interface ApiClient {
+  clientId: string;
+  label: string;
+  /** Allowed merchant identifiers, or ["*"] for all. */
+  merchants: string[];
+  scopes: string[];
+  status: "active" | "revoked";
+  tokenVersion: number;
+  rateLimitPerMinute?: number;
+  createdBy: string | null;
+  createdAt: string;
+  updatedAt?: string;
+  lastUsedAt?: string | null;
+}
+
+export async function listApiClients(): Promise<ApiClient[]> {
+  const response = await postFunction<{ clients?: ApiClient[] }>("apiClients", {
+    action: "list",
+  });
+  return response.clients ?? [];
+}
+
+/** Create a credential. The returned clientSecret is shown to the caller
+ * exactly once — the backend stores only a hash. */
+export async function createApiClient(
+  label: string,
+  merchants: string[]
+): Promise<{ client: ApiClient; clientSecret: string }> {
+  const response = await postFunction<{ client: ApiClient; clientSecret: string }>(
+    "apiClients",
+    { action: "create", label, merchants }
+  );
+  return { client: response.client, clientSecret: response.clientSecret };
+}
+
+/** Rotate a client's secret. Outstanding access tokens die immediately;
+ * the new clientSecret is shown exactly once. */
+export async function rotateApiClient(
+  clientId: string
+): Promise<{ client: ApiClient; clientSecret: string }> {
+  const response = await postFunction<{ client: ApiClient; clientSecret: string }>(
+    "apiClients",
+    { action: "rotate", clientId }
+  );
+  return { client: response.client, clientSecret: response.clientSecret };
+}
+
+/** Revoke a client: blocks future token exchanges and kills outstanding
+ * tokens immediately. */
+export async function revokeApiClient(clientId: string): Promise<ApiClient> {
+  const response = await postFunction<{ client: ApiClient }>("apiClients", {
+    action: "revoke",
+    clientId,
+  });
+  return response.client;
 }
 

--- a/app/src/lib/firestore/admin-queries.ts
+++ b/app/src/lib/firestore/admin-queries.ts
@@ -52,7 +52,7 @@ export interface KnownUser {
   active: boolean | null;
 }
 
-export type OperationLogType = "sync" | "classification" | "summary";
+export type OperationLogType = "sync" | "classification" | "summary" | "apiClient";
 export type OperationLogLevel = "info" | "success" | "warning" | "error";
 export type OperationLogSource = "scheduled" | "manual" | "system";
 


### PR DESCRIPTION
Adds the dashboard UI for managing public-reviews-API credentials, replacing the curl/Postman-only flow. Backend (`apiClients` function, `manageApiClients` permission) shipped in #62; this is frontend-only.

## What it does

**`/admin/api-access`** (gated by the `manageApiClients` permission — owners and admins):

- **Create** — label + merchant scoping (all merchants, or per-merchant checkboxes sourced from the brand config). On success, a **one-time reveal dialog** shows the `client_id` + `client_secret` with copy buttons, an amber "shown once" warning, and an explicit *"I've stored both — close"* button. The secret is never persisted client-side and cannot be retrieved again (backend stores only a hash).
- **List** — copyable client id, merchant chips ("All merchants" for `*`), Active/Revoked badge, last used, created by/at. Revoked rows render muted with no actions.
- **Rotate secret / Revoke** — confirmation dialogs that spell out the consequence (outstanding tokens die immediately); rotate re-opens the one-time reveal with the new secret.

The admin landing page gains an **"API Access" card** linking here, and its page-access check now also admits users whose only permission is `manageApiClients`.

## Implementation notes

- Follows the existing admin subpage pattern exactly (`admin/logs/page.tsx`): client component, `onAuthStateChanged` + `getCurrentAdminAccess()` gate, breadcrumb header, toast.
- `admin-queries.ts` adds `manageApiClients` to the permission union (the backend's `adminUsers current` already returns it) and typed wrappers for the `apiClients` function.
- Defers the initial load with the repo's `Promise.resolve().then(...)` idiom to satisfy `react-hooks/set-state-in-effect`.

## Verification

- `tsc --noEmit`: clean
- `eslint` on all touched files: clean
- Full `next build` (static export): passes, `/admin/api-access` present in the route list
- Backend behaviors this UI drives (create/rotate/revoke, immediate token death) were emulator-verified 50/50 in #62

**Not automated:** the signed-in click-through (requires a real Google sign-in). Suggested post-merge smoke: open Admin → Manage API Clients, create a test client, confirm the reveal dialog, rotate it, revoke it, and check the audit entries appear in Operational Logs (type `apiClient`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
