### PR TITLE
Add agent briefs (CLAUDE.md/AGENTS.md) and emulator reset script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent instructions
+
+Read `CLAUDE.md` in this directory: product doctrine (match Feefo exactly), Node 20 requirement, PR-gated deploys, credentials location, and the known counts-vs-Feefo bug family. `app/AGENTS.md` adds Next.js-specific rules for code inside `app/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+# Feefo Reviews Dashboard
+
+Internal dashboard + API that mirrors Feefo review data for TTC brands (~16 merchants; Uniworld and Luxury Gold are the main ones today). Repo: `Uniworld-River-Cruises/reviews-dashboard`. Live app: `feefo-reviews.web.app` (Firebase Hosting). App code lives in `app/` (Next.js; `app/CLAUDE.md` and `app/AGENTS.md` add framework-specific rules), API/functions in `functions/`, shared code in `shared/`.
+
+## Product doctrine: match Feefo exactly
+When in doubt, copy Feefo. Filter names, date presets, sort defaults, terminology, and the public API shape should mirror Feefo's dashboard and API ("merchant" not brand; per-brand display terms for products, since not every brand calls them itineraries). Feefo distinguishes PRODUCT reviews from SERVICE reviews; never conflate them. API reference: https://feefo.readme.io (note: feefo.com pages 403 plain fetchers; use the Chrome MCP or curl with a browser UA).
+
+## Environment
+- Node 20 (root `.nvmrc` = 20.20.0). The machine's default node is v14, so use `nvm use 20` or call `C:\Users\matt.urbano\AppData\Local\nvm\v20.20.0\node.exe` directly.
+- Firebase emulators need Java: `JAVA_HOME` points at the repo-local `.tools\jre`.
+- Restart/reset the local stack with `scripts/dev-reset.sh` (kills stray java processes, restarts emulators, waits for "All emulators ready"). Smoke tests: `scripts/smoke-api.sh`, `scripts/smoke-rules.sh`. Seed data: `scripts/seed-emulator.js`.
+- Format-on-save is active in this workspace: after editing, expect files to be reformatted underneath you; re-read before further edits instead of fighting stale content.
+
+## Credentials
+- Feefo API credentials live in `api-credentials.txt` at the repo root (gitignored) and in GitHub Actions secrets. Read them from there; never inline secret values into command lines or output, and never commit them.
+
+## Deploy (strictly PR-gated)
+- Never deploy to production directly. Changes go: branch → PR → merge → GitHub Actions `firebase-deploy.yml`.
+- After a merge, watch the deploy yourself (`gh run watch` or `gh run list --workflow=firebase-deploy.yml`); on failure, pull logs with `gh run view <id> --log-failed` and fix. Don't wait for Matt to report it.
+- Remember what's visible where: code changes are NOT on the live site until deployed; use localhost/emulators to demo pre-merge work.
+- Before any commit: `npx tsc --noEmit` (from `app/`) and eslint on changed files.
+
+## Known bug family: counts vs Feefo
+The recurring defect shape is client-side operations silently limited to the first loaded page (50 reviews): totals, sort, CSV export, media filters, and theme aggregation have each shipped with this bug. Any new aggregate/sort/export MUST be server-side over the full dataset, then verified against the Feefo dashboard side by side. Also watch: duplicate reviews (dedupe by review id) and date semantics (Feefo "Updated" vs "Created" are different fields; presets must say which they use).

--- a/scripts/dev-reset.sh
+++ b/scripts/dev-reset.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Reset the local Firebase emulator stack (functions + firestore).
+# Replaces the hand-typed kill/restart/wait ritual. Git-Bash-on-Windows aware.
+# Usage: bash scripts/dev-reset.sh [--seed]
+#   --seed   apply scripts/seed-emulator.js after the emulators are ready
+# Env overrides: NODE_DIR (node 20 dir), EMULATORS (--only list), WAIT_SECS
+set -u
+cd "$(dirname "$0")/.."
+
+SEED=0
+[ "${1:-}" = "--seed" ] && SEED=1
+
+NODE_DIR="${NODE_DIR:-/c/Users/matt.urbano/AppData/Local/nvm/v20.20.0}"
+EMULATORS="${EMULATORS:-functions,firestore}"
+WAIT_SECS="${WAIT_SECS:-180}"
+LOG="emulator.log"
+
+# Node 20 required (machine default is 14); repo-local JRE for the emulators.
+export PATH="$NODE_DIR:$PATH"
+export JAVA_HOME="$(pwd)/.tools/jre"
+export PATH="$JAVA_HOME/bin:$PATH"
+
+echo "node: $(node --version)  java: $("$JAVA_HOME/bin/java" -version 2>&1 | head -1)"
+
+# Kill any previous emulator JVMs (ignore 'not found').
+taskkill.exe //F //IM java.exe >/dev/null 2>&1 || true
+sleep 2
+rm -f "$LOG"
+
+echo "starting emulators (--only $EMULATORS) -> $LOG"
+npx firebase emulators:start --only "$EMULATORS" >"$LOG" 2>&1 &
+EMU_PID=$!
+
+elapsed=0
+until grep -q "All emulators ready" "$LOG" 2>/dev/null; do
+  if ! kill -0 "$EMU_PID" 2>/dev/null; then
+    echo "FAIL: emulator process exited early. Last log lines:"
+    tail -20 "$LOG"
+    exit 1
+  fi
+  if [ "$elapsed" -ge "$WAIT_SECS" ]; then
+    echo "FAIL: emulators not ready after ${WAIT_SECS}s. Last log lines:"
+    tail -20 "$LOG"
+    exit 1
+  fi
+  sleep 2
+  elapsed=$((elapsed + 2))
+done
+echo "emulators ready (${elapsed}s)"
+
+if [ "$SEED" = "1" ]; then
+  echo "seeding: scripts/seed-emulator.js"
+  node scripts/seed-emulator.js || { echo "FAIL: seed script failed"; exit 1; }
+fi
+
+echo "OK. Logs: tail -f $LOG   Smoke: bash scripts/smoke-api.sh"


### PR DESCRIPTION
CLAUDE.md is the canonical AI-agent onboarding: match-Feefo doctrine, Node 20, PR-gated deploys, credentials location, and the known counts-vs-Feefo bug family. AGENTS.md points Codex/Copilot at it. scripts/dev-reset.sh replaces the hand-typed emulator kill/restart/wait ritual (supports --seed).

Docs and tooling only; no app code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)